### PR TITLE
fix: Fix typo in function name Update MultisigBase.sol

### DIFF
--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -100,7 +100,7 @@ abstract contract MultisigBase is CommonBase {
         bytes32 hash = _getTransactionHash(_safe, data);
         _signatures = Signatures.prepareSignatures(_safe, hash, _signatures);
 
-        bytes memory simData = _execTransationCalldata(_safe, data, _signatures);
+        bytes memory simData = _execTransactionCalldata(_safe, data, _signatures);
         Simulation.logSimulationLink({_to: _safe, _from: msg.sender, _data: simData});
 
         vm.startStateDiffRecording();
@@ -144,7 +144,7 @@ abstract contract MultisigBase is CommonBase {
         });
     }
 
-    function _execTransationCalldata(address _safe, bytes memory _data, bytes memory _signatures)
+    function _execTransactionCalldata(address _safe, bytes memory _data, bytes memory _signatures)
         internal
         pure
         returns (bytes memory)


### PR DESCRIPTION
### Description 
A typo in the function name `_execTransationCalldata` where "Transaction" was misspelled (missing an "s").
This PR corrects the function name to `_execTransactionCalldata` to ensure consistency and avoid confusion.
All references to the function have been updated accordingly.

Based.