### PR TITLE
fix: change storage to memory in Drippie.executable() view function

### DIFF
--- a/src/periphery/drippie/Drippie.sol
+++ b/src/periphery/drippie/Drippie.sol
@@ -171,7 +171,7 @@ contract Drippie is AssetReceiver {
     /// @param _name Drip to check.
     /// @return True if the drip is executable, reverts otherwise.
     function executable(string calldata _name) public view returns (bool) {
-        DripState storage state = drips[_name];
+        DripState memory state = drips[_name];
 
         // Only allow active drips to be executed, an obvious security measure.
         require(state.status == DripStatus.ACTIVE, "Drippie: selected drip does not exist or is not currently active");


### PR DESCRIPTION
Drippie.executable() is a view function but the DripAction return value is declared as storage. Since this function never writes to state memory is the correct location here. Storage in a view function is misleading and costs unnecessary gas.