### PR TITLE
fix: add array length validation in Recovery.withdrawETH

### DIFF
--- a/test/recovery/Recovery.t.sol
+++ b/test/recovery/Recovery.t.sol
@@ -73,6 +73,21 @@ contract RecoveryTest is Test {
         recovery.withdrawETH(targets, amounts);
     }
 
+    function test_WithdrawETH_ArrayLengthMismatch() public {
+        // Arrange
+        address[] memory targets = new address[](2);
+        targets[0] = recipient1;
+        targets[1] = recipient2;
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1 ether;
+
+        // Act & Assert
+        vm.expectRevert(Recovery.ArrayLengthMismatch.selector);
+        vm.prank(owner);
+        recovery.withdrawETH(targets, amounts);
+    }
+
     function test_WithdrawETH_FailedTransfer() public {
         // Create a contract that rejects ETH
         RejectETH rejecter = new RejectETH();


### PR DESCRIPTION
Add validation to ensure targets and amounts arrays have the same length in Recovery.withdrawETH method to prevent potential out-of-bounds access. This security improvement helps avoid panic errors that would occur if targets.length > amounts.length, and ensures correct function behavior by validating input parameters