### PR TITLE
docs: update stale base-org references in README to base

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 This repo contains contracts and scripts for Base.
 Note that Base primarily utilizes Optimism's bedrock contracts located in Optimism's repo [here](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock).
-For contract deployment artifacts, see [base-org/contract-deployments](https://github.com/base-org/contract-deployments).
+For contract deployment artifacts, see [base/contract-deployments](https://github.com/base/contract-deployments).
 
 <!-- Badge row 1 - status -->
 
-[![GitHub contributors](https://img.shields.io/github/contributors/base-org/contracts)](https://github.com/base/contracts/graphs/contributors)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base-org/contracts)](https://github.com/base/contracts/graphs/contributors)
-[![GitHub Stars](https://img.shields.io/github/stars/base-org/contracts.svg)](https://github.com/base/contracts/stargazers)
-![GitHub repo size](https://img.shields.io/github/repo-size/base-org/contracts)
-[![GitHub](https://img.shields.io/github/license/base-org/contracts?color=blue)](https://github.com/base/contracts/blob/main/LICENSE)
+[![GitHub contributors](https://img.shields.io/github/contributors/base/contracts)](https://github.com/base/contracts/graphs/contributors)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base/contracts)](https://github.com/base/contracts/graphs/contributors)
+[![GitHub Stars](https://img.shields.io/github/stars/base/contracts.svg)](https://github.com/base/contracts/stargazers)
+![GitHub repo size](https://img.shields.io/github/repo-size/base/contracts)
+[![GitHub](https://img.shields.io/github/license/base/contracts?color=blue)](https://github.com/base/contracts/blob/main/LICENSE)
 
 <!-- Badge row 2 - links and profiles -->
 
@@ -24,8 +24,8 @@ For contract deployment artifacts, see [base-org/contract-deployments](https://g
 
 <!-- Badge row 3 - detailed status -->
 
-[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base-org/contracts)](https://github.com/base/contracts/pulls)
-[![GitHub Issues](https://img.shields.io/github/issues-raw/base-org/contracts.svg)](https://github.com/base/contracts/issues)
+[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base/contracts)](https://github.com/base/contracts/pulls)
+[![GitHub Issues](https://img.shields.io/github/issues-raw/base/contracts.svg)](https://github.com/base/contracts/issues)
 
 ### Fixing semver-lock CI failures
 


### PR DESCRIPTION
## Problem

The org moved from `base-org` to `base`, but the root `README.md` still references the old org in eight places: the `contract-deployments` link on line 7, and seven shield badge URLs on lines 11-15 and 27-28 (contributors, commit activity, stars, repo size, license, open PRs, open issues). The badges render images for a path that no longer exists, and the deployments link resolves to the defunct org.

## Fix

Replaced every `base-org/contracts` and `base-org/contract-deployments` occurrence with `base/contracts` and `base/contract-deployments`. No other files in the repo carry the stale org name.

## Changes

- **`README.md`** — Updated the contract-deployments link (line 7) and all seven shield badge URLs (lines 11-15, 27-28) to use the current `base` GitHub org

## Testing

- Ran \`grep -rn \"base-org\" .\` on the whole repo after the fix — no remaining occurrences
- Verified each updated URL resolves (badges: \`img.shields.io/github/*/base/contracts\`; link: \`github.com/base/contract-deployments\`)
- Confirmed the fix matches the enumeration in the reporter's issue (line 7, lines 11-15, lines 27-28)

Closes #248