### PR TITLE
docs: fix broken anchor line and stale org name in badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ For contract deployment artifacts, see [base-org/contract-deployments](https://g
 
 <!-- Badge row 1 - status -->
 
-[![GitHub contributors](https://img.shields.io/github/contributors/base-org/contracts)](https://github.com/base/contracts/graphs/contributors)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base-org/contracts)](https://github.com/base/contracts/graphs/contributors)
-[![GitHub Stars](https://img.shields.io/github/stars/base-org/contracts.svg)](https://github.com/base/contracts/stargazers)
-![GitHub repo size](https://img.shields.io/github/repo-size/base-org/contracts)
-[![GitHub](https://img.shields.io/github/license/base-org/contracts?color=blue)](https://github.com/base/contracts/blob/main/LICENSE)
+[![GitHub contributors](https://img.shields.io/github/contributors/base/contracts)](https://github.com/base/contracts/graphs/contributors)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base/contracts)](https://github.com/base/contracts/graphs/contributors)
+[![GitHub Stars](https://img.shields.io/github/stars/base/contracts.svg)](https://github.com/base/contracts/stargazers)
+![GitHub repo size](https://img.shields.io/github/repo-size/base/contracts)
+[![GitHub](https://img.shields.io/github/license/base/contracts?color=blue)](https://github.com/base/contracts/blob/main/LICENSE)
 
 <!-- Badge row 2 - links and profiles -->
 
@@ -24,8 +24,8 @@ For contract deployment artifacts, see [base-org/contract-deployments](https://g
 
 <!-- Badge row 3 - detailed status -->
 
-[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base-org/contracts)](https://github.com/base/contracts/pulls)
-[![GitHub Issues](https://img.shields.io/github/issues-raw/base-org/contracts.svg)](https://github.com/base/contracts/issues)
+[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base/contracts)](https://github.com/base/contracts/pulls)
+[![GitHub Issues](https://img.shields.io/github/issues-raw/base/contracts.svg)](https://github.com/base/contracts/issues)
 
 ### Fixing semver-lock CI failures
 

--- a/scripts/multiproof/README.md
+++ b/scripts/multiproof/README.md
@@ -8,7 +8,7 @@ This guide covers deploying the multiproof contracts and registering a prover on
 
 The scripts in this directory are **development and testing tools only**. They are not suitable for production deployments. Specifically, the NoNitro path (`DeployDevNoNitro.s.sol`):
 
-- Does **no AWS Nitro attestation checking**. Instead it uses a bypass function for quickly registering provers: [`MockDevTEEProverRegistry.addDevSigner()`](https://github.com/base/contracts/blob/main/test/mocks/MockDevTEEProverRegistry.sol#L22)
+- Does **no AWS Nitro attestation checking**. Instead it uses a bypass function for quickly registering provers: [`MockDevTEEProverRegistry.addDevSigner()`](https://github.com/base/contracts/blob/main/test/mocks/MockDevTEEProverRegistry.sol#L30)
 - Uses a simplified mock `AnchorStateRegistry` (with some differences from the real one): [`MockAnchorStateRegistry`](https://github.com/base/contracts/blob/main/scripts/multiproof/mocks/MockAnchorStateRegistry.sol)
 
 ---


### PR DESCRIPTION
## Summary

Two small documentation link fixes.

## Changes

### 1. `scripts/multiproof/README.md` (line 11) — Wrong anchor line number

```diff
- [`MockDevTEEProverRegistry.addDevSigner()`](https://github.com/base/contracts/blob/main/test/mocks/MockDevTEEProverRegistry.sol#L22)
+ [`MockDevTEEProverRegistry.addDevSigner()`](https://github.com/base/contracts/blob/main/test/mocks/MockDevTEEProverRegistry.sol#L30)
```

The link is supposed to point to the `addDevSigner()` function definition. Line 22 lands inside the constructor body — the function is actually defined at line 30. Anyone clicking through to understand the dev signer bypass mechanism lands in the wrong place.

### 2. `README.md` — Stale `base-org/contracts` in 7 shield.io badge URLs

The repo's actual path is `github.com/base/contracts` (confirmed via `git remote -v`), and the linked targets already point to the correct location. But all 7 badge image URLs still query stats via the old `base-org/contracts` path:

```diff
- https://img.shields.io/github/contributors/base-org/contracts
- https://img.shields.io/github/commit-activity/w/base-org/contracts
- https://img.shields.io/github/stars/base-org/contracts.svg
- https://img.shields.io/github/repo-size/base-org/contracts
- https://img.shields.io/github/license/base-org/contracts?color=blue
- https://img.shields.io/github/issues-pr-raw/base-org/contracts
- https://img.shields.io/github/issues-raw/base-org/contracts.svg
+ https://img.shields.io/github/contributors/base/contracts
+ https://img.shields.io/github/commit-activity/w/base/contracts
+ https://img.shields.io/github/stars/base/contracts.svg
+ https://img.shields.io/github/repo-size/base/contracts
+ https://img.shields.io/github/license/base/contracts?color=blue
+ https://img.shields.io/github/issues-pr-raw/base/contracts
+ https://img.shields.io/github/issues-raw/base/contracts.svg
```

Shields.io fetches stats from GitHub's API using the path provided. If GitHub's redirect doesn't transparently pass through to the API for stats endpoints, the badges either show stale numbers or fail silently.

## Verification

- ✅ Only README files touched
- ✅ Anchor line `30` confirmed against `test/mocks/MockDevTEEProverRegistry.sol`
- ✅ All 7 badge URLs updated to current org path