### PR TITLE
chore: use Call3Value for _buildCalls

### DIFF
--- a/script/deploy/l1/SetGasLimit.sol
+++ b/script/deploy/l1/SetGasLimit.sol
@@ -26,13 +26,14 @@ contract SetGasLimit is MultisigScript {
         assert(SystemConfig(L1_SYSTEM_CONFIG).gasLimit() == _toGasLimit());
     }
 
-    function _buildCalls() internal view override returns (IMulticall3.Call3[] memory) {
-        IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](1);
+    function _buildCalls() internal view override returns (IMulticall3.Call3Value[] memory) {
+        IMulticall3.Call3Value[] memory calls = new IMulticall3.Call3Value[](1);
 
-        calls[0] = IMulticall3.Call3({
+        calls[0] = IMulticall3.Call3Value({
             target: L1_SYSTEM_CONFIG,
             allowFailure: false,
-            callData: abi.encodeCall(SystemConfig.setGasLimit, (_toGasLimit()))
+            callData: abi.encodeCall(SystemConfig.setGasLimit, (_toGasLimit())),
+            value: 0
         });
 
         return calls;

--- a/test/universal/DoubleNestedMultisigBuilder.t.sol
+++ b/test/universal/DoubleNestedMultisigBuilder.t.sol
@@ -24,9 +24,9 @@ contract DoubleNestedMultisigBuilderTest is Test, DoubleNestedMultisigBuilder {
 
     bytes internal dataToSign1 =
     // solhint-disable max-line-length
-        hex"1901d4bb33110137810c444c1d9617abe97df097d587ecde64e6fcb38d7f49e1280c32a807b9689901dd0dbb7352e9e6c5265e3f6a68667de4be988f03f6a88511f7";
+        hex"1901d4bb33110137810c444c1d9617abe97df097d587ecde64e6fcb38d7f49e1280c79f9c7295573dc135fa98d1fc9f5a01ae7e7caad046143376e34f9945288b7a0";
     bytes internal dataToSign2 =
-        hex"190132640243d7aade8c72f3d90d2dbf359e9897feba5fce1453bc8d9e7ba10d171532a807b9689901dd0dbb7352e9e6c5265e3f6a68667de4be988f03f6a88511f7";
+        hex"190132640243d7aade8c72f3d90d2dbf359e9897feba5fce1453bc8d9e7ba10d171579f9c7295573dc135fa98d1fc9f5a01ae7e7caad046143376e34f9945288b7a0";
 
     function setUp() public {
         bytes memory safeCode = Preinstalls.getDeployedCode(Preinstalls.Safe_v130, block.chainid);
@@ -60,13 +60,14 @@ contract DoubleNestedMultisigBuilderTest is Test, DoubleNestedMultisigBuilder {
         require(counterValue == 1, "Counter value is not 1");
     }
 
-    function _buildCalls() internal view override returns (IMulticall3.Call3[] memory) {
-        IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](1);
+    function _buildCalls() internal view override returns (IMulticall3.Call3Value[] memory) {
+        IMulticall3.Call3Value[] memory calls = new IMulticall3.Call3Value[](1);
 
-        calls[0] = IMulticall3.Call3({
+        calls[0] = IMulticall3.Call3Value({
             target: address(counter),
             allowFailure: false,
-            callData: abi.encodeCall(Counter.increment, ())
+            callData: abi.encodeCall(Counter.increment, ()),
+            value: 0
         });
 
         return calls;

--- a/test/universal/MultisigBuilder.t.sol
+++ b/test/universal/MultisigBuilder.t.sol
@@ -21,7 +21,7 @@ contract MultisigBuilderTest is Test, MultisigBuilder {
 
     bytes internal dataToSign =
     // solhint-disable-next-line max-line-length
-        hex"1901d4bb33110137810c444c1d9617abe97df097d587ecde64e6fcb38d7f49e1280c41dcff2c17a271265df60d1612a7387110475b6fc5178add5518196db5dba6bd";
+        hex"1901d4bb33110137810c444c1d9617abe97df097d587ecde64e6fcb38d7f49e1280cd0722aa57d06d71497c199147817c38ae160e5b355d3fb5ccbe34c3dbadeae6d";
 
     function setUp() public {
         vm.etch(safe, Preinstalls.getDeployedCode(Preinstalls.Safe_v130, block.chainid));
@@ -39,13 +39,14 @@ contract MultisigBuilderTest is Test, MultisigBuilder {
         require(counterValue == 1, "Counter value is not 1");
     }
 
-    function _buildCalls() internal view override returns (IMulticall3.Call3[] memory) {
-        IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](1);
+    function _buildCalls() internal view override returns (IMulticall3.Call3Value[] memory) {
+        IMulticall3.Call3Value[] memory calls = new IMulticall3.Call3Value[](1);
 
-        calls[0] = IMulticall3.Call3({
+        calls[0] = IMulticall3.Call3Value({
             target: address(counter),
             allowFailure: false,
-            callData: abi.encodeCall(Counter.increment, ())
+            callData: abi.encodeCall(Counter.increment, ()),
+            value: 0
         });
 
         return calls;

--- a/test/universal/NestedMultisigBuilder.t.sol
+++ b/test/universal/NestedMultisigBuilder.t.sol
@@ -23,9 +23,9 @@ contract NestedMultisigBuilderTest is Test, NestedMultisigBuilder {
 
     bytes internal dataToSign1 =
     // solhint-disable max-line-length
-        hex"1901d4bb33110137810c444c1d9617abe97df097d587ecde64e6fcb38d7f49e1280c3afd48ea8b0056e1028951ba44695d612396f4a1c3851f4b8a262c53ee1f2503";
+        hex"1901d4bb33110137810c444c1d9617abe97df097d587ecde64e6fcb38d7f49e1280c5f51d24161b7d5dfddfd10cad9118e4e37e6fde740a81d2d84dc35a401b0f74c";
     bytes internal dataToSign2 =
-        hex"190132640243d7aade8c72f3d90d2dbf359e9897feba5fce1453bc8d9e7ba10d17153afd48ea8b0056e1028951ba44695d612396f4a1c3851f4b8a262c53ee1f2503";
+        hex"190132640243d7aade8c72f3d90d2dbf359e9897feba5fce1453bc8d9e7ba10d17155f51d24161b7d5dfddfd10cad9118e4e37e6fde740a81d2d84dc35a401b0f74c";
 
     function setUp() public {
         bytes memory safeCode = Preinstalls.getDeployedCode(Preinstalls.Safe_v130, block.chainid);
@@ -54,13 +54,14 @@ contract NestedMultisigBuilderTest is Test, NestedMultisigBuilder {
         require(counterValue == 1, "Counter value is not 1");
     }
 
-    function _buildCalls() internal view override returns (IMulticall3.Call3[] memory) {
-        IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](1);
+    function _buildCalls() internal view override returns (IMulticall3.Call3Value[] memory) {
+        IMulticall3.Call3Value[] memory calls = new IMulticall3.Call3Value[](1);
 
-        calls[0] = IMulticall3.Call3({
+        calls[0] = IMulticall3.Call3Value({
             target: address(counter),
             allowFailure: false,
-            callData: abi.encodeCall(Counter.increment, ())
+            callData: abi.encodeCall(Counter.increment, ()),
+            value: 0
         });
 
         return calls;


### PR DESCRIPTION
Change `_buildCalls` to return an array of `Call3Value`, enabling ETH transfers (primarily for funding new facilitator ledgers).

Update the unit tests with the new expected "data to sign", which changed due to the use of `aggregate3Value` instead of `aggregate3`, and the addition of the `value` field in the `Call3Value` calls.