### PR TITLE
fix: align token symbol with parameter naming

### DIFF
--- a/script/deploy/l2/tests/DeployTestTokenContracts.s.sol
+++ b/script/deploy/l2/tests/DeployTestTokenContracts.s.sol
@@ -17,7 +17,7 @@ contract DeployTestTokenContracts is Script {
         console.log("Bridged erc20 deployed to: %s", address(erc20));
 
         address erc721 = OptimismMintableERC721Factory(payable(Predeploys.OPTIMISM_MINTABLE_ERC721_FACTORY))
-            .createOptimismMintableERC721(_l1erc721, "L2 TEST ERC721", "L1T721");
+            .createOptimismMintableERC721(_l1erc721, "L2 TEST ERC721", "L2T721");
         console.log("Bridged erc721 deployed to: %s", address(erc721));
 
         vm.stopBroadcast();


### PR DESCRIPTION
This pr is to address issue #99 

## Description
The `_l1erc721` parameter in `createOptimismMintableERC721` represents the L1 token, while `L1T721` was incorrectly used as the L2 token's symbol. Changed to `L2T721` to properly reflect the relationship between the parameter and the created token.