### PR TITLE
Optional SAFE_NONCE variable fix

### DIFF
--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -28,8 +28,9 @@ abstract contract MultisigBase is Simulator {
         uint256 nonce = safe.nonce();
         console.log("Safe current nonce:", nonce);
 
-        if (bytes(vm.envOr("SAFE_NONCE", "")).length > 0) {
-            nonce = vm.envUint("SAFE_NONCE");
+        uint256 providedNonce = vm.envOr("SAFE_NONCE", nonce);
+        if (providedNonce > nonce) {
+            nonce = providedNonce;
             console.log("Creating transaction with nonce:", nonce);
         }
 

--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -28,11 +28,8 @@ abstract contract MultisigBase is Simulator {
         uint256 nonce = safe.nonce();
         console.log("Safe current nonce:", nonce);
 
-        uint256 providedNonce = vm.envOr("SAFE_NONCE", nonce);
-        if (providedNonce > nonce) {
-            nonce = providedNonce;
-            console.log("Creating transaction with nonce:", nonce);
-        }
+        nonce = vm.envOr("SAFE_NONCE", nonce); // allow overriding the nonce for testing
+        console.log("Creating transaction with nonce:", nonce);
 
         return safe.encodeTransactionData({
             to: address(multicall),

--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -25,12 +25,12 @@ abstract contract MultisigBuilder is MultisigBase {
     /**
      * @notice Creates the calldata
      */
-    function _buildCalls() internal virtual view returns (IMulticall3.Call3[] memory);
+    function _buildCalls() internal virtual pure returns (IMulticall3.Call3[] memory);
 
     /**
      * @notice Returns the safe address to execute the transaction from
      */
-    function _ownerSafe() internal virtual view returns (address);
+    function _ownerSafe() internal virtual pure returns (address);
 
     /**
      * -----------------------------------------------------------

--- a/script/universal/NestedMultisigBuilder.sol
+++ b/script/universal/NestedMultisigBuilder.sol
@@ -27,12 +27,12 @@ abstract contract NestedMultisigBuilder is MultisigBase {
     /**
      * @notice Creates the calldata
      */
-    function _buildCalls() internal virtual view returns (IMulticall3.Call3[] memory);
+    function _buildCalls() internal virtual pure returns (IMulticall3.Call3[] memory);
 
     /**
      * @notice Returns the nested safe address to execute the final transaction from
      */
-    function _ownerSafe() internal virtual view returns (address);
+    function _ownerSafe() internal virtual pure returns (address);
 
     /**
      * -----------------------------------------------------------


### PR DESCRIPTION
The way we were using `envOr` to take in `SAFE_NONCE` as an optional argument was not compiling. After fixing, it was causing other issues across the codebase because we were using a `envOr` which was not marked as a view function in view functions. I checked with the foundry team and looks like this was an oversight so I upstreamed a change to make `envOr` a `view` function:
* https://github.com/foundry-rs/foundry/pull/6757
* https://github.com/foundry-rs/forge-std/pull/491

This now compiles & works (if you run into issues, try running `make deps` which should pull the latest forge-std version).
