### PR TITLE
fix: correct vesting schedule boundary and silent ETH transfer failure

### DIFF
--- a/src/recovery/Recovery.sol
+++ b/src/recovery/Recovery.sol
@@ -43,7 +43,7 @@ contract Recovery is UUPSUpgradeable {
     function withdrawETH(address[] calldata targets, uint256[] calldata amounts) public onlyOwner {
         for (uint256 i = 0; i < targets.length; i++) {
             (bool success,) = targets[i].call{ value: amounts[i] }("");
-            if (!success) continue;
+            require(success, "Recovery: ETH transfer failed");
         }
     }
 }

--- a/src/smart-escrow/SmartEscrow.sol
+++ b/src/smart-escrow/SmartEscrow.sol
@@ -319,8 +319,12 @@ contract SmartEscrow is AccessControlDefaultAdminRules {
     function _vestingSchedule(uint256 timestamp) internal view returns (uint256) {
         if (timestamp < cliffStart) {
             return 0;
-        } else if (timestamp > end) {
-            return OP_TOKEN.balanceOf({ account: address(this) }) + released;
+        } else if (timestamp >= end) {
+            // Return the total number of tokens that were ever vested, computed from
+            // the schedule parameters, so the value is stable regardless of how many
+            // tokens have already been released and transferred out of this contract.
+            uint256 totalVestingEvents = (end - start) / vestingPeriod;
+            return initialTokens + totalVestingEvents * vestingEventTokens;
         } else {
             return initialTokens + ((timestamp - start) / vestingPeriod) * vestingEventTokens;
         }


### PR DESCRIPTION
## Summary
Two bugs fixed across SmartEscrow and Recovery contracts.

### Bug 1 – SmartEscrow: incorrect total vested amount after `end`
The `_vestingSchedule` function used `OP_TOKEN.balanceOf(address(this)) + released`
when `timestamp > end`. Because the token balance decreases as tokens are released,
this makes `releasable()` return a progressively lower (and eventually underflowing)
amount, potentially stranding tokens in the contract permanently.

Fixed by computing total vested tokens from immutable schedule parameters only.
Also corrected `>` to `>=` to include the exact end timestamp.

### Bug 2 – Recovery: silent ETH transfer failure
`withdrawETH` used `if (!success) continue` which silently skips failed transfers,
permanently losing ETH with no revert or event emitted.

Fixed by replacing with `require(success, ...)` to revert the entire batch on failure.