### PR TITLE
Add game seeding scripts for multiproof testing

### DIFF
--- a/scripts/multiproof/README.md
+++ b/scripts/multiproof/README.md
@@ -121,3 +121,84 @@ The deployer address (`finalSystemOwner`) is the owner of `DevTEEProverRegistry`
 ## Path 2: WithNitro (Dev — Real Attestation)
 
 > **TODO:** Add deployment and registration guide for `DeployDevWithNitro.s.sol`.
+
+---
+
+## Pre-Seeding Games (Post-Deployment)
+
+After deploying via either path, you can pre-seed the `DisputeGameFactory` with a chain of `AggregateVerifier` games. This is useful for testing forward traversal at proposer restart — the proposer can walk the linked list of games to find where to resume.
+
+Games are created using `ProofType.ZK` with the `MockVerifier` (deployed by both WithNitro and NoNitro), which auto-accepts any proof. The output roots themselves are real values fetched from an L2 archive node.
+
+### Step 1: Set the anchor state
+
+Pick an anchor block far enough behind the L2 tip to cover all the games you want to create. Each game covers `BLOCK_INTERVAL` (600) L2 blocks, so for 500 games you need 300,000 blocks of headroom.
+
+```bash
+# Calculate an anchor block 300,000 blocks behind the L2 tip
+ANCHOR_BLOCK=$(( $(cast block-number --rpc-url $L2_RPC_URL) - 300000 ))
+
+# Get the real output root at that block
+OUTPUT_ROOT=$(cast rpc optimism_outputAtBlock $(printf "0x%x" $ANCHOR_BLOCK) \
+  --rpc-url $L2_RPC_URL | jq -r '.outputRoot')
+
+# Set it on the MockAnchorStateRegistry (no access control — any caller works)
+cast send $ANCHOR_STATE_REGISTRY_ADDRESS \
+  "setAnchorState(bytes32,uint256)" $OUTPUT_ROOT $ANCHOR_BLOCK \
+  --rpc-url $L1_RPC_URL --private-key $PRIVATE_KEY
+```
+
+### Step 2: Generate real output roots
+
+Fetch the real L2 output roots for every intermediate block across all games. This queries `optimism_outputAtBlock` on the L2 archive node (10,000 queries for 500 games, parallelized).
+
+```bash
+./scripts/multiproof/generate-roots.sh $ANCHOR_BLOCK $L2_RPC_URL 500
+```
+
+Arguments: `<anchor_block> <l2_rpc_url> [game_count] [parallelism] [output_file]`
+
+Defaults: `game_count=500`, `parallelism=20`, `output_file=roots.json`.
+
+### Step 3: Move roots file for Foundry access
+
+Foundry's filesystem sandbox only allows reads from paths listed in `foundry.toml` `fs_permissions`. The `deployments/` directory already has read-write access, so move the file there:
+
+```bash
+mv roots.json deployments/roots.json
+```
+
+### Step 4: Run the seeding script
+
+Create all games on-chain. Each game is chained to the previous one (game 0's parent is the `AnchorStateRegistry`, game N's parent is game N-1). The account running this needs enough ETH for bonds and gas (500 games at 0.00001 ETH bond = 0.005 ETH + gas).
+
+```bash
+ROOTS_FILE=./deployments/roots.json \
+FACTORY_ADDRESS=$FACTORY_ADDRESS \
+ANCHOR_STATE_REGISTRY_ADDRESS=$ANCHOR_STATE_REGISTRY_ADDRESS \
+forge script scripts/multiproof/SeedGames.s.sol \
+  --rpc-url $L1_RPC_URL --broadcast --private-key $PRIVATE_KEY
+```
+
+> **Note:** Use `--private-key` instead of `--ledger` to avoid manually confirming 500 transactions on a hardware wallet.
+
+Optional env vars:
+
+| Variable | Default | Description |
+|---|---|---|
+| `GAME_COUNT` | 500 | Number of games to create |
+| `ROOTS_FILE` | `roots.json` | Path to the output roots JSON |
+
+### Step 5: Verify on-chain
+
+```bash
+# Check total game count
+cast call $FACTORY_ADDRESS "gameCount()(uint256)" --rpc-url $L1_RPC_URL
+
+# Check first game's parent is the AnchorStateRegistry
+FIRST_GAME=$(cast call $FACTORY_ADDRESS \
+  "gameAtIndex(uint256)(uint32,uint64,address)" 0 --rpc-url $L1_RPC_URL | tail -1)
+cast call $FIRST_GAME "parentAddress()(address)" --rpc-url $L1_RPC_URL
+```
+
+Output metadata is saved to `deployments/<chainId>-seeded-games.json`.

