### PR TITLE
feat(CHAIN-1796): add CBMulticall contract

### DIFF
--- a/src/utils/CBMulticall.sol
+++ b/src/utils/CBMulticall.sol
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+/// @title CBMulticall
+///
+/// @notice Aggregate results from multiple function calls
+///
+/// @dev This is an exact copy of the standard Multicall3 contract with one minor modification. The `require` statement
+///      at the bottom of `aggregate3Value` has been removed to support smart contract operations involving an array of
+///      permissioned calls that require a value set. When routing a call through a multisig, for example, it's
+///      beneficial to be able to DELEGATECALL from the multisig to this contract, thus maintaining the multisig as the
+///      `msg.sender` while still allowing the calls to utilize ETH already held by the multisig.
+contract CBMulticall {
+    struct Call {
+        address target;
+        bytes callData;
+    }
+
+    struct Call3 {
+        address target;
+        bool allowFailure;
+        bytes callData;
+    }
+
+    struct Call3Value {
+        address target;
+        bool allowFailure;
+        uint256 value;
+        bytes callData;
+    }
+
+    struct Result {
+        bool success;
+        bytes returnData;
+    }
+
+    /// @notice Backwards-compatible call aggregation with Multicall
+    /// @param calls An array of Call structs
+    /// @return blockNumber The block number where the calls were executed
+    /// @return returnData An array of bytes containing the responses
+    function aggregate(Call[] calldata calls) public payable returns (uint256 blockNumber, bytes[] memory returnData) {
+        blockNumber = block.number;
+        uint256 length = calls.length;
+        returnData = new bytes[](length);
+        Call calldata call;
+        for (uint256 i = 0; i < length;) {
+            bool success;
+            call = calls[i];
+            (success, returnData[i]) = call.target.call(call.callData);
+            require(success, "Multicall3: call failed");
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Backwards-compatible with Multicall2
+    /// @notice Aggregate calls without requiring success
+    /// @param requireSuccess If true, require all calls to succeed
+    /// @param calls An array of Call structs
+    /// @return returnData An array of Result structs
+    function tryAggregate(bool requireSuccess, Call[] calldata calls)
+        public
+        payable
+        returns (Result[] memory returnData)
+    {
+        uint256 length = calls.length;
+        returnData = new Result[](length);
+        Call calldata call;
+        for (uint256 i = 0; i < length;) {
+            Result memory result = returnData[i];
+            call = calls[i];
+            (result.success, result.returnData) = call.target.call(call.callData);
+            if (requireSuccess) require(result.success, "Multicall3: call failed");
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Backwards-compatible with Multicall2
+    /// @notice Aggregate calls and allow failures using tryAggregate
+    /// @param calls An array of Call structs
+    /// @return blockNumber The block number where the calls were executed
+    /// @return blockHash The hash of the block where the calls were executed
+    /// @return returnData An array of Result structs
+    function tryBlockAndAggregate(bool requireSuccess, Call[] calldata calls)
+        public
+        payable
+        returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData)
+    {
+        blockNumber = block.number;
+        blockHash = blockhash(block.number);
+        returnData = tryAggregate(requireSuccess, calls);
+    }
+
+    /// @notice Backwards-compatible with Multicall2
+    /// @notice Aggregate calls and allow failures using tryAggregate
+    /// @param calls An array of Call structs
+    /// @return blockNumber The block number where the calls were executed
+    /// @return blockHash The hash of the block where the calls were executed
+    /// @return returnData An array of Result structs
+    function blockAndAggregate(Call[] calldata calls)
+        public
+        payable
+        returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData)
+    {
+        (blockNumber, blockHash, returnData) = tryBlockAndAggregate(true, calls);
+    }
+
+    /// @notice Aggregate calls, ensuring each returns success if required
+    /// @param calls An array of Call3 structs
+    /// @return returnData An array of Result structs
+    function aggregate3(Call3[] calldata calls) public payable returns (Result[] memory returnData) {
+        uint256 length = calls.length;
+        returnData = new Result[](length);
+        Call3 calldata calli;
+        for (uint256 i = 0; i < length;) {
+            Result memory result = returnData[i];
+            calli = calls[i];
+            (result.success, result.returnData) = calli.target.call(calli.callData);
+            assembly {
+                // Revert if the call fails and failure is not allowed
+                // `allowFailure := calldataload(add(calli, 0x20))` and `success := mload(result)`
+                if iszero(or(calldataload(add(calli, 0x20)), mload(result))) {
+                    // set "Error(string)" signature: bytes32(bytes4(keccak256("Error(string)")))
+                    mstore(0x00, 0x08c379a000000000000000000000000000000000000000000000000000000000)
+                    // set data offset
+                    mstore(0x04, 0x0000000000000000000000000000000000000000000000000000000000000020)
+                    // set length of revert string
+                    mstore(0x24, 0x0000000000000000000000000000000000000000000000000000000000000017)
+                    // set revert string: bytes32(abi.encodePacked("Multicall3: call failed"))
+                    mstore(0x44, 0x4d756c746963616c6c333a2063616c6c206661696c6564000000000000000000)
+                    revert(0x00, 0x64)
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Aggregate calls with a msg value
+    /// @notice Reverts if msg.value is less than the sum of the call values
+    /// @param calls An array of Call3Value structs
+    /// @return returnData An array of Result structs
+    function aggregate3Value(Call3Value[] calldata calls) public payable returns (Result[] memory returnData) {
+        uint256 valAccumulator;
+        uint256 length = calls.length;
+        returnData = new Result[](length);
+        Call3Value calldata calli;
+        for (uint256 i = 0; i < length;) {
+            Result memory result = returnData[i];
+            calli = calls[i];
+            uint256 val = calli.value;
+            // Humanity will be a Type V Kardashev Civilization before this overflows - andreas
+            // ~ 10^25 Wei in existence << ~ 10^76 size uint fits in a uint256
+            unchecked {
+                valAccumulator += val;
+            }
+            (result.success, result.returnData) = calli.target.call{value: val}(calli.callData);
+            assembly {
+                // Revert if the call fails and failure is not allowed
+                // `allowFailure := calldataload(add(calli, 0x20))` and `success := mload(result)`
+                if iszero(or(calldataload(add(calli, 0x20)), mload(result))) {
+                    // set "Error(string)" signature: bytes32(bytes4(keccak256("Error(string)")))
+                    mstore(0x00, 0x08c379a000000000000000000000000000000000000000000000000000000000)
+                    // set data offset
+                    mstore(0x04, 0x0000000000000000000000000000000000000000000000000000000000000020)
+                    // set length of revert string
+                    mstore(0x24, 0x0000000000000000000000000000000000000000000000000000000000000017)
+                    // set revert string: bytes32(abi.encodePacked("Multicall3: call failed"))
+                    mstore(0x44, 0x4d756c746963616c6c333a2063616c6c206661696c6564000000000000000000)
+                    revert(0x00, 0x84)
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Returns the block hash for the given block number
+    /// @param blockNumber The block number
+    function getBlockHash(uint256 blockNumber) public view returns (bytes32 blockHash) {
+        blockHash = blockhash(blockNumber);
+    }
+
+    /// @notice Returns the block number
+    function getBlockNumber() public view returns (uint256 blockNumber) {
+        blockNumber = block.number;
+    }
+
+    /// @notice Returns the block coinbase
+    function getCurrentBlockCoinbase() public view returns (address coinbase) {
+        coinbase = block.coinbase;
+    }
+
+    /// @notice Returns the block difficulty
+    function getCurrentBlockDifficulty() public view returns (uint256 difficulty) {
+        difficulty = block.difficulty;
+    }
+
+    /// @notice Returns the block gas limit
+    function getCurrentBlockGasLimit() public view returns (uint256 gaslimit) {
+        gaslimit = block.gaslimit;
+    }
+
+    /// @notice Returns the block timestamp
+    function getCurrentBlockTimestamp() public view returns (uint256 timestamp) {
+        timestamp = block.timestamp;
+    }
+
+    /// @notice Returns the (ETH) balance of a given address
+    function getEthBalance(address addr) public view returns (uint256 balance) {
+        balance = addr.balance;
+    }
+
+    /// @notice Returns the block hash of the last block
+    function getLastBlockHash() public view returns (bytes32 blockHash) {
+        unchecked {
+            blockHash = blockhash(block.number - 1);
+        }
+    }
+
+    /// @notice Gets the base fee of the given block
+    /// @notice Can revert if the BASEFEE opcode is not implemented by the given chain
+    function getBasefee() public view returns (uint256 basefee) {
+        basefee = block.basefee;
+    }
+
+    /// @notice Returns the chain id
+    function getChainId() public view returns (uint256 chainid) {
+        chainid = block.chainid;
+    }
+}

--- a/src/utils/CBMulticall.sol
+++ b/src/utils/CBMulticall.sol
@@ -141,7 +141,6 @@ contract CBMulticall {
     }
 
     /// @notice Aggregate calls with a msg value
-    /// @notice Reverts if msg.value is less than the sum of the call values
     /// @param calls An array of Call3Value structs
     /// @return returnData An array of Result structs
     function aggregate3Value(Call3Value[] calldata calls) public payable returns (Result[] memory returnData) {

--- a/src/utils/CBMulticall.sol
+++ b/src/utils/CBMulticall.sol
@@ -145,7 +145,6 @@ contract CBMulticall {
     /// @param calls An array of Call3Value structs
     /// @return returnData An array of Result structs
     function aggregate3Value(Call3Value[] calldata calls) public payable returns (Result[] memory returnData) {
-        uint256 valAccumulator;
         uint256 length = calls.length;
         returnData = new Result[](length);
         Call3Value calldata calli;
@@ -153,11 +152,6 @@ contract CBMulticall {
             Result memory result = returnData[i];
             calli = calls[i];
             uint256 val = calli.value;
-            // Humanity will be a Type V Kardashev Civilization before this overflows - andreas
-            // ~ 10^25 Wei in existence << ~ 10^76 size uint fits in a uint256
-            unchecked {
-                valAccumulator += val;
-            }
             (result.success, result.returnData) = calli.target.call{value: val}(calli.callData);
             assembly {
                 // Revert if the call fails and failure is not allowed
@@ -171,7 +165,7 @@ contract CBMulticall {
                     mstore(0x24, 0x0000000000000000000000000000000000000000000000000000000000000017)
                     // set revert string: bytes32(abi.encodePacked("Multicall3: call failed"))
                     mstore(0x44, 0x4d756c746963616c6c333a2063616c6c206661696c6564000000000000000000)
-                    revert(0x00, 0x84)
+                    revert(0x00, 0x64)
                 }
             }
             unchecked {

--- a/test/mocks/MockReceiver.sol
+++ b/test/mocks/MockReceiver.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+contract MockReceiver {
+    function bump(uint256 x) external pure returns (uint256) {
+        return x + 1;
+    }
+
+    function payAndEcho(uint256 x) external payable returns (uint256, uint256) {
+        return (x, msg.value);
+    }
+
+    function willRevert() external pure {
+        revert("revert");
+    }
+}

--- a/test/utils/CBMulticall.t.sol
+++ b/test/utils/CBMulticall.t.sol
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {CBMulticall} from "src/utils/CBMulticall.sol";
+import {CommonTest} from "test/CommonTest.t.sol";
+import {MockReceiver} from "test/mocks/MockReceiver.sol";
+
+contract CBMulticallTest is CommonTest {
+    CBMulticall mc;
+    MockReceiver target;
+
+    function setUp() public override {
+        super.setUp();
+        mc = new CBMulticall();
+        target = new MockReceiver();
+    }
+
+    function test_aggregate_returnsBlockNumberAndData() external {
+        CBMulticall.Call[] memory calls = new CBMulticall.Call[](2);
+        calls[0] = CBMulticall.Call({
+            target: address(target),
+            callData: abi.encodeWithSelector(MockReceiver.bump.selector, 41)
+        });
+        calls[1] =
+            CBMulticall.Call({target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 1)});
+
+        (uint256 bn, bytes[] memory rdata) = mc.aggregate(calls);
+        assertEq(bn, block.number);
+        assertEq(abi.decode(rdata[0], (uint256)), 42);
+        assertEq(abi.decode(rdata[1], (uint256)), 2);
+    }
+
+    function test_aggregate_revertsOnFailedCall() external {
+        CBMulticall.Call[] memory calls = new CBMulticall.Call[](2);
+        calls[0] =
+            CBMulticall.Call({target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 0)});
+        calls[1] = CBMulticall.Call({
+            target: address(target),
+            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
+        });
+        vm.expectRevert(bytes("Multicall3: call failed"));
+        mc.aggregate(calls);
+    }
+
+    function test_tryAggregate_noRequire_returnsResults() external {
+        CBMulticall.Call[] memory calls = new CBMulticall.Call[](2);
+        calls[0] =
+            CBMulticall.Call({target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 1)});
+        calls[1] = CBMulticall.Call({
+            target: address(target),
+            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
+        });
+
+        CBMulticall.Result[] memory results = mc.tryAggregate(false, calls);
+        assertEq(results.length, 2);
+        assertTrue(results[0].success);
+        assertEq(abi.decode(results[0].returnData, (uint256)), 2);
+        assertFalse(results[1].success);
+    }
+
+    function test_tryAggregate_requireSuccess_revertsOnFailure() external {
+        CBMulticall.Call[] memory calls = new CBMulticall.Call[](2);
+        calls[0] =
+            CBMulticall.Call({target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 0)});
+        calls[1] = CBMulticall.Call({
+            target: address(target),
+            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
+        });
+        vm.expectRevert(bytes("Multicall3: call failed"));
+        mc.tryAggregate(true, calls);
+    }
+
+    function test_tryBlockAndAggregate_noRequire_returnsBlockInfoAndResults() external {
+        CBMulticall.Call[] memory calls = new CBMulticall.Call[](2);
+        calls[0] =
+            CBMulticall.Call({target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 0)});
+        calls[1] = CBMulticall.Call({
+            target: address(target),
+            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
+        });
+
+        (uint256 bn, bytes32 bh, CBMulticall.Result[] memory res) = mc.tryBlockAndAggregate(false, calls);
+        assertEq(bn, block.number);
+        assertEq(bh, blockhash(block.number));
+        assertTrue(res[0].success);
+        assertEq(abi.decode(res[0].returnData, (uint256)), 1);
+        assertFalse(res[1].success);
+    }
+
+    function test_blockAndAggregate_allSuccess_returnsResults() external {
+        CBMulticall.Call[] memory calls = new CBMulticall.Call[](2);
+        calls[0] =
+            CBMulticall.Call({target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 1)});
+        calls[1] =
+            CBMulticall.Call({target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 2)});
+        (uint256 bn, bytes32 bh, CBMulticall.Result[] memory res) = mc.blockAndAggregate(calls);
+        // silence unused vars while still asserting one result
+        assertEq(bn, block.number);
+        assertEq(bh, blockhash(block.number));
+        assertEq(res.length, 2);
+        assertEq(abi.decode(res[1].returnData, (uint256)), 3);
+    }
+
+    function test_blockAndAggregate_revertsOnFailure() external {
+        CBMulticall.Call[] memory calls = new CBMulticall.Call[](2);
+        calls[0] =
+            CBMulticall.Call({target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 0)});
+        calls[1] = CBMulticall.Call({
+            target: address(target),
+            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
+        });
+        vm.expectRevert(bytes("Multicall3: call failed"));
+        mc.blockAndAggregate(calls);
+    }
+
+    function test_tryBlockAndAggregate_requireSuccess_revertsOnFailure() external {
+        CBMulticall.Call[] memory calls = new CBMulticall.Call[](2);
+        calls[0] =
+            CBMulticall.Call({target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 0)});
+        calls[1] = CBMulticall.Call({
+            target: address(target),
+            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
+        });
+        vm.expectRevert(bytes("Multicall3: call failed"));
+        mc.tryBlockAndAggregate(true, calls);
+    }
+
+    function test_aggregate3_success() external {
+        CBMulticall.Call3[] memory calls3 = new CBMulticall.Call3[](1);
+        calls3[0] = CBMulticall.Call3({
+            target: address(target),
+            allowFailure: false,
+            callData: abi.encodeWithSelector(MockReceiver.bump.selector, 4)
+        });
+        CBMulticall.Result[] memory ret3 = mc.aggregate3(calls3);
+        assertTrue(ret3[0].success);
+        assertEq(abi.decode(ret3[0].returnData, (uint256)), 5);
+    }
+
+    function test_aggregate3_allowedFailure_returnsFalse() external {
+        CBMulticall.Call3[] memory calls3 = new CBMulticall.Call3[](1);
+        calls3[0] = CBMulticall.Call3({
+            target: address(target),
+            allowFailure: true,
+            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
+        });
+        CBMulticall.Result[] memory ret3 = mc.aggregate3(calls3);
+        assertFalse(ret3[0].success);
+    }
+
+    function test_aggregate3_revertsOnNonAllowedFailure() external {
+        CBMulticall.Call3[] memory calls3 = new CBMulticall.Call3[](1);
+        calls3[0] = CBMulticall.Call3({
+            target: address(target),
+            allowFailure: false,
+            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
+        });
+        vm.expectRevert(bytes("Multicall3: call failed"));
+        mc.aggregate3(calls3);
+    }
+
+    function test_aggregate3Value_success_usesContractBalance() external {
+        vm.deal(address(mc), 1 ether);
+        CBMulticall.Call3Value[] memory callsV = new CBMulticall.Call3Value[](1);
+        callsV[0] = CBMulticall.Call3Value({
+            target: address(target),
+            allowFailure: false,
+            value: 0.5 ether,
+            callData: abi.encodeWithSelector(MockReceiver.payAndEcho.selector, 7)
+        });
+        CBMulticall.Result[] memory retV = mc.aggregate3Value(callsV);
+        (uint256 x, uint256 v) = abi.decode(retV[0].returnData, (uint256, uint256));
+        assertEq(x, 7);
+        assertEq(v, 0.5 ether);
+        assertEq(address(target).balance, 0.5 ether);
+    }
+
+    function test_aggregate3Value_revertsOnNonAllowedFailure() external {
+        CBMulticall.Call3Value[] memory callsV = new CBMulticall.Call3Value[](1);
+        callsV[0] = CBMulticall.Call3Value({
+            target: address(target),
+            allowFailure: false,
+            value: 0,
+            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
+        });
+        vm.expectRevert(bytes("Multicall3: call failed"));
+        mc.aggregate3Value(callsV);
+    }
+
+    function test_getBlockNumber() external view {
+        assertEq(mc.getBlockNumber(), block.number);
+    }
+
+    function test_getBlockHash() external view {
+        assertEq(mc.getBlockHash(block.number), blockhash(block.number));
+    }
+
+    function test_getCurrentBlockCoinbase() external view {
+        assertEq(mc.getCurrentBlockCoinbase(), block.coinbase);
+    }
+
+    function test_getCurrentBlockDifficulty() external view {
+        assertEq(mc.getCurrentBlockDifficulty(), block.difficulty);
+    }
+
+    function test_getCurrentBlockGasLimit() external view {
+        assertEq(mc.getCurrentBlockGasLimit(), block.gaslimit);
+    }
+
+    function test_getCurrentBlockTimestamp() external view {
+        assertEq(mc.getCurrentBlockTimestamp(), block.timestamp);
+    }
+
+    function test_getEthBalance() external view {
+        assertEq(mc.getEthBalance(address(target)), address(target).balance);
+    }
+
+    function test_getLastBlockHash() external view {
+        assertEq(mc.getLastBlockHash(), blockhash(block.number - 1));
+    }
+
+    function test_getBasefee() external view {
+        assertEq(mc.getBasefee(), block.basefee);
+    }
+
+    function test_getChainId() external view {
+        assertEq(mc.getChainId(), block.chainid);
+    }
+}

--- a/test/utils/CBMulticall.t.sol
+++ b/test/utils/CBMulticall.t.sol
@@ -94,7 +94,6 @@ contract CBMulticallTest is CommonTest {
         calls[1] =
             CBMulticall.Call({target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 2)});
         (uint256 bn, bytes32 bh, CBMulticall.Result[] memory res) = mc.blockAndAggregate(calls);
-        // silence unused vars while still asserting one result
         assertEq(bn, block.number);
         assertEq(bh, blockhash(block.number));
         assertEq(res.length, 2);


### PR DESCRIPTION
Adds the Multicall contract utilized by our eth recovery task. In the regular `Multicall3` contract, the `aggregate3Value` function has the following line:

```solidity
require(msg.value == valAccumulator, "Multicall3: value mismatch");
```

This did not allow us to delegatecall from a multisig because you cannot send a value with this call type. Since our multisig already holds ETH, removing the above `require` statement allows calling `aggregate3Value` via delegatecall.