### PR TITLE
chore(CHAIN-2839): use CBMulticall interface in multisig tooling

### DIFF
--- a/src/utils/CBMulticall.sol
+++ b/src/utils/CBMulticall.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+import {ICBMulticall, Call, Call3, Call3Value, Result} from "./ICBMulticall.sol";
+
 /// @title CBMulticall
 ///
 /// @notice Aggregate results from multiple function calls
@@ -10,30 +12,7 @@ pragma solidity 0.8.15;
 ///      permissioned calls that require a value set. When routing a call through a multisig, for example, it's
 ///      beneficial to be able to DELEGATECALL from the multisig to this contract, thus maintaining the multisig as the
 ///      `msg.sender` while still allowing the calls to utilize ETH already held by the multisig.
-contract CBMulticall {
-    struct Call {
-        address target;
-        bytes callData;
-    }
-
-    struct Call3 {
-        address target;
-        bool allowFailure;
-        bytes callData;
-    }
-
-    struct Call3Value {
-        address target;
-        bool allowFailure;
-        uint256 value;
-        bytes callData;
-    }
-
-    struct Result {
-        bool success;
-        bytes returnData;
-    }
-
+contract CBMulticall is ICBMulticall {
     address private immutable THIS_CB_MULTICALL;
 
     error MustDelegateCall();

--- a/src/utils/ICBMulticall.sol
+++ b/src/utils/ICBMulticall.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+struct Call {
+    address target;
+    bytes callData;
+}
+
+struct Call3 {
+    address target;
+    bool allowFailure;
+    bytes callData;
+}
+
+struct Call3Value {
+    address target;
+    bool allowFailure;
+    uint256 value;
+    bytes callData;
+}
+
+struct Result {
+    bool success;
+    bytes returnData;
+}
+
+/// @title ICBMulticall
+/// @notice Interface for the CBMulticall contract used in multisig scripts.
+interface ICBMulticall {
+    /// @notice Aggregate calls, ensuring each returns success if required
+    /// @param calls An array of Call3 structs
+    /// @return returnData An array of Result structs
+    function aggregate3(Call3[] calldata calls) external payable returns (Result[] memory returnData);
+
+    /// @notice Aggregate calls, ensuring each returns success if required
+    /// @param calls An array of Call3 structs
+    /// @return returnData An array of Result structs
+    function aggregateDelegateCalls(Call3[] calldata calls) external payable returns (Result[] memory returnData);
+
+    /// @notice Aggregate calls with a msg value
+    /// @param calls An array of Call3Value structs
+    /// @return returnData An array of Result structs
+    function aggregate3Value(Call3Value[] calldata calls) external payable returns (Result[] memory returnData);
+}


### PR DESCRIPTION
This fixes the following issue: The `CBMulticall` contract expects a strict solidity pragma version of `0.8.15` while `MultisigScript` is `^0.8.15`. If a script above `0.8.15` tries to inherit `MultisigScript`, it will not compile.