### PR TITLE
feat: gas tracking tests for core contract operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,7 @@ checkout-op-commit:
 	git remote add origin https://github.com/ethereum-optimism/optimism.git; \
 	git fetch --depth=1 origin $(OP_COMMIT); \
 	git reset --hard FETCH_HEAD
+
+.PHONY: gas-report
+gas-report:
+	forge build && forge test --ffi -vvv --gas-report

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,8 +1,20 @@
 [profile.default]
 libs = ['lib']
-fs_permissions = [ {access = "read-write", path = "./"} ]
+fs_permissions = [{ access = "read-write", path = "./" }]
 optimizer = true
 optimizer_runs = 999999
 solc_version = "0.8.15"
+
+# Gas reporting settings
+gas_reports = ["*"]
+gas_reports_ignore = []
+gas_per_pub_word = 20000
+gas_per_pub_slot_storage = 20000
+
+[profile.gas]
+gas_reports = ["*"]
+optimizer = true
+optimizer_runs = 999999
+verbosity = 3
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/test/GasReport.t.sol
+++ b/test/GasReport.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import "forge-std/Test.sol";
+import "../src/Challenger1of2.sol";
+import "../src/revenue-share/BalanceTracker.sol";
+import {FeeVault as CustomFeeVault} from "../src/fee-vault-fixes/FeeVault.sol";
+import {Proxy} from "@eth-optimism-bedrock/src/universal/Proxy.sol";
+
+contract GasReportTest is Test {
+    Challenger1of2 challenger;
+    BalanceTracker balanceTracker;
+    CustomFeeVault feeVault;
+    address opSigner;
+    address otherSigner;
+    address proxyAdmin;
+
+    // Proxy-related variables
+    Proxy balanceTrackerProxy;
+    BalanceTracker balanceTrackerImplementation;
+
+    function setUp() public {
+        opSigner = makeAddr("opSigner");
+        otherSigner = makeAddr("otherSigner");
+        proxyAdmin = makeAddr("proxyAdmin");
+
+        // Setup Challenger
+        challenger = new Challenger1of2(
+            opSigner,
+            otherSigner,
+            address(new MockL2OutputOracle())
+        );
+
+        // Setup BalanceTracker
+        address payable profitWallet = payable(makeAddr("profitWallet"));
+        balanceTrackerImplementation = new BalanceTracker(profitWallet);
+        balanceTrackerProxy = new Proxy(proxyAdmin);
+        vm.prank(proxyAdmin);
+        balanceTrackerProxy.upgradeTo(address(balanceTrackerImplementation));
+        balanceTracker = BalanceTracker(payable(address(balanceTrackerProxy)));
+
+        // Initialize BalanceTracker
+        address payable[] memory systemAddresses = new address payable[](2);
+        systemAddresses[0] = payable(makeAddr("system1"));
+        systemAddresses[1] = payable(makeAddr("system2"));
+        uint256[] memory targetBalances = new uint256[](2);
+        targetBalances[0] = 1 ether;
+        targetBalances[1] = 2 ether;
+        balanceTracker.initialize(systemAddresses, targetBalances);
+
+        feeVault = new CustomFeeVault();
+    }
+
+    /// @notice Gas report for challenge execution
+    function test_challenger_execute() public {
+        bytes memory message = abi.encodeWithSelector(
+            MockL2OutputOracle.deleteL2Outputs.selector,
+            0
+        );
+        vm.prank(opSigner);
+        challenger.execute(message);
+    }
+
+    /// @notice Gas report for processing fees in BalanceTracker
+    function test_balanceTracker_processFees() public {
+        vm.deal(address(balanceTracker), 10 ether);
+        balanceTracker.processFees();
+    }
+
+    /// @notice Gas report for setting total processed in FeeVault
+    function test_feeVault_setTotalProcessed() public {
+        feeVault.setTotalProcessed(1 ether);
+    }
+
+    receive() external payable {}
+}
+
+contract MockL2OutputOracle {
+    function deleteL2Outputs(uint256) external pure returns (bool) {
+        return true;
+    }
+}


### PR DESCRIPTION
Added gas tracking tests for key operations to establish baselines for:
- Identifying potential gas optimizations
- Preventing gas cost regressions in future updates
- Making sure operations remain within acceptable gas limits

## Testing the added repo feature:
From root directory run
```bash
make gas-report
```

## Current repo result

https://github.com/user-attachments/assets/4b999060-2924-46ce-9c2d-8a5f12a1ad3b


