### PR TITLE
fix: change storage to memory in Drippie.executable() view functiont.

### DIFF
--- a/src/periphery/drippie/Drippie.sol
+++ b/src/periphery/drippie/Drippie.sol
@@ -171,7 +171,7 @@ contract Drippie is AssetReceiver {
     /// @param _name Drip to check.
     /// @return True if the drip is executable, reverts otherwise.
     function executable(string calldata _name) public view returns (bool) {
-        DripState storage state = drips[_name];
+        DripState memory state = drips[_name];
 
         // Only allow active drips to be executed, an obvious security measure.
         require(state.status == DripStatus.ACTIVE, "Drippie: selected drip does not exist or is not currently active");


### PR DESCRIPTION
## Problem
The `executable()` function in [Drippie.sol](cci:7://file:///src/periphery/drippie/Drippie.sol:0:0-0:0) was incorrectly using `storage` instead of `memory` for a local state variable, despite being marked as a `view` function.

## Impact
- Violated the view function contract by implying storage modification
- Could cause compilation issues
- Inefficient gas usage due to incorrect memory handling

## Solution
Changed `DripState storage state` to `DripState memory state` on line 174 in the `executable()` function.