### PR TITLE
Custom nitro enclave verifier contract

### DIFF
--- a/scripts/multiproof/DeployDevNoNitro.s.sol
+++ b/scripts/multiproof/DeployDevNoNitro.s.sol
@@ -199,7 +199,7 @@ contract DeployDevNoNitro is Script {
         );
         console.log("AggregateVerifier:", aggregateVerifier);
 
-        DisputeGameFactory(disputeGameFactory).setImplementation(gameType, IDisputeGame(aggregateVerifier));
+        DisputeGameFactory(disputeGameFactory).setImplementation(gameType, IDisputeGame(aggregateVerifier), "");
         DisputeGameFactory(disputeGameFactory).setInitBond(gameType, INIT_BOND);
         console.log("Registered AggregateVerifier with factory");
     }

--- a/scripts/multiproof/DeployDevWithNitro.s.sol
+++ b/scripts/multiproof/DeployDevWithNitro.s.sol
@@ -234,7 +234,7 @@ contract DeployDevWithNitro is Script {
         );
         console.log("AggregateVerifier:", aggregateVerifier);
 
-        DisputeGameFactory(disputeGameFactory).setImplementation(gameType, IDisputeGame(aggregateVerifier));
+        DisputeGameFactory(disputeGameFactory).setImplementation(gameType, IDisputeGame(aggregateVerifier), "");
         DisputeGameFactory(disputeGameFactory).setInitBond(gameType, INIT_BOND);
         console.log("Registered AggregateVerifier with factory");
     }

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -248,7 +248,7 @@
     "sourceCodeHash": "0x3a079ea52a26c8c38fb0cb3e9a9ff6ec9648cf83786b65c0fc1161e949b8f7e0"
   },
   "src/multiproof/tee/SystemConfigGlobal.sol:SystemConfigGlobal": {
-    "initCodeHash": "0x8ae045f0121d2c63ab6f0a830be842aaf0445096bfabe29d85cfd9bd38b40565",
+    "initCodeHash": "0xee219c003a6af440b447e214e43d520e802001ae3d557262a7921ca3d57ebddf",
     "sourceCodeHash": "0xe350108585e0855f10bac20d0e8894b3de9afe3be413908b4c59a1036e7a9842"
   },
   "src/multiproof/tee/SystemConfigGlobal.sol:SystemConfigGlobal:dispute": {


### PR DESCRIPTION
Adds a custom version of Automata's NitroEnclaveVerifier [contract](https://github.com/automata-network/aws-nitro-enclave-attestation/blob/main/contracts/src/NitroEnclaveVerifier.sol)

- Adds more events to allow for easier monitoring
- Gates proof verification behind a `proofSubmitter` role that is owner controlled
- Removes Pico verifier
- Removes verification with program ID