### PR TITLE
fix: use inclusive timestamp boundaries in attestation validation

### DIFF
--- a/src/L1/proofs/tee/NitroEnclaveVerifier.sol
+++ b/src/L1/proofs/tee/NitroEnclaveVerifier.sol
@@ -591,11 +591,8 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
      * 5. Caches newly discovered certificates for future use
      *
      * The timestamp validation converts milliseconds to seconds and checks:
-     * - Attestation is not too old (timestamp + maxTimeDiff > block.timestamp)
-     * - Attestation is not from the future (timestamp < block.timestamp)
-     * Note that due to truncating timestamp from milliseconds, to seconds,
-     * some valid attestations may be rejected. However, this ensures all invalid
-     * timestamps are rejected.
+     * - Attestation is not too old (timestamp + maxTimeDiff >= block.timestamp)
+     * - Attestation is not from the future (timestamp <= block.timestamp)
      */
     function _verifyJournal(VerifierJournal memory journal) internal returns (VerifierJournal memory) {
         if (journal.result != VerificationResult.Success) {
@@ -630,7 +627,7 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
             }
         }
         uint64 timestamp = journal.timestamp / 1000;
-        if (timestamp + maxTimeDiff <= block.timestamp || timestamp >= block.timestamp) {
+        if (timestamp + maxTimeDiff < block.timestamp || timestamp > block.timestamp) {
             journal.result = VerificationResult.InvalidTimestamp;
             return journal;
         }

--- a/src/L1/proofs/tee/TEEProverRegistry.sol
+++ b/src/L1/proofs/tee/TEEProverRegistry.sol
@@ -149,7 +149,7 @@ contract TEEProverRegistry is OwnableManagedUpgradeable, ISemver {
 
         // We allow attestations up to MAX_AGE old. This means a cert may be expired between when
         // the attestation is generated and when it is submitted to this contract.
-        if (journal.timestamp / MS_PER_SECOND + MAX_AGE <= block.timestamp) revert AttestationTooOld();
+        if (journal.timestamp / MS_PER_SECOND + MAX_AGE < block.timestamp) revert AttestationTooOld();
 
         // Extract the attestation's PCR0 and store it for TEEVerifier to check at
         // proof-submission time. No comparison against the current TEE_IMAGE_HASH

--- a/test/L1/proofs/NitroEnclaveVerifier.t.sol
+++ b/test/L1/proofs/NitroEnclaveVerifier.t.sol
@@ -642,6 +642,58 @@ contract NitroEnclaveVerifierTest is Test {
         assertEq(uint8(result.result), uint8(VerificationResult.InvalidTimestamp));
     }
 
+    function testVerifyJournalTimestampEqualToBlockTimestamp() public {
+        _setUpRiscZeroConfig();
+
+        VerifierJournal memory journal = _createSuccessJournal();
+        // Set timestamp exactly equal to block.timestamp (in ms) — should be accepted
+        journal.timestamp = uint64(block.timestamp) * 1000;
+        bytes memory output = abi.encode(journal);
+        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+
+        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
+
+        vm.prank(submitter);
+        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
+
+        assertEq(uint8(result.result), uint8(VerificationResult.Success));
+    }
+
+    function testVerifyJournalTimestampAtMaxTimeDiffBoundary() public {
+        _setUpRiscZeroConfig();
+
+        VerifierJournal memory journal = _createSuccessJournal();
+        // Set timestamp exactly maxTimeDiff seconds in the past (in ms) — should be accepted
+        journal.timestamp = uint64(block.timestamp - MAX_TIME_DIFF) * 1000;
+        bytes memory output = abi.encode(journal);
+        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+
+        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
+
+        vm.prank(submitter);
+        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
+
+        assertEq(uint8(result.result), uint8(VerificationResult.Success));
+    }
+
+    function testVerifyJournalTimestampSubSecondTruncation() public {
+        _setUpRiscZeroConfig();
+
+        VerifierJournal memory journal = _createSuccessJournal();
+        // Set timestamp to block.timestamp * 1000 + 999 — sub-second offset that truncates
+        // to block.timestamp, should be accepted
+        journal.timestamp = uint64(block.timestamp) * 1000 + 999;
+        bytes memory output = abi.encode(journal);
+        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+
+        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
+
+        vm.prank(submitter);
+        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
+
+        assertEq(uint8(result.result), uint8(VerificationResult.Success));
+    }
+
     function testVerifyCachesNewCerts() public {
         _setUpRiscZeroConfig();
 


### PR DESCRIPTION
## Summary

- Fixes off-by-one in `NitroEnclaveVerifier._verifyJournal` timestamp validation that rejected valid attestations whose truncated timestamp equaled `block.timestamp` or was exactly `maxTimeDiff` seconds old
- Fixes matching off-by-one in `TEEProverRegistry.registerSigner` where attestations exactly `MAX_AGE` seconds old were incorrectly rejected
- Adds 3 boundary tests covering `timestamp == block.timestamp`, `timestamp + maxTimeDiff == block.timestamp`, and sub-second truncation

## Details

The timestamp validation in `_verifyJournal` (line 630) used strict inequality operators that excluded the boundary:

```solidity
// Before (rejects boundary-valid attestations)
if (timestamp + maxTimeDiff <= block.timestamp || timestamp >= block.timestamp)

// After (accepts boundary-valid attestations)
if (timestamp + maxTimeDiff < block.timestamp || timestamp > block.timestamp)
```

The same pattern existed in `TEEProverRegistry.registerSigner` (line 152):

```solidity
// Before
if (journal.timestamp / MS_PER_SECOND + MAX_AGE <= block.timestamp) revert AttestationTooOld();

// After
if (journal.timestamp / MS_PER_SECOND + MAX_AGE < block.timestamp) revert AttestationTooOld();
```

The natspec is updated to reflect the now-inclusive validity window (`>=` / `<=`), and the previous caveat about rejecting valid attestations at truncation boundaries is removed since it no longer applies.

## Refs

Immunefi #74423, #75086