### PR TITLE
Backport: add verifier contract

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -247,6 +247,10 @@
     "initCodeHash": "0x9f65f2d6e2c43512594f7a08fc0ea475d06f48d230690c3c85cc85dee3a9679a",
     "sourceCodeHash": "0xd5e01b4f4e69313e56e51f2f46b7bbe699ef8dc24b8a6385b8ebac4162e05353"
   },
+  "src/multiproof/zk/ZKVerifier.sol:ZkVerifier": {
+    "initCodeHash": "0xb50364a38af3ef7dbfab9a84210d08c5f61105638326e6a442828dfa5afc924d",
+    "sourceCodeHash": "0x0ffc935dbd768b4aad6c35e2d6826c556191cc5e8f20737045d1bc196b13e19f"
+  },
   "src/revenue-share/FeeDisburser.sol:FeeDisburser": {
     "initCodeHash": "0x1278027e3756e2989e80c0a7b513e221a5fe0d3dbd9ded108375a29b2c1f3d57",
     "sourceCodeHash": "0xac49a0ecf22b8a7bb3ebef830a2d27b19050f9b08941186e8563d5113cf0ce9c"

--- a/src/multiproof/zk/ZKVerifier.sol
+++ b/src/multiproof/zk/ZKVerifier.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { ISP1Verifier } from "src/dispute/zk/ISP1Verifier.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { Verifier } from "../Verifier.sol";
+
+/// @title ZkVerifier
+/// @notice Verifies ZK proofs via a Succinct SP1 verifier gateway.
+/// @dev Adapts the SP1 verifier interface to the IVerifier interface used by AggregateVerifier.
+///      The AggregateVerifier passes (proofBytes, imageId=ZK_IMAGE_HASH, journal=keccak256(publicInputs)).
+///      This contract re-encodes the journal as SP1 public values and forwards the proof to the
+///      SP1 verifier gateway, using imageId as the program verification key.
+contract ZkVerifier is Verifier {
+    /// @notice The SP1 verifier gateway contract.
+    ISP1Verifier public immutable SP1_VERIFIER;
+
+    /// @notice Thrown when SP1 proof verification reverts.
+    error SP1VerificationFailed();
+
+    /// @param sp1Verifier The deployed SP1 verifier gateway address.
+    /// @param anchorStateRegistry The anchor state registry for nullification checks.
+    constructor(ISP1Verifier sp1Verifier, IAnchorStateRegistry anchorStateRegistry) Verifier(anchorStateRegistry) {
+        SP1_VERIFIER = sp1Verifier;
+    }
+
+    /// @notice Verifies a ZK proof via the SP1 verifier gateway.
+    /// @param proofBytes The SP1 proof bytes (first 4 bytes must match the verifier hash).
+    /// @param imageId The SP1 program verification key (ZK_IMAGE_HASH from AggregateVerifier).
+    /// @param journal The keccak256 hash of the proof's public inputs.
+    /// @return True if the proof is valid.
+    function verify(
+        bytes calldata proofBytes,
+        bytes32 imageId,
+        bytes32 journal
+    )
+        external
+        view
+        override
+        notNullified
+        returns (bool)
+    {
+        SP1_VERIFIER.verifyProof(imageId, abi.encodePacked(journal), proofBytes);
+        return true;
+    }
+
+    /// @custom:semver 0.1.0
+    function version() public pure virtual returns (string memory) {
+        return "0.1.0";
+    }
+}


### PR DESCRIPTION
## Summary
- Backports the ZKVerifier contract and semver-lock update from `feat/add-verifier` to the `releases/v8.0.0` branch.
- Cherry-picked commits: `b54e5e6f` (add verifier contract) and `ece59317` (update semver-lock.json file).