### PR TITLE
Change function visibility of run() from public to external

### DIFF
--- a/script/deploy/l2/tests/TestWithdraw.s.sol
+++ b/script/deploy/l2/tests/TestWithdraw.s.sol
@@ -10,7 +10,7 @@ import {L2ERC721Bridge} from "@eth-optimism-bedrock/src/L2/L2ERC721Bridge.sol";
 
 // Withdraws tokens from L2 to L1 to test Base Mainnet's bridging functionality
 contract TestWithdraw is Script {
-    function run(address _tester, address _l2erc20, address _l1erc721, address _l2erc721) public {
+    function run(address _tester, address _l2erc20, address _l1erc721, address _l2erc721) external {
         vm.startBroadcast(_tester);
         L2StandardBridge(payable(Predeploys.L2_STANDARD_BRIDGE)).withdraw(_l2erc20, 10_000 ether, 200_000, bytes(""));
         console.log("erc20 withdrawal initiated");


### PR DESCRIPTION
Updated the visibility of the run() function in the TestWithdraw contract from public to external. This change improves gas efficiency by restricting the function to external calls only, as it is intended to be invoked by external contracts or accounts.  No other functionality or logic in the contract has been altered.