### PR TITLE
Fix function call ordering in dev deployment scripts

### DIFF
--- a/scripts/multiproof/DeployDevNoNitro.s.sol
+++ b/scripts/multiproof/DeployDevNoNitro.s.sol
@@ -118,9 +118,9 @@ contract DeployDevNoNitro is Script {
 
         vm.startBroadcast();
 
-        _registerProposer(cfg.teeProposer());
         _deployInfrastructure(gameType);
         _deployTEEContracts(cfg.finalSystemOwner());
+        _registerProposer(cfg.teeProposer());
         _deployAggregateVerifier(gameType);
 
         vm.stopBroadcast();

--- a/scripts/multiproof/DeployDevWithNitro.s.sol
+++ b/scripts/multiproof/DeployDevWithNitro.s.sol
@@ -152,9 +152,9 @@ contract DeployDevWithNitro is Script {
 
         vm.startBroadcast();
 
-        _registerProposer(cfg.teeProposer());
         _deployInfrastructure(gameType);
         _deployTEEContracts(cfg.finalSystemOwner(), cfg.nitroEnclaveVerifier());
+        _registerProposer(cfg.teeProposer());
         _deployAggregateVerifier(gameType);
 
         vm.stopBroadcast();


### PR DESCRIPTION
Both DeployDevNoNitro and DeployDevWithNitro had `_registerProposer` called before `_deployInfrastructure` and `_deployTEEContracts`, meaning it attempted to call `setProposer` on `address(0)` and would revert on every run.

Fix the ordering so infrastructure and TEE contracts are fully deployed before the proposer is registered:
```
1. _deployInfrastructure
2. _deployTEEContracts
3. _registerProposer
4. _deployAggregateVerifier
```

The bug was introduced in #201.