### PR TITLE
Multiproof audit 2 fixes

### DIFF
--- a/interfaces/multiproof/tee/INitroEnclaveVerifier.sol
+++ b/interfaces/multiproof/tee/INitroEnclaveVerifier.sol
@@ -24,9 +24,6 @@ enum ZkCoProcessorType {
 /**
  * @dev Configuration parameters for a specific zero-knowledge coprocessor
  * Contains all necessary identifiers and addresses for ZK proof verification
- *
- * Note: This struct stores the "latest" (active) program identifiers.
- * Multiple versions can be supported simultaneously via the version management functions.
  */
 struct ZkCoProcessorConfig {
     // Latest program ID for single attestation verification
@@ -138,7 +135,6 @@ enum VerificationResult {
  * Key features:
  * - Single and batch attestation verification
  * - Support for multiple ZK proving systems
- * - Multi-version program support for seamless upgrades
  * - Route-based verifier configuration
  * - Certificate chain management and revocation
  * - Timestamp validation with configurable tolerance

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -233,7 +233,7 @@
   },
   "src/multiproof/AggregateVerifier.sol:AggregateVerifier": {
     "initCodeHash": "0x54168f8e087c104e6bcc532d2d323327205a14b4ad3597d14d6cadcc1924543b",
-    "sourceCodeHash": "0xeb00a1de85c18b4b8c3928b8f8b6c635effd07ccbd32fac8d58ef3022e98429b"
+    "sourceCodeHash": "0x36342bdca5dd7c41f408216377b4b0e1a6d076df6396c77a6350d5d67e499ebe"
   },
   "src/multiproof/tee/NitroEnclaveVerifier.sol:NitroEnclaveVerifier": {
     "initCodeHash": "0x100364f9b0c63a61538386ba91e73dcffba22d3f6dfe8efdbbf5ff347b6fce47",

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -233,7 +233,7 @@
   },
   "src/multiproof/AggregateVerifier.sol:AggregateVerifier": {
     "initCodeHash": "0x54168f8e087c104e6bcc532d2d323327205a14b4ad3597d14d6cadcc1924543b",
-    "sourceCodeHash": "0x21b65f0471af2a1da4c8812088d4056768c13e3634e2d68192ffe5c226b1fe74"
+    "sourceCodeHash": "0xeb00a1de85c18b4b8c3928b8f8b6c635effd07ccbd32fac8d58ef3022e98429b"
   },
   "src/multiproof/tee/NitroEnclaveVerifier.sol:NitroEnclaveVerifier": {
     "initCodeHash": "0x100364f9b0c63a61538386ba91e73dcffba22d3f6dfe8efdbbf5ff347b6fce47",

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -236,8 +236,8 @@
     "sourceCodeHash": "0x21b65f0471af2a1da4c8812088d4056768c13e3634e2d68192ffe5c226b1fe74"
   },
   "src/multiproof/tee/NitroEnclaveVerifier.sol:NitroEnclaveVerifier": {
-    "initCodeHash": "0x4210e4b415f18d50ec4b2d76f216af08f5943cf9a930262a8189c32e3b9ea49c",
-    "sourceCodeHash": "0x9f9ac5cdff6e537cf1ac70700e060a4c984c17aa3bd50e2f44cee4448dda1a88"
+    "initCodeHash": "0x100364f9b0c63a61538386ba91e73dcffba22d3f6dfe8efdbbf5ff347b6fce47",
+    "sourceCodeHash": "0xed5d92ee1f32f2fde5e89ba278f3142c8113c774f6ce7bd831781a8abe7bddf3"
   },
   "src/multiproof/tee/TEEProverRegistry.sol:TEEProverRegistry": {
     "initCodeHash": "0xfd1942e1c2f59b0aa72b33d698a948a53b6e4cf1040106f173fb5d89f63f57b0",

--- a/src/multiproof/AggregateVerifier.sol
+++ b/src/multiproof/AggregateVerifier.sol
@@ -319,12 +319,12 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
         //
         // Expected length: 0x8E + 0x20 * intermediateOutputRootsCount()
         // - 0x04 selector
-        // - 0x14 creator address
-        // - 0x20 root claim
-        // - 0x20 l1 head
-        // - 0x20 extraData (l2BlockNumber)
-        // - 0x14 extraData (parent game address)
-        // - 0x20 x (BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL) extraData (intermediate roots)
+        // - 0x14 creator address (CWIA data offset: 0x00)
+        // - 0x20 root claim (CWIA data offset: 0x14)
+        // - 0x20 l1 head (CWIA data offset: 0x34)
+        // - 0x20 extraData (l2BlockNumber) (CWIA data offset: 0x54)
+        // - 0x14 extraData (parent game address) (CWIA data offset: 0x74)
+        // - 0x20 x (BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL) extraData (intermediate roots) (CWIA data offset: 0x88)
         // - 0x02 CWIA bytes
 
         // - 0x20 proof length location

--- a/src/multiproof/AggregateVerifier.sol
+++ b/src/multiproof/AggregateVerifier.sol
@@ -324,7 +324,8 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
         // - 0x20 l1 head (CWIA data offset: 0x34)
         // - 0x20 extraData (l2BlockNumber) (CWIA data offset: 0x54)
         // - 0x14 extraData (parent game address) (CWIA data offset: 0x74)
-        // - 0x20 x (BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL) extraData (intermediate roots) (CWIA data offset: 0x88)
+        // - 0x20 x (BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL) extraData (intermediate roots) (CWIA data offset:
+        //   0x88)
         // - 0x02 CWIA bytes
 
         // - 0x20 proof length location

--- a/src/multiproof/tee/NitroEnclaveVerifier.sol
+++ b/src/multiproof/tee/NitroEnclaveVerifier.sol
@@ -341,6 +341,8 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
      *
      * This function allows the owner or revoker to revoke compromised intermediate certificates
      * without affecting the root certificate or other trusted certificates.
+     *
+     * Note: A revoked cert can be trusted again by reproving it.
      */
     function revokeCert(bytes32 certHash) external onlyOwnerOrRevoker {
         if (trustedIntermediateCerts[certHash] == 0) {

--- a/src/multiproof/tee/NitroEnclaveVerifier.sol
+++ b/src/multiproof/tee/NitroEnclaveVerifier.sol
@@ -619,6 +619,14 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
                 return journal;
             }
         }
+        // Check any remaining certificates in the chain that are not yet trusted
+        for (uint256 i = journal.trustedCertsPrefixLen; i < journal.certs.length; i++) {
+            uint64 expiry = journal.certExpiries[i];
+            if (block.timestamp > expiry) {
+                journal.result = VerificationResult.InvalidTimestamp;
+                return journal;
+            }
+        }
         uint64 timestamp = journal.timestamp / 1000;
         if (timestamp + maxTimeDiff <= block.timestamp || timestamp >= block.timestamp) {
             journal.result = VerificationResult.InvalidTimestamp;

--- a/src/multiproof/tee/NitroEnclaveVerifier.sol
+++ b/src/multiproof/tee/NitroEnclaveVerifier.sol
@@ -319,9 +319,6 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
      * - verifierId: Program ID for single attestation verification
      * - aggregatorId: Program ID for batch/aggregated verification
      * - zkVerifier: Address of the deployed ZK verifier contract
-     *
-     * Note: Program IDs are automatically added to the supported version sets
-     * The verifierProofId is stored in a separate mapping (verifierId => verifierProofId)
      */
     function setZkConfiguration(
         ZkCoProcessorType zkCoProcessor,

--- a/test/multiproof/NitroEnclaveVerifier.t.sol
+++ b/test/multiproof/NitroEnclaveVerifier.t.sol
@@ -862,6 +862,38 @@ contract NitroEnclaveVerifierTest is Test {
         assertEq(uint8(result.result), uint8(VerificationResult.Success));
     }
 
+    // Untrusted chain certs (past trustedCertsPrefixLen): expired journal notAfter => InvalidTimestamp
+    function testVerifyJournalInvalidTimestampExpiredUntrustedCertInChain() public {
+        _setUpRiscZeroConfig();
+
+        bytes32 expiredLeaf = keccak256("expired-untrusted-leaf");
+
+        VerifierJournal memory journal = _createSuccessJournal();
+        bytes32[] memory certs = new bytes32[](3);
+        certs[0] = ROOT_CERT;
+        certs[1] = INTERMEDIATE_CERT_1;
+        certs[2] = expiredLeaf;
+        journal.certs = certs;
+
+        uint64[] memory expiries = new uint64[](3);
+        expiries[0] = INTERMEDIATE_CERT_1_EXPIRY + 100_000_000;
+        expiries[1] = INTERMEDIATE_CERT_1_EXPIRY;
+        expiries[2] = uint64(block.timestamp - 1);
+        journal.certExpiries = expiries;
+        journal.trustedCertsPrefixLen = 2;
+
+        bytes memory output = abi.encode(journal);
+        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+
+        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
+
+        vm.prank(submitter);
+        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
+
+        assertEq(uint8(result.result), uint8(VerificationResult.InvalidTimestamp));
+        assertEq(verifier.trustedIntermediateCerts(expiredLeaf), 0);
+    }
+
     function testCheckTrustedIntermediateCertsStopsAtExpiredCert() public {
         // Warp past the intermediate cert's expiry
         vm.warp(INTERMEDIATE_CERT_1_EXPIRY + 1);


### PR DESCRIPTION
## Summary

Hardens `NitroEnclaveVerifier` journal verification around certificate expiry and general multiproof audit follow-ups. 

## Changes

- After trusted-prefix checks, reject verification when any remaining certificate in the journal chain has a `notAfter` before `block.timestamp` (audit finding 1).
- Remove stale or misleading comments (finding 3).
- Document that a revoked intermediate can become trusted again if re-added with a new expiry (finding 5).
- Add a test that an expired leaf past `trustedCertsPrefixLen` yields `InvalidTimestamp` and is not cached.
- Additional documentation on CWIA offsets in `AggregateVerifier`