### PR TITLE
docs(README): update stale base-org references to base after org rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 This repo contains contracts and scripts for Base.
 Note that Base primarily utilizes Optimism's bedrock contracts located in Optimism's repo [here](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock).
-For contract deployment artifacts, see [base-org/contract-deployments](https://github.com/base-org/contract-deployments).
+For contract deployment artifacts, see [base/contract-deployments](https://github.com/base/contract-deployments).
 
 <!-- Badge row 1 - status -->
 
-[![GitHub contributors](https://img.shields.io/github/contributors/base-org/contracts)](https://github.com/base/contracts/graphs/contributors)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base-org/contracts)](https://github.com/base/contracts/graphs/contributors)
-[![GitHub Stars](https://img.shields.io/github/stars/base-org/contracts.svg)](https://github.com/base/contracts/stargazers)
-![GitHub repo size](https://img.shields.io/github/repo-size/base-org/contracts)
-[![GitHub](https://img.shields.io/github/license/base-org/contracts?color=blue)](https://github.com/base/contracts/blob/main/LICENSE)
+[![GitHub contributors](https://img.shields.io/github/contributors/base/contracts)](https://github.com/base/contracts/graphs/contributors)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base/contracts)](https://github.com/base/contracts/graphs/contributors)
+[![GitHub Stars](https://img.shields.io/github/stars/base/contracts.svg)](https://github.com/base/contracts/stargazers)
+![GitHub repo size](https://img.shields.io/github/repo-size/base/contracts)
+[![GitHub](https://img.shields.io/github/license/base/contracts?color=blue)](https://github.com/base/contracts/blob/main/LICENSE)
 
 <!-- Badge row 2 - links and profiles -->
 
@@ -24,8 +24,8 @@ For contract deployment artifacts, see [base-org/contract-deployments](https://g
 
 <!-- Badge row 3 - detailed status -->
 
-[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base-org/contracts)](https://github.com/base/contracts/pulls)
-[![GitHub Issues](https://img.shields.io/github/issues-raw/base-org/contracts.svg)](https://github.com/base/contracts/issues)
+[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base/contracts)](https://github.com/base/contracts/pulls)
+[![GitHub Issues](https://img.shields.io/github/issues-raw/base/contracts.svg)](https://github.com/base/contracts/issues)
 
 ### Fixing semver-lock CI failures
 


### PR DESCRIPTION
Closes #248.

The GitHub organization was renamed from `base-org` to `base`. The old `base-org/*` URLs still redirect, but the README still surfaces them in two places:

1. The Markdown link to the contract-deployments repo on line 7.
2. The `img.shields.io` badge source URLs in lines 11–15 and 27–28. (The rendered badge target links already point at `base/*` and were left unchanged.)

This PR updates both to use the canonical `base/*` paths.

### Diff summary
- 1 file changed, 8 insertions(+), 8 deletions(-)
- README-only, no contract or build changes.