### PR TITLE
docs: fix duplicate words and 'subwrod' typos in cannon NatSpec

### DIFF
--- a/src/cannon/MIPS64.sol
+++ b/src/cannon/MIPS64.sol
@@ -359,9 +359,9 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice Loads a subword of byteLength size contained from memory based on the low-order bits of vaddr
-    /// @param _vaddr The virtual address of the the subword.
+    /// @param _vaddr The virtual address of the subword.
     /// @param _byteLength The size of the subword.
-    /// @param _signExtend Whether to sign extend the selected subwrod.
+    /// @param _signExtend Whether to sign extend the selected subword.
     function loadSubWord(
         State memory _state,
         uint64 _vaddr,

--- a/src/cannon/libraries/MIPS64Instructions.sol
+++ b/src/cannon/libraries/MIPS64Instructions.sol
@@ -880,10 +880,10 @@ library MIPS64Instructions {
     }
 
     /// @notice Selects a subword of byteLength size contained in memWord based on the low-order bits of vaddr
-    /// @param _vaddr The virtual address of the the subword.
+    /// @param _vaddr The virtual address of the subword.
     /// @param _memWord The full word to select a subword from.
     /// @param _byteLength The size of the subword.
-    /// @param _signExtend Whether to sign extend the selected subwrod.
+    /// @param _signExtend Whether to sign extend the selected subword.
     function selectSubWord(
         uint64 _vaddr,
         uint64 _memWord,


### PR DESCRIPTION
## Summary

Comment/NatSpec-only fixes for typos that have been sitting in the cannon files since their introduction:

- `src/cannon/MIPS64.sol` — `loadSubWord` NatSpec: `the the subword` → `the subword`; `subwrod` → `subword`
- `src/cannon/libraries/MIPS64Instructions.sol` — `selectSubWord` NatSpec: `the the subword` → `the subword`; `subwrod` → `subword`

Rebased on current main (removed the `DeployOPChain.s.sol` change since that file was deleted upstream).

No behavior change — comment-only fixes.