### PR TITLE
docs: update README to reflect Base stack architecture post-OP-Stack …

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # contracts
 
 This repo contains contracts and scripts for Base.
-Note that Base primarily utilizes Optimism's bedrock contracts located in Optimism's repo [here](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock).
+Note that Base's core protocol contracts are maintained in the [base/base](https://github.com/base/base).
 For contract deployment artifacts, see [base-org/contract-deployments](https://github.com/base-org/contract-deployments).
 
 <!-- Badge row 1 - status -->


### PR DESCRIPTION
Replaces stale reference to Optimism's bedrock contracts with updated link to the base/base repository, reflecting Base's exit from the OP Stack (Feb 2026).

Closes base/docs#1395