--- a/scripts/multiproof/SeedGames.s.sol
+++ b/scripts/multiproof/SeedGames.s.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+/**
+ * @title SeedGames
+ * @notice Seeds the DisputeGameFactory with chained AggregateVerifier games using real L2 output roots.
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════
+ *                        POST-DEPLOYMENT GAME SEEDING
+ * ══════════════════════════════════════════════════════════════════════════════════
+ *
+ * Creates a chain of AggregateVerifier (multiproof) games via the DisputeGameFactory
+ * deployed by DeployDevWithNitro (or DeployDevNoNitro). Each game's parent is the
+ * previous game, forming a linked list suitable for testing forward traversal at
+ * proposer restart.
+ *
+ * Games use ProofType.ZK (value 1) because both deployment scripts wire up a
+ * MockVerifier for ZK that auto-accepts any proof — no real ZK proof needed.
+ * Output roots, however, are real values fetched from an L2 archive node.
+ *
+ * PREREQUISITES:
+ *   1. Deploy the multiproof stack via DeployDevWithNitro.s.sol (or DeployDevNoNitro.s.sol).
+ *   2. Set the anchor state on MockAnchorStateRegistry to a recent block (see README.md).
+ *   3. Generate real output roots using generate-roots.sh:
+ *
+ *        ./scripts/multiproof/generate-roots.sh <anchor_block> <l2_rpc_url> [game_count]
+ *
+ * USAGE:
+ *   FACTORY_ADDRESS=0x... \
+ *   ANCHOR_STATE_REGISTRY_ADDRESS=0x... \
+ *   forge script scripts/multiproof/SeedGames.s.sol \
+ *     --rpc-url $RPC_URL --broadcast --private-key $PRIVATE_KEY
+ *
+ * OPTIONAL ENV VARS:
+ *   GAME_COUNT    Number of games to create (default: 500)
+ *   ROOTS_FILE    Path to the roots JSON from generate-roots.sh (default: roots.json)
+ *
+ * NOTE: All transactions must confirm within the 256-block blockhash window
+ * (~51 min on mainnet/Sepolia) of the L1 origin block captured at simulation time.
+ * For large game counts, consider using --slow or splitting into batches.
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════
+ */
+
+import { Script } from "forge-std/Script.sol";
+import { console2 as console } from "forge-std/console2.sol";
+
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+import { Claim, GameType, Hash } from "src/dispute/lib/Types.sol";
+
+import { MockAnchorStateRegistry } from "./mocks/MockAnchorStateRegistry.sol";
+
+contract SeedGames is Script {
+    /// @notice Must match the AggregateVerifier deployment constants from DeployDevWithNitro/NoNitro.
+    uint256 public constant BLOCK_INTERVAL = 600;
+    uint256 public constant INTERMEDIATE_BLOCK_INTERVAL = 30;
+    uint256 public constant INTERMEDIATE_ROOTS_COUNT = BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL;
+    uint32 public constant GAME_TYPE_ID = 621;
+
+    /// @dev Stored as state to avoid stack-too-deep in run().
+    IDisputeGameFactory internal factory;
+    GameType internal gameType;
+    uint256 internal initBond;
+    uint256 internal anchorBlock;
+    bytes32 internal l1OriginHash;
+    uint256 internal l1OriginNumber;
+    bytes32[] internal allRoots;
+
+    function run() external {
+        // ── Configuration ──────────────────────────────────────────────
+        address factoryAddr = vm.envAddress("FACTORY_ADDRESS");
+        address asrAddr = vm.envAddress("ANCHOR_STATE_REGISTRY_ADDRESS");
+        uint256 gameCount = vm.envOr("GAME_COUNT", uint256(500));
+        string memory rootsPath = vm.envOr("ROOTS_FILE", string("roots.json"));
+
+        factory = IDisputeGameFactory(factoryAddr);
+        gameType = GameType.wrap(GAME_TYPE_ID);
+        initBond = factory.initBonds(gameType);
+
+        (, anchorBlock) = MockAnchorStateRegistry(asrAddr).getAnchorRoot();
+
+        // L1 origin — must remain within the blockhash window when txns execute on-chain
+        l1OriginHash = blockhash(block.number - 1);
+        l1OriginNumber = block.number - 1;
+
+        // ── Load real output roots ─────────────────────────────────────
+        string memory rootsJson = vm.readFile(rootsPath);
+        allRoots = abi.decode(vm.parseJson(rootsJson, ".roots"), (bytes32[]));
+
+        uint256 expectedRoots = gameCount * INTERMEDIATE_ROOTS_COUNT;
+        require(
+            allRoots.length == expectedRoots,
+            string.concat(
+                "Root count mismatch: got ",
+                vm.toString(allRoots.length),
+                ", expected ",
+                vm.toString(expectedRoots),
+                ". Re-run generate-roots.sh with matching game count."
+            )
+        );
+
+        // ── Summary ────────────────────────────────────────────────────
+        console.log("=== Seeding Multiproof Games ===");
+        console.log("Factory:", factoryAddr);
+        console.log("AnchorStateRegistry:", asrAddr);
+        console.log("Roots file:", rootsPath);
+        console.log("Game count:", gameCount);
+        console.log("Game type:", uint256(GAME_TYPE_ID));
+        console.log("Init bond per game:", initBond);
+        console.log("Anchor block:", anchorBlock);
+        console.log("Total ETH required:", initBond * gameCount);
+
+        // ── Create chained games ───────────────────────────────────────
+        vm.startBroadcast();
+
+        (address firstGame, address lastGame) = _createGames(asrAddr, gameCount);
+
+        vm.stopBroadcast();
+
+        // ── Output ─────────────────────────────────────────────────────
+        uint256 l2Start = anchorBlock + BLOCK_INTERVAL;
+        uint256 l2End = anchorBlock + BLOCK_INTERVAL * gameCount;
+
+        console.log("");
+        console.log("=== Seeding Complete ===");
+        console.log("Games created:", gameCount);
+        console.log("First game:", firstGame);
+        console.log("Last game:", lastGame);
+        console.log("L2 block range start:", l2Start);
+        console.log("L2 block range end:", l2End);
+
+        _writeOutput(firstGame, lastGame, gameCount, l2Start, l2End);
+    }
+
+    /// @notice Creates `count` chained games, each parented to the previous one.
+    /// @param asrAddr The AnchorStateRegistry address (parent of the first game).
+    /// @param count The number of games to create.
+    /// @return firstGame The address of the first game created.
+    /// @return lastGame The address of the last game created.
+    function _createGames(address asrAddr, uint256 count) internal returns (address firstGame, address lastGame) {
+        address parentAddr = asrAddr;
+
+        for (uint256 i = 0; i < count; i++) {
+            address game = _createSingleGame(i, parentAddr);
+
+            if (i == 0) firstGame = game;
+            parentAddr = game;
+
+            if ((i + 1) % 100 == 0) {
+                console.log("  Created games:", i + 1);
+            }
+        }
+
+        lastGame = parentAddr;
+    }
+
+    /// @notice Creates a single game at the given index in the chain.
+    /// @param index The zero-based index of this game in the chain.
+    /// @param parentAddr The parent game address (or ASR address for the first game).
+    /// @return game The address of the newly created game.
+    function _createSingleGame(uint256 index, address parentAddr) internal returns (address game) {
+        uint256 l2Block = anchorBlock + BLOCK_INTERVAL * (index + 1);
+
+        // Slice this game's intermediate roots from the flat array
+        uint256 rootsOffset = index * INTERMEDIATE_ROOTS_COUNT;
+        bytes32 rootClaimHash = allRoots[rootsOffset + INTERMEDIATE_ROOTS_COUNT - 1];
+
+        bytes memory intermediateRoots = _sliceRoots(rootsOffset);
+        bytes memory extraData = abi.encodePacked(l2Block, parentAddr, intermediateRoots);
+
+        // ZK proof — MockVerifier auto-accepts any input
+        bytes memory proof = abi.encodePacked(
+            uint8(1), // ProofType.ZK
+            l1OriginHash,
+            l1OriginNumber,
+            bytes32(0) // dummy proof payload
+        );
+
+        IDisputeGame created =
+            factory.createWithInitData{ value: initBond }(gameType, Claim.wrap(rootClaimHash), extraData, proof);
+
+        return address(created);
+    }
+
+    /// @notice Packs INTERMEDIATE_ROOTS_COUNT roots from allRoots starting at offset.
+    /// @param offset The starting index in allRoots.
+    /// @return roots The abi.encodePacked intermediate roots.
+    function _sliceRoots(uint256 offset) internal view returns (bytes memory roots) {
+        for (uint256 j = 0; j < INTERMEDIATE_ROOTS_COUNT; j++) {
+            roots = abi.encodePacked(roots, allRoots[offset + j]);
+        }
+    }
+
+    /// @notice Writes seeding metadata to a JSON file.
+    function _writeOutput(
+        address firstGame,
+        address lastGame,
+        uint256 gameCount,
+        uint256 l2Start,
+        uint256 l2End
+    )
+        internal
+    {
+        string memory key = "seeding";
+        vm.serializeAddress(key, "firstGame", firstGame);
+        vm.serializeAddress(key, "lastGame", lastGame);
+        vm.serializeUint(key, "gameCount", gameCount);
+        vm.serializeUint(key, "l2BlockStart", l2Start);
+        string memory json = vm.serializeUint(key, "l2BlockEnd", l2End);
+
+        string memory outPath = string.concat("deployments/", vm.toString(block.chainid), "-seeded-games.json");
+        vm.writeJson(json, outPath);
+        console.log("Output saved to:", outPath);
+    }
+}

