### PR TITLE
docs: add predeploy contract addresses to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ If CI still rejects it (Foundry version mismatch), update your local Foundry fir
 foundryup
 just semver-lock
 ```
+## Contract Addresses
 
+| Contract | Network | Address |
+|----------|---------|---------|
+| BaseFeeVault | Base Mainnet | `0x4200000000000000000000000000000000000019` |
+| L1FeeVault | Base Mainnet | `0x420000000000000000000000000000000000001a` |
+| SequencerFeeVault | Base Mainnet | `0x4200000000000000000000000000000000000011` |
 ### setup and testing
 
 - If you don't have foundry installed, run `make install-foundry`.


### PR DESCRIPTION
## Summary

Added a Contract Addresses section to the README with Base Mainnet 
predeploy addresses for BaseFeeVault, L1FeeVault, and SequencerFeeVault.

This makes it easier for developers to quickly find the deployed 
contract addresses without having to search through the codebase.