### PR TITLE
Changes to enable delegate calling to OPCM upgrade.

### DIFF
--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -13,8 +13,19 @@ import {Simulation} from "./Simulation.sol";
 
 abstract contract MultisigBase is CommonBase {
     bytes32 internal constant SAFE_NONCE_SLOT = bytes32(uint256(5));
+    address internal constant MULTI_DELEGATECALL_ADDRESS = 0x95b259eae68ba96edB128eF853fFbDffe47D2Db0;
 
     event DataToSign(bytes);
+
+    function _target(address _safe) internal view returns (address) {
+        // Always parse the env var as a string to avoid issues with boolean values. This lets
+        // us use "true" or "1" as the value to enable the multi-delegatecall.
+        bool useMultiDelegatecall = (vm.envOr("USE_MULTI_DELEGATECALL", false) || vm.envOr("USE_MULTI_DELEGATECALL", uint256(0)) == 1);
+        if (_safe == 0x1Eb2fFc903729a0F03966B917003800b145F56E2 && useMultiDelegatecall) {
+            return MULTI_DELEGATECALL_ADDRESS;
+        }
+        return MULTICALL3_ADDRESS;
+    }
 
     // Subclasses that use nested safes should return `false` to force use of the
     // explicit SAFE_NONCE_{UPPERCASE_SAFE_ADDRESS} env var.

--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -17,11 +17,13 @@ abstract contract MultisigBase is CommonBase {
 
     event DataToSign(bytes);
 
+    function _ownerSafe() internal view virtual returns (address);
+
     function _target(address _safe) internal view returns (address) {
         // Always parse the env var as a string to avoid issues with boolean values. This lets
         // us use "true" or "1" as the value to enable the multi-delegatecall.
         bool useMultiDelegatecall = (vm.envOr("USE_MULTI_DELEGATECALL", false) || vm.envOr("USE_MULTI_DELEGATECALL", uint256(0)) == 1);
-        if (_safe == 0x1Eb2fFc903729a0F03966B917003800b145F56E2 && useMultiDelegatecall) {
+        if (_safe == _ownerSafe() && useMultiDelegatecall) {
             return MULTI_DELEGATECALL_ADDRESS;
         }
         return MULTICALL3_ADDRESS;

--- a/script/universal/MultisigBase.sol
+++ b/script/universal/MultisigBase.sol
@@ -145,7 +145,7 @@ abstract contract MultisigBase is CommonBase {
 
     function _encodeTransactionData(address _safe, bytes memory _data) internal view returns (bytes memory) {
         return IGnosisSafe(_safe).encodeTransactionData({
-            to: MULTICALL3_ADDRESS,
+            to: _target(_safe),
             value: 0,
             data: _data,
             operation: Enum.Operation.DelegateCall,
@@ -160,23 +160,12 @@ abstract contract MultisigBase is CommonBase {
 
     function _execTransationCalldata(address _safe, bytes memory _data, bytes memory _signatures)
         internal
-        pure
+        view
         returns (bytes memory)
     {
         return abi.encodeCall(
             IGnosisSafe(_safe).execTransaction,
-            (
-                MULTICALL3_ADDRESS,
-                0,
-                _data,
-                Enum.Operation.DelegateCall,
-                0,
-                0,
-                0,
-                address(0),
-                payable(address(0)),
-                _signatures
-            )
+            (_target(_safe), 0, _data, Enum.Operation.DelegateCall, 0, 0, 0, address(0), payable(address(0)), _signatures)
         );
     }
 
@@ -184,11 +173,12 @@ abstract contract MultisigBase is CommonBase {
         internal
         returns (bool)
     {
+        address target = _target(_safe);
         if (_broadcast) {
             vm.broadcast();
         }
         return IGnosisSafe(_safe).execTransaction({
-            to: MULTICALL3_ADDRESS,
+            to: target,
             value: 0,
             data: _data,
             operation: Enum.Operation.DelegateCall,

--- a/script/universal/MultisigBuilder.sol
+++ b/script/universal/MultisigBuilder.sol
@@ -23,11 +23,6 @@ abstract contract MultisigBuilder is MultisigBase {
      */
 
     /**
-     * @notice Returns the safe address to execute the transaction from
-     */
-    function _ownerSafe() internal view virtual returns (address);
-
-    /**
      * @notice Creates the calldata for both signatures (`sign`) and execution (`run`)
      */
     function _buildCalls() internal view virtual returns (IMulticall3.Call3[] memory);

--- a/script/universal/NestedMultisigBase.sol
+++ b/script/universal/NestedMultisigBase.sol
@@ -19,11 +19,6 @@ abstract contract NestedMultisigBase is MultisigBase {
      */
 
     /**
-     * @notice Returns the nested safe address to execute the final transaction from
-     */
-    function _ownerSafe() internal view virtual returns (address);
-
-    /**
      * @notice Creates the calldata for both signatures (`sign`) and execution (`run`)
      */
     function _buildCalls() internal view virtual returns (IMulticall3.Call3[] memory);

--- a/script/universal/Simulation.sol
+++ b/script/universal/Simulation.sol
@@ -191,6 +191,9 @@ library Simulation {
             "&stateOverrides=",
             stateOverrides
         );
+        if (vm.envOr("TENDERLY_GAS", uint256(0)) > 0) {
+            str = string.concat(str, "&gas=", vm.toString(vm.envOr("TENDERLY_GAS", uint256(0))));
+        }
         if (bytes(str).length + _data.length * 2 > 7980) {
             // tenderly's nginx has issues with long URLs, so print the raw input data separately
             str = string.concat(str, "\nInsert the following hex into the 'Raw input data' field:");


### PR DESCRIPTION
This PR applies the necessary changes to enable the base contracts to execute the OPCM upgrade call in https://github.com/ethereum-optimism/superchain-ops/pull/581.

1. Ensures that the call from the owner safe targets the Multicall3DelegateCall contract.
2. Enables increasing the gas limit in the tenderly simulation.