--- a/scripts/multiproof/SeedGames.s.sol
+++ b/scripts/multiproof/SeedGames.s.sol
@@ -68,7 +68,8 @@ contract SeedGames is Script {
     bytes32[] internal allRoots;
 
     function run() external {
-        // ── Configuration ──────────────────────────────────────────────
+        // ── Configuration
+        // ──────────────────────────────────────────────
         address factoryAddr = vm.envAddress("FACTORY_ADDRESS");
         address asrAddr = vm.envAddress("ANCHOR_STATE_REGISTRY_ADDRESS");
         uint256 gameCount = vm.envOr("GAME_COUNT", uint256(500));
@@ -84,7 +85,8 @@ contract SeedGames is Script {
         l1OriginHash = blockhash(block.number - 1);
         l1OriginNumber = block.number - 1;
 
-        // ── Load real output roots ─────────────────────────────────────
+        // ── Load real output roots
+        // ─────────────────────────────────────
         string memory rootsJson = vm.readFile(rootsPath);
         allRoots = abi.decode(vm.parseJson(rootsJson, ".roots"), (bytes32[]));
 
@@ -100,7 +102,8 @@ contract SeedGames is Script {
             )
         );
 
-        // ── Summary ────────────────────────────────────────────────────
+        // ── Summary
+        // ────────────────────────────────────────────────────
         console.log("=== Seeding Multiproof Games ===");
         console.log("Factory:", factoryAddr);
         console.log("AnchorStateRegistry:", asrAddr);
@@ -111,14 +114,16 @@ contract SeedGames is Script {
         console.log("Anchor block:", anchorBlock);
         console.log("Total ETH required:", initBond * gameCount);
 
-        // ── Create chained games ───────────────────────────────────────
+        // ── Create chained games
+        // ───────────────────────────────────────
         vm.startBroadcast();
 
         (address firstGame, address lastGame) = _createGames(asrAddr, gameCount);
 
         vm.stopBroadcast();
 
-        // ── Output ─────────────────────────────────────────────────────
+        // ── Output
+        // ─────────────────────────────────────────────────────
         uint256 l2Start = anchorBlock + BLOCK_INTERVAL;
         uint256 l2End = anchorBlock + BLOCK_INTERVAL * gameCount;
 

--- a/scripts/multiproof/generate-roots.sh
+++ b/scripts/multiproof/generate-roots.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ══════════════════════════════════════════════════════════════════════════════
+# generate-roots.sh
+#
+# Fetches real L2 output roots from an archive node for use with SeedGames.s.sol.
+# Queries optimism_outputAtBlock for every intermediate block across all games.
+#
+# USAGE:
+#   ./scripts/multiproof/generate-roots.sh <anchor_block> <l2_rpc_url> [game_count] [parallelism] [output_file]
+#
+# EXAMPLE:
+#   ./scripts/multiproof/generate-roots.sh 37223829 https://my-l2-archive:7545 500 20 roots.json
+#
+# PREREQUISITES:
+#   - cast (from Foundry toolchain)
+#   - jq
+#   - L2 archive node with optimism_outputAtBlock RPC method
+#
+# OUTPUT:
+#   JSON file: {"roots": ["0x...", "0x...", ...]}
+#   Flat array of bytes32 output roots, ordered by game index then intermediate root index.
+#   For game i, roots are at indices [i*ROOTS_PER_GAME, (i+1)*ROOTS_PER_GAME).
+#   The last root for each game is the root claim.
+# ══════════════════════════════════════════════════════════════════════════════
+
+ANCHOR_BLOCK="${1:?Usage: $0 <anchor_block> <l2_rpc_url> [game_count] [parallelism] [output_file]}"
+L2_RPC_URL="${2:?Usage: $0 <anchor_block> <l2_rpc_url> [game_count] [parallelism] [output_file]}"
+GAME_COUNT="${3:-500}"
+PARALLELISM="${4:-20}"
+OUTPUT_FILE="${5:-roots.json}"
+
+# Must match AggregateVerifier / SeedGames constants
+BLOCK_INTERVAL=600
+INTERMEDIATE_BLOCK_INTERVAL=30
+ROOTS_PER_GAME=$((BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL))
+TOTAL_ROOTS=$((GAME_COUNT * ROOTS_PER_GAME))
+
+LAST_BLOCK=$((ANCHOR_BLOCK + GAME_COUNT * BLOCK_INTERVAL))
+
+echo "=== Generating Output Roots ==="
+echo "Anchor block:     $ANCHOR_BLOCK"
+echo "Game count:       $GAME_COUNT"
+echo "Roots per game:   $ROOTS_PER_GAME"
+echo "Total roots:      $TOTAL_ROOTS"
+echo "L2 block range:   [$((ANCHOR_BLOCK + INTERMEDIATE_BLOCK_INTERVAL)), $LAST_BLOCK]"
+echo "Parallelism:      $PARALLELISM"
+echo "Output file:      $OUTPUT_FILE"
+echo ""
+
+# Verify tools are available
+command -v cast >/dev/null 2>&1 || { echo "ERROR: cast not found. Install Foundry first." >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq not found." >&2; exit 1; }
+
+# Quick sanity check: verify the RPC is reachable and the anchor block exists
+echo "Verifying RPC connectivity..."
+TEST_HEX=$(printf "0x%x" "$ANCHOR_BLOCK")
+TEST_RESULT=$(cast rpc optimism_outputAtBlock "$TEST_HEX" --rpc-url "$L2_RPC_URL" 2>&1) || {
+    echo "ERROR: Failed to query optimism_outputAtBlock for anchor block $ANCHOR_BLOCK" >&2
+    echo "       RPC: $L2_RPC_URL" >&2
+    echo "       Response: $TEST_RESULT" >&2
+    exit 1
+}
+echo "RPC OK."
+echo ""
+
+# Create temp directory for individual root files
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Fetch roots in batches of PARALLELISM
+echo "Fetching roots..."
+for ((batch_start=0; batch_start<TOTAL_ROOTS; batch_start+=PARALLELISM)); do
+    batch_end=$((batch_start + PARALLELISM))
+    if [ "$batch_end" -gt "$TOTAL_ROOTS" ]; then
+        batch_end=$TOTAL_ROOTS
+    fi
+
+    for ((i=batch_start; i<batch_end; i++)); do
+        game=$((i / ROOTS_PER_GAME))
+        j=$(( (i % ROOTS_PER_GAME) + 1 ))
+        block=$((ANCHOR_BLOCK + game * BLOCK_INTERVAL + j * INTERMEDIATE_BLOCK_INTERVAL))
+
+        (
+            hex_block=$(printf "0x%x" "$block")
+            root=$(cast rpc optimism_outputAtBlock "$hex_block" --rpc-url "$L2_RPC_URL" | jq -r '.outputRoot')
+
+            if [ -z "$root" ] || [ "$root" = "null" ]; then
+                echo "ERROR: Failed to fetch root for block $block (index $i)" >&2
+                exit 1
+            fi
+
+            echo "$root" > "$TMPDIR/$i"
+        ) &
+    done
+
+    wait
+
+    # Progress reporting every 200 roots
+    if (( batch_end % 200 == 0 )) || [ "$batch_end" -eq "$TOTAL_ROOTS" ]; then
+        echo "  Fetched $batch_end / $TOTAL_ROOTS roots"
+    fi
+done
+
+# Verify all roots were fetched
+echo ""
+echo "Verifying completeness..."
+MISSING=0
+for ((i=0; i<TOTAL_ROOTS; i++)); do
+    if [ ! -f "$TMPDIR/$i" ]; then
+        echo "  MISSING root at index $i" >&2
+        MISSING=$((MISSING + 1))
+    fi
+done
+
+if [ "$MISSING" -gt 0 ]; then
+    echo "ERROR: $MISSING roots missing. Aborting." >&2
+    exit 1
+fi
+
+# Assemble JSON
+echo "Assembling JSON..."
+{
+    echo -n '{"roots":['
+    for ((i=0; i<TOTAL_ROOTS; i++)); do
+        if [ "$i" -gt 0 ]; then echo -n ','; fi
+        echo -n "\"$(cat "$TMPDIR/$i")\""
+    done
+    echo ']}'
+} > "$OUTPUT_FILE"
+
+echo ""
+echo "=== Done ==="
+echo "Saved $TOTAL_ROOTS roots to $OUTPUT_FILE"
+echo ""
+echo "Next step: run SeedGames.s.sol with ROOTS_FILE=$OUTPUT_FILE"


### PR DESCRIPTION
## Summary
- Adds `SeedGames.s.sol` Foundry script that pre-populates the `DisputeGameFactory` with chained `AggregateVerifier` games using real L2 output roots
- Adds `generate-roots.sh` bash script that fetches real output roots from an L2 archive node via `optimism_outputAtBlock`
- Updates `scripts/multiproof/README.md` with a 5-step guide for the full seeding workflow

These scripts are useful for testing forward traversal at proposer restart — the proposer can walk the linked list of games to find where to resume. Games use `ProofType.ZK` with the `MockVerifier` (which auto-accepts), while the output roots are real values from the L2 chain.