### PR TITLE
Fix L2 implementation deploy script param

### DIFF
--- a/script/deploy/Utils.sol
+++ b/script/deploy/Utils.sol
@@ -16,6 +16,7 @@ contract Utils is Script {
         uint256 finalizationPeriodSeconds;
         uint256 gasPriceOracleOverhead;
         uint256 gasPriceOracleScalar;
+        uint256 l1ChainId;
         address l1FeeVaultRecipient;
         uint256 l2BlockTime;
         uint256 l2ChainId;

--- a/script/deploy/l2/DeployBedrockL2ImplContracts.s.sol
+++ b/script/deploy/l2/DeployBedrockL2ImplContracts.s.sol
@@ -110,9 +110,9 @@ contract DeployBedrockL2ImplContracts is Script {
 
         // Deploy OptimismMintableERC721Factory
         vm.broadcast(deployer);
-        optimismMintableERC721FactoryImpl = new OptimismMintableERC721Factory(Predeploys.L2_ERC721_BRIDGE, deployConfig.l2ChainId);
+        optimismMintableERC721FactoryImpl = new OptimismMintableERC721Factory(Predeploys.L2_ERC721_BRIDGE, deployConfig.l1ChainId);
         require(address(optimismMintableERC721FactoryImpl.BRIDGE()) == address(Predeploys.L2_ERC721_BRIDGE), "Deploy: optimismMintableERC721Factory l2ERC721BridgeProxy is incorrect");
-        require(optimismMintableERC721FactoryImpl.REMOTE_CHAIN_ID() == deployConfig.l2ChainId, "Deploy: optimismMintableERC721Factory chain ID is incorrect");
+        require(optimismMintableERC721FactoryImpl.REMOTE_CHAIN_ID() == deployConfig.l1ChainId, "Deploy: optimismMintableERC721Factory chain ID is incorrect");
 
         // Publish L2 implementation contract addresses
         addressL2Cfg.BaseFeeVault = address(baseFeeVaultImpl);


### PR DESCRIPTION
Remote chain ID was set to L2 chain ID, but it should be L1 chain ID (confirmed this with the value set on OP chain as well as existing Base testnet remote chain ID value)