### PR TITLE
Re-add gnosis safe owner management to IGnosisSafe

### DIFF
--- a/script/universal/IGnosisSafe.sol
+++ b/script/universal/IGnosisSafe.sol
@@ -12,25 +12,6 @@ abstract contract Enum {
 
 /// @title IGnosisSafe - Gnosis Safe Interface
 interface IGnosisSafe {
-    event AddedOwner(address owner);
-    event ApproveHash(bytes32 indexed approvedHash, address indexed owner);
-    event ChangedFallbackHandler(address handler);
-    event ChangedGuard(address guard);
-    event ChangedThreshold(uint256 threshold);
-    event DisabledModule(address module);
-    event EnabledModule(address module);
-    event ExecutionFailure(bytes32 txHash, uint256 payment);
-    event ExecutionFromModuleFailure(address indexed module);
-    event ExecutionFromModuleSuccess(address indexed module);
-    event ExecutionSuccess(bytes32 txHash, uint256 payment);
-    event RemovedOwner(address owner);
-    event SafeReceived(address indexed sender, uint256 value);
-    event SafeSetup(
-        address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler
-    );
-    event SignMsg(bytes32 indexed msgHash);
-
-    function VERSION() external view returns (string memory);
     function addOwnerWithThreshold(address owner, uint256 _threshold) external;
     function approveHash(bytes32 hashToApprove) external;
     function approvedHashes(address, bytes32) external view returns (uint256);
@@ -39,9 +20,6 @@ interface IGnosisSafe {
         external
         view;
     function checkSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures) external view;
-    function disableModule(address prevModule, address module) external;
-    function domainSeparator() external view returns (bytes32);
-    function enableModule(address module) external;
     function encodeTransactionData(
         address to,
         uint256 value,
@@ -66,41 +44,12 @@ interface IGnosisSafe {
         address refundReceiver,
         bytes memory signatures
     ) external payable returns (bool success);
-    function execTransactionFromModule(address to, uint256 value, bytes memory data, Enum.Operation operation)
-        external
-        returns (bool success);
-    function execTransactionFromModuleReturnData(address to, uint256 value, bytes memory data, Enum.Operation operation)
-        external
-        returns (bool success, bytes memory returnData);
-    function getChainId() external view returns (uint256);
-    function getModulesPaginated(address start, uint256 pageSize)
-        external
-        view
-        returns (address[] memory array, address next);
     function getOwners() external view returns (address[] memory);
-    function getStorageAt(uint256 offset, uint256 length) external view returns (bytes memory);
     function getThreshold() external view returns (uint256);
-    function getTransactionHash(
-        address to,
-        uint256 value,
-        bytes memory data,
-        Enum.Operation operation,
-        uint256 safeTxGas,
-        uint256 baseGas,
-        uint256 gasPrice,
-        address gasToken,
-        address refundReceiver,
-        uint256 _nonce
-    ) external view returns (bytes32);
     function isModuleEnabled(address module) external view returns (bool);
     function isOwner(address owner) external view returns (bool);
     function nonce() external view returns (uint256);
     function removeOwner(address prevOwner, address owner, uint256 _threshold) external;
-    function requiredTxGas(address to, uint256 value, bytes memory data, Enum.Operation operation)
-        external
-        returns (uint256);
-    function setFallbackHandler(address handler) external;
-    function setGuard(address guard) external;
     function setup(
         address[] memory _owners,
         uint256 _threshold,
@@ -111,7 +60,5 @@ interface IGnosisSafe {
         uint256 payment,
         address paymentReceiver
     ) external;
-    function signedMessages(bytes32) external view returns (uint256);
-    function simulateAndRevert(address targetContract, bytes memory calldataPayload) external;
     function swapOwner(address prevOwner, address oldOwner, address newOwner) external;
 }

--- a/script/universal/IGnosisSafe.sol
+++ b/script/universal/IGnosisSafe.sol
@@ -12,12 +12,36 @@ abstract contract Enum {
 
 /// @title IGnosisSafe - Gnosis Safe Interface
 interface IGnosisSafe {
+    event AddedOwner(address owner);
+    event ApproveHash(bytes32 indexed approvedHash, address indexed owner);
+    event ChangedFallbackHandler(address handler);
+    event ChangedGuard(address guard);
+    event ChangedThreshold(uint256 threshold);
+    event DisabledModule(address module);
+    event EnabledModule(address module);
+    event ExecutionFailure(bytes32 txHash, uint256 payment);
+    event ExecutionFromModuleFailure(address indexed module);
+    event ExecutionFromModuleSuccess(address indexed module);
+    event ExecutionSuccess(bytes32 txHash, uint256 payment);
+    event RemovedOwner(address owner);
+    event SafeReceived(address indexed sender, uint256 value);
+    event SafeSetup(
+        address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler
+    );
+    event SignMsg(bytes32 indexed msgHash);
+
+    function VERSION() external view returns (string memory);
+    function addOwnerWithThreshold(address owner, uint256 _threshold) external;
     function approveHash(bytes32 hashToApprove) external;
     function approvedHashes(address, bytes32) external view returns (uint256);
+    function changeThreshold(uint256 _threshold) external;
     function checkNSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures, uint256 requiredSignatures)
         external
         view;
     function checkSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures) external view;
+    function disableModule(address prevModule, address module) external;
+    function domainSeparator() external view returns (bytes32);
+    function enableModule(address module) external;
     function encodeTransactionData(
         address to,
         uint256 value,
@@ -42,10 +66,41 @@ interface IGnosisSafe {
         address refundReceiver,
         bytes memory signatures
     ) external payable returns (bool success);
+    function execTransactionFromModule(address to, uint256 value, bytes memory data, Enum.Operation operation)
+        external
+        returns (bool success);
+    function execTransactionFromModuleReturnData(address to, uint256 value, bytes memory data, Enum.Operation operation)
+        external
+        returns (bool success, bytes memory returnData);
+    function getChainId() external view returns (uint256);
+    function getModulesPaginated(address start, uint256 pageSize)
+        external
+        view
+        returns (address[] memory array, address next);
     function getOwners() external view returns (address[] memory);
+    function getStorageAt(uint256 offset, uint256 length) external view returns (bytes memory);
     function getThreshold() external view returns (uint256);
+    function getTransactionHash(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address refundReceiver,
+        uint256 _nonce
+    ) external view returns (bytes32);
+    function isModuleEnabled(address module) external view returns (bool);
     function isOwner(address owner) external view returns (bool);
     function nonce() external view returns (uint256);
+    function removeOwner(address prevOwner, address owner, uint256 _threshold) external;
+    function requiredTxGas(address to, uint256 value, bytes memory data, Enum.Operation operation)
+        external
+        returns (uint256);
+    function setFallbackHandler(address handler) external;
+    function setGuard(address guard) external;
     function setup(
         address[] memory _owners,
         uint256 _threshold,
@@ -56,4 +111,7 @@ interface IGnosisSafe {
         uint256 payment,
         address paymentReceiver
     ) external;
+    function signedMessages(bytes32) external view returns (uint256);
+    function simulateAndRevert(address targetContract, bytes memory calldataPayload) external;
+    function swapOwner(address prevOwner, address oldOwner, address newOwner) external;
 }


### PR DESCRIPTION
We still use the ownership management features in the contract-deployments repo. Re-adding those to the shared IGnosisSafe interface so we can use the latest commit hash of this repo.  