### PR TITLE
fix: correct NatSpec tags, typo, and parameter naming

### DIFF
--- a/src/L1/SystemConfig.sol
+++ b/src/L1/SystemConfig.sol
@@ -476,10 +476,10 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     }
 
     /// @notice Internal function for updating the DA footprint gas scalar.
-    function _setDAFootprintGasScalar(uint16 _dAFootprintGasScalar) internal {
-        daFootprintGasScalar = _dAFootprintGasScalar;
+    function _setDAFootprintGasScalar(uint16 _daFootprintGasScalar) internal {
+        daFootprintGasScalar = _daFootprintGasScalar;
 
-        bytes memory data = abi.encode(_dAFootprintGasScalar);
+        bytes memory data = abi.encode(_daFootprintGasScalar);
         emit ConfigUpdate(VERSION, UpdateType.DA_FOOTPRINT_GAS_SCALAR, data);
     }
 

--- a/src/L1/proofs/v2/FaultDisputeGameV2.sol
+++ b/src/L1/proofs/v2/FaultDisputeGameV2.sol
@@ -564,7 +564,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
     }
 
     /// @notice Defend an agreed upon `Claim`.
-    /// @notice _disputed The `Claim` being defended.
+    /// @param _disputed The `Claim` being defended.
     /// @param _parentIndex Index of the claim to defend in the `claimData` array. This must match the `_disputed`
     /// claim.
     /// @param _claim The `Claim` at the relative defense position.
@@ -572,7 +572,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         move(_disputed, _parentIndex, _claim, false);
     }
 
-    /// @notice Posts the requested local data to the VM's `PreimageOralce`.
+    /// @notice Posts the requested local data to the VM's `PreimageOracle`.
     /// @param _ident The local identifier of the data to post.
     /// @param _execLeafIdx The index of the leaf claim in an execution subgame that requires the local data for a step.
     /// @param _partOffset The offset of the data to post.

--- a/src/L1/proofs/v2/PermissionedDisputeGameV2.sol
+++ b/src/L1/proofs/v2/PermissionedDisputeGameV2.sol
@@ -49,7 +49,7 @@ contract PermissionedDisputeGameV2 is FaultDisputeGameV2 {
     }
 
     /// @notice Generic move function, used for both `attack` and `defend` moves.
-    /// @notice _disputed The disputed `Claim`.
+    /// @param _disputed The disputed `Claim`.
     /// @param _challengeIndex The index of the claim being moved against. This must match the `_disputed` claim.
     /// @param _claim The claim at the next logical position in the game.
     /// @param _isAttack Whether or not the move is an attack or defense.


### PR DESCRIPTION
## Summary

Three small but real fixes across dispute game and system config contracts.

## Changes

### 1. `@notice` → `@param` for `_disputed` parameter (2 files)

The wrong tag type means NatSpec tooling (forge doc, etherscan) renders these parameters as undocumented while the description shows up as a stray contract notice.

**`src/L1/proofs/v2/FaultDisputeGameV2.sol`** (line 567, `defend()`):

```diff
- /// @notice _disputed The `Claim` being defended.
+ /// @param _disputed The `Claim` being defended.
```

**`src/L1/proofs/v2/PermissionedDisputeGameV2.sol`** (line 52, `move()`):

```diff
- /// @notice _disputed The disputed `Claim`.
+ /// @param _disputed The disputed `Claim`.
```

The sibling `attack()` function already uses the correct `@param _disputed` tag, making the inconsistency obvious.

### 2. Typo: `PreimageOralce` → `PreimageOracle`

**`src/L1/proofs/v2/FaultDisputeGameV2.sol`** (line 575):

```diff
- /// @notice Posts the requested local data to the VM's `PreimageOralce`.
+ /// @notice Posts the requested local data to the VM's `PreimageOracle`.
```

The contract name is misspelled in a backtick-wrapped type reference, which would render as a broken link in generated docs.

### 3. Parameter naming: `_dAFootprintGasScalar` → `_daFootprintGasScalar`

**`src/L1/SystemConfig.sol`** (lines 479-482):

```diff
- function _setDAFootprintGasScalar(uint16 _dAFootprintGasScalar) internal {
-     daFootprintGasScalar = _dAFootprintGasScalar;
-     bytes memory data = abi.encode(_dAFootprintGasScalar);
+ function _setDAFootprintGasScalar(uint16 _daFootprintGasScalar) internal {
+     daFootprintGasScalar = _daFootprintGasScalar;
+     bytes memory data = abi.encode(_daFootprintGasScalar);
```

The "DA" abbreviation should be a single lowercase prefix in camelCase. The public wrapper, the storage variable (`daFootprintGasScalar`), and the NatSpec `@param` tag at line 473 all use the lowercase-a form. This was likely a copy-paste error where "DA" was typed as two separate letters.

## Verification

- ✅ All changes verified locally
- ✅ Only the 3 specified files touched
- ✅ Internal naming consistency confirmed against existing patterns in each file