### PR TITLE
fix(libraries/rlp): remove duplicate word in writeList NatSpec

### DIFF
--- a/src/libraries/rlp/RLPWriter.sol
+++ b/src/libraries/rlp/RLPWriter.sol
@@ -18,7 +18,7 @@ library RLPWriter {
         }
     }
 
-    /// @notice RLP encodes a list of RLP encoded byte byte strings.
+    /// @notice RLP encodes a list of RLP encoded byte strings.
     /// @param _in The list of RLP encoded byte strings.
     /// @return list_ The RLP encoded list of items in bytes.
     function writeList(bytes[] memory _in) internal pure returns (bytes memory list_) {


### PR DESCRIPTION
`RLPWriter.writeList` NatSpec (line 21) contains a duplicate word: `byte byte strings` → `byte strings`.

The line below the notice (`@param _in`) already reads `byte strings` correctly — the typo is in the `@notice` only.

```diff
-    /// @notice RLP encodes a list of RLP encoded byte byte strings.
+    /// @notice RLP encodes a list of RLP encoded byte strings.
```

String-only edit, no logic changes. GPG-signed.