### PR TITLE
[CHAIN-282] Add upgradeable recovery contract

### DIFF
--- a/src/recovery/Recovery.sol
+++ b/src/recovery/Recovery.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+
+/// @title Recovery
+///
+/// @notice A utility contract for recovering funds from addresses controlled by signers owned by Coinbase.
+///
+/// @dev This contract provides a flexible mechanism to recover ETH (and potentially other assets in future
+///      upgrades) that have been sent to addresses where Coinbase has control over the deployment nonce.
+///      The contract is designed as UUPS upgradeable to allow adaptation to various recovery scenarios,
+///      such as recovering different asset types or implementing new recovery patterns as needs evolve.
+contract Recovery is UUPSUpgradeable {
+    /// @dev The address of the owner.
+    address public immutable OWNER;
+
+    /// @dev Error thrown when the caller is not the owner.
+    error Unauthorized();
+
+    /// @dev Error thrown when the ETH withdrawal fails.
+    error ETHWithdrawalFailed();
+
+    /// @dev Modifier to check if the caller is the owner.
+    modifier onlyOwner() {
+        if (msg.sender != OWNER) revert Unauthorized();
+        _;
+    }
+
+    /// @notice Constructor.
+    ///
+    /// @param owner The address of the owner.
+    constructor(address owner) {
+        OWNER = owner;
+    }
+
+    /// @inheritdoc UUPSUpgradeable
+    function _authorizeUpgrade(address) internal view override onlyOwner {}
+
+    /// @notice Withdraw ETH from the contract.
+    ///
+    /// @dev This function is only callable by the owner.
+    ///
+    /// @param targets The addresses to send the ETH to.
+    /// @param amounts The amounts of ETH to send to each address.
+    function withdrawETH(address[] calldata targets, uint256[] calldata amounts) public onlyOwner {
+        for (uint256 i = 0; i < targets.length; i++) {
+            (bool success,) = targets[i].call{value: amounts[i]}("");
+            if (!success) revert ETHWithdrawalFailed();
+        }
+    }
+}

--- a/test/recovery/Recovery.t.sol
+++ b/test/recovery/Recovery.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Test} from "forge-std/Test.sol";
+import {Recovery} from "../../src/recovery/Recovery.sol";
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract RecoveryTest is Test {
+    Recovery public recovery;
+    Recovery public implementation;
+
+    address public owner = makeAddr("owner");
+    address public user = makeAddr("user");
+
+    address public recipient1 = makeAddr("recipient1");
+    address public recipient2 = makeAddr("recipient2");
+
+    function setUp() public {
+        // Deploy implementation
+        implementation = new Recovery(owner);
+
+        // Deploy proxy with implementation
+        bytes memory initData = "";
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), initData);
+        recovery = Recovery(address(proxy));
+
+        // Fund the recovery contract with some ETH
+        vm.deal(address(recovery), 10 ether);
+
+        // Fund test accounts
+        vm.deal(owner, 1 ether);
+        vm.deal(user, 1 ether);
+    }
+
+    function test_Owner() public view {
+        assertEq(recovery.OWNER(), owner);
+    }
+
+    function test_WithdrawETH_Success() public {
+        // Arrange
+        address[] memory targets = new address[](2);
+        targets[0] = recipient1;
+        targets[1] = recipient2;
+
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 1 ether;
+        amounts[1] = 2 ether;
+
+        uint256 initialBalance1 = recipient1.balance;
+        uint256 initialBalance2 = recipient2.balance;
+
+        // Act
+        vm.prank(owner);
+        recovery.withdrawETH(targets, amounts);
+
+        // Assert
+        assertEq(recipient1.balance, initialBalance1 + 1 ether);
+        assertEq(recipient2.balance, initialBalance2 + 2 ether);
+    }
+
+    function test_WithdrawETH_Unauthorized() public {
+        // Arrange
+        address[] memory targets = new address[](1);
+        targets[0] = recipient1;
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1 ether;
+
+        // Act & Assert
+        vm.expectRevert(Recovery.Unauthorized.selector);
+        vm.prank(user);
+        recovery.withdrawETH(targets, amounts);
+    }
+
+    function test_WithdrawETH_FailedTransfer() public {
+        // Create a contract that rejects ETH
+        RejectETH rejecter = new RejectETH();
+
+        // Arrange - set up 2 transfers where the 2nd one will fail
+        address[] memory targets = new address[](2);
+        targets[0] = recipient1; // This transfer will succeed
+        targets[1] = address(rejecter); // This transfer will fail
+
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 1 ether;
+        amounts[1] = 2 ether;
+
+        // Act & Assert - the entire transaction should revert
+        vm.expectRevert(Recovery.ETHWithdrawalFailed.selector);
+        vm.prank(owner);
+        recovery.withdrawETH(targets, amounts);
+    }
+
+    function test_AuthorizeUpgrade_OnlyOwner() public {
+        // Deploy new implementation
+        Recovery newImplementation = new Recovery(owner);
+
+        // Non-owner cannot upgrade
+        vm.expectRevert(Recovery.Unauthorized.selector);
+        vm.prank(user);
+        recovery.upgradeTo(address(newImplementation));
+
+        // Owner can upgrade
+        vm.prank(owner);
+        recovery.upgradeTo(address(newImplementation));
+    }
+}
+
+// Helper contract that rejects ETH
+contract RejectETH {
+    receive() external payable {
+        revert("ETH rejected");
+    }
+}


### PR DESCRIPTION
## Summary

Implements a Recovery utility contract to recover funds from addresses controlled by signers owned by Coinbase.

## Context

Users have been mistakenly sending ETH (and some tokens) to addresses on L2 chains (e.g., Arbitrum, Base) that match portal contract addresses on Ethereum mainnet. Since Coinbase controls the deployer nonce for these addresses, we can deploy a recovery contract to rescue these funds.

## Changes

### Contract Implementation
- Added `Recovery.sol` - A UUPS upgradeable contract that allows withdrawing ETH to specified addresses
- Includes owner-only access control for security
- Designed to be upgradeable to support future recovery scenarios (e.g., ERC20 tokens, new recovery patterns)

### Tests
- Added comprehensive unit tests in `test/recovery/Recovery.t.sol`
- Tests cover:
  - Owner verification
  - Successful ETH withdrawals to multiple recipients
  - Access control (unauthorized access prevention)
  - Failed transfer handling with atomic reversion
  - Upgrade authorization

## Key Features

- **Owner-controlled**: Only the designated owner can execute withdrawals
- **Batch operations**: Supports withdrawing to multiple addresses in a single transaction
- **Atomic execution**: If any transfer fails, the entire batch reverts
- **Future-proof**: UUPS upgradeable pattern allows adapting to new recovery needs

## Testing

Run tests with:
```bash
forge test --match-path test/recovery/Recovery.t.sol
```
