### PR TITLE
docs: fix duplicate words and 'subwrod' typos in cannon NatSpec

### DIFF
--- a/scripts/deploy/DeployOPChain.s.sol
+++ b/scripts/deploy/DeployOPChain.s.sol
@@ -290,7 +290,7 @@ contract DeployOPChain is SystemDeploy {
         // support deploying straight to permissioned games, and the starting root does not
         // matter for that, as long as it is non-zero, since no games will be played. We do not
         // deploy the permissionless game (and therefore do not set a starting root for it here)
-        // because to to update to the permissionless game, we will need to update its starting
+        // because to update to the permissionless game, we will need to update its starting
         // anchor root and deploy a new permissioned dispute game contract anyway.
         //
         // You can `console.logBytes(abi.encode(ScriptConstants.DEFAULT_OUTPUT_ROOT()))` to get the bytes that

--- a/src/cannon/MIPS64.sol
+++ b/src/cannon/MIPS64.sol
@@ -359,9 +359,9 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice Loads a subword of byteLength size contained from memory based on the low-order bits of vaddr
-    /// @param _vaddr The virtual address of the the subword.
+    /// @param _vaddr The virtual address of the subword.
     /// @param _byteLength The size of the subword.
-    /// @param _signExtend Whether to sign extend the selected subwrod.
+    /// @param _signExtend Whether to sign extend the selected subword.
     function loadSubWord(
         State memory _state,
         uint64 _vaddr,

--- a/src/cannon/libraries/MIPS64Instructions.sol
+++ b/src/cannon/libraries/MIPS64Instructions.sol
@@ -880,10 +880,10 @@ library MIPS64Instructions {
     }
 
     /// @notice Selects a subword of byteLength size contained in memWord based on the low-order bits of vaddr
-    /// @param _vaddr The virtual address of the the subword.
+    /// @param _vaddr The virtual address of the subword.
     /// @param _memWord The full word to select a subword from.
     /// @param _byteLength The size of the subword.
-    /// @param _signExtend Whether to sign extend the selected subwrod.
+    /// @param _signExtend Whether to sign extend the selected subword.
     function selectSubWord(
         uint64 _vaddr,
         uint64 _memWord,


### PR DESCRIPTION
## Summary

Comment/NatSpec-only fixes for typos that have been sitting in the cannon files since their introduction (Feb 22 commit `27731f5`):

- \`src/cannon/MIPS64.sol\` — \`loadSubWord\` NatSpec: \`the the subword\` → \`the subword\`; \`subwrod\` → \`subword\`
- \`src/cannon/libraries/MIPS64Instructions.sol\` — \`selectSubWord\` NatSpec: \`the the subword\` → \`the subword\`; \`subwrod\` → \`subword\`
- \`scripts/deploy/DeployOPChain.s.sol\` — inline comment: \`because to to update\` → \`because to update\`

```diff
- /// @param _vaddr The virtual address of the the subword.
+ /// @param _vaddr The virtual address of the subword.
```

```diff
- /// @param _signExtend Whether to sign extend the selected subwrod.
+ /// @param _signExtend Whether to sign extend the selected subword.
```

```diff
- // because to to update to the permissionless game, we will need to update its starting
+ // because to update to the permissionless game, we will need to update its starting
```

No behavior change — strings/identifiers/Solidity code are untouched, only NatSpec and inline comments.

GPG-signed.