### PR TITLE
Support submitting approveHash onchain, rather than signatures

### DIFF
--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -45,7 +45,7 @@ abstract contract MultisigBase is Simulator {
         bytes memory data = abi.encodeCall(IMulticall3.aggregate3, (_calls));
         bytes memory txData = _encodeTransactionData(_safe, data);
 
-        console.log("Data to sign:");
+        console.log("---\nData to sign:");
         console.log("vvvvvvvv");
         console.logBytes(txData);
         console.log("^^^^^^^^");


### PR DESCRIPTION
This will allow support for nested-nested-multisigs, e.g. there's a safe that is a signer for the nested safe (3 layers of safes). Instead of providing a signature, this inner safe can submit an `approveHash` to the middle safe, which will eventually allow `approveHash` on the outer safe.