### PR TITLE
chore: clean up deploy test files

### DIFF
--- a/test/deploy/SystemDeploy.t.sol
+++ b/test/deploy/SystemDeploy.t.sol
@@ -8,16 +8,12 @@ import { SystemDeploy } from "scripts/deploy/SystemDeploy.s.sol";
 import { Types } from "scripts/libraries/Types.sol";
 import { SystemDeployAssertions } from "test/deploy/SystemDeployAssertions.sol";
 
-import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
 import { ISP1Verifier } from "interfaces/L1/proofs/zk/ISP1Verifier.sol";
-import { IProxy } from "interfaces/universal/IProxy.sol";
-import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-import { AggregateVerifier } from "src/L1/proofs/AggregateVerifier.sol";
 import { TEEProverRegistry } from "src/L1/proofs/tee/TEEProverRegistry.sol";
 import { TEEVerifier } from "src/L1/proofs/tee/TEEVerifier.sol";
 import { ZKVerifier } from "src/L1/proofs/zk/ZKVerifier.sol";
 import { GameType, Hash, Proposal } from "src/libraries/bridge/Types.sol";
-import { Claim } from "src/libraries/bridge/LibUDT.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 contract MockNitroEnclaveVerifier {
     address public proofSubmitter;
@@ -47,7 +43,6 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
     MockSP1Verifier internal sp1Verifier;
 
     uint256 internal l2ChainId = 901;
-    Claim internal absolutePrestate = Claim.wrap(0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c);
 
     function setUp() public {
         systemDeploy = new SystemDeploy();
@@ -76,32 +71,28 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
         assertEq(output.superchainProxyAdmin.owner(), _superchainProxyAdminOwner, "proxy admin owner");
         assertEq(output.superchainConfigProxy.guardian(), _guardian, "proxy guardian");
         assertEq(output.superchainConfigImpl.guardian(), _guardian, "impl guardian");
+        assertEq(output.superchainConfigProxy.incidentResponder(), _incidentResponder, "proxy incident responder");
+        assertEq(output.superchainConfigImpl.incidentResponder(), _incidentResponder, "impl incident responder");
 
-        vm.startPrank(address(0));
         assertEq(
-            IProxy(payable(address(output.superchainConfigProxy))).implementation(),
+            EIP1967Helper.getImplementation(address(output.superchainConfigProxy)),
             address(output.superchainConfigImpl),
             "implementation"
         );
         assertEq(
-            IProxy(payable(address(output.superchainConfigProxy))).admin(),
-            address(output.superchainProxyAdmin),
-            "admin"
+            EIP1967Helper.getAdmin(address(output.superchainConfigProxy)), address(output.superchainProxyAdmin), "admin"
         );
-        vm.stopPrank();
     }
 
     function test_deploySuperchain_nullInput_reverts() public {
         SystemDeploy.SuperchainInput memory input = SystemDeploy.SuperchainInput({
-            guardian: guardian, incidentResponder: address(0), superchainProxyAdminOwner: owner
+            guardian: guardian, incidentResponder: incidentResponder, superchainProxyAdminOwner: address(0)
         });
-
-        input.superchainProxyAdminOwner = address(0);
         vm.expectRevert(abi.encodeWithSelector(SystemDeploy.InvalidRoleAddress.selector, "superchainProxyAdminOwner"));
         systemDeploy.deploySuperchain(input);
 
         input = SystemDeploy.SuperchainInput({
-            guardian: address(0), incidentResponder: address(0), superchainProxyAdminOwner: owner
+            guardian: address(0), incidentResponder: incidentResponder, superchainProxyAdminOwner: owner
         });
         vm.expectRevert(abi.encodeWithSelector(SystemDeploy.InvalidRoleAddress.selector, "guardian"));
         systemDeploy.deploySuperchain(input);
@@ -109,7 +100,7 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
 
     function test_deploySuperchain_reuseAddresses_succeeds() public {
         SystemDeploy.SuperchainInput memory input = SystemDeploy.SuperchainInput({
-            guardian: guardian, incidentResponder: address(0), superchainProxyAdminOwner: owner
+            guardian: guardian, incidentResponder: incidentResponder, superchainProxyAdminOwner: owner
         });
 
         SystemDeploy.SuperchainOutput memory output0 = systemDeploy.deploySuperchain(input);
@@ -141,7 +132,8 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
     }
 
     function test_upgrade_withoutManagerDelegatecall_succeeds() public {
-        SystemDeploy.DeployOutput memory output = systemDeploy.deploy(_defaultDeployInput());
+        SystemDeploy.DeployInput memory input = _defaultDeployInput();
+        SystemDeploy.DeployOutput memory output = systemDeploy.deploy(input);
 
         SystemDeploy.UpgradeOutput memory upgradeOutput = systemDeploy.upgrade(
             SystemDeploy.UpgradeInput({
@@ -154,14 +146,19 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
 
         assertFalse(upgradeOutput.superchainConfigUpgraded, "superchain already current");
         assertTrue(upgradeOutput.chainUpgraded, "chain upgraded");
-        _assertUpgradedProxyImplementations(output);
-        assertValidStandardSystem(_expected(output, _defaultDeployInput()));
+        assertEq(
+            output.superchain.superchainProxyAdmin
+                .getProxyImplementation(address(output.superchain.superchainConfigProxy)),
+            output.impls.superchainConfigImpl,
+            "superchain config impl"
+        );
+        assertValidStandardSystem(_expected(output, input));
     }
 
     function test_deploy_reusingImplementations_doesNotSaveZeroImplementationOnlyArtifacts() public {
-        SystemDeploy.DeployOutput memory output = systemDeploy.deploy(_defaultDeployInput());
-
         SystemDeploy.DeployInput memory input = _defaultDeployInput();
+        SystemDeploy.DeployOutput memory output = systemDeploy.deploy(input);
+
         input.saveArtifacts = true;
         input.superchainConfigProxy = output.superchain.superchainConfigProxy;
         input.implementations = output.impls;
@@ -224,50 +221,27 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
         internal
         view
     {
-        GameType gameType = GameType.wrap(uint32(_input.implementationsInput.multiproofGameType));
-        address aggregateVerifierAddr = address(_output.opChain.aggregateVerifier);
         address teeProverRegistryProxyAddr = address(_output.opChain.teeProverRegistryProxy);
         address teeVerifierAddr = address(_output.opChain.teeVerifier);
         address zkVerifierAddr = address(_output.opChain.zkVerifier);
         Types.Implementations memory impls = _output.impls;
 
-        assertNotEq(aggregateVerifierAddr, address(0), "aggregate verifier");
         assertNotEq(teeProverRegistryProxyAddr, address(0), "tee prover registry proxy");
         assertNotEq(impls.teeProverRegistryImpl, address(0), "tee prover registry impl");
-        assertNotEq(teeVerifierAddr, address(0), "tee verifier");
-        assertNotEq(zkVerifierAddr, address(0), "zk verifier");
-        assertEq(impls.aggregateVerifierImpl, aggregateVerifierAddr, "aggregate verifier impl");
+        assertEq(impls.aggregateVerifierImpl, address(_output.opChain.aggregateVerifier), "aggregate verifier impl");
         assertEq(impls.teeVerifierImpl, teeVerifierAddr, "tee verifier impl");
         assertEq(impls.zkVerifierImpl, zkVerifierAddr, "zk verifier impl");
-        assertEq(address(_output.opChain.nitroEnclaveVerifier), _input.implementationsInput.nitroEnclaveVerifier);
-        assertEq(address(_output.opChain.sp1Verifier), address(_input.implementationsInput.sp1Verifier));
+        assertEq(
+            address(_output.opChain.nitroEnclaveVerifier),
+            _input.implementationsInput.nitroEnclaveVerifier,
+            "nitro enclave verifier"
+        );
+        assertEq(address(_output.opChain.sp1Verifier), address(_input.implementationsInput.sp1Verifier), "sp1 verifier");
         assertEq(
             _output.opChain.opChainProxyAdmin.getProxyImplementation(teeProverRegistryProxyAddr),
             impls.teeProverRegistryImpl,
             "tee registry proxy impl"
         );
-
-        assertEq(
-            address(_output.opChain.disputeGameFactoryProxy.gameImpls(gameType)),
-            aggregateVerifierAddr,
-            "multiproof game impl"
-        );
-
-        AggregateVerifier aggregateVerifier = AggregateVerifier(aggregateVerifierAddr);
-        assertEq(
-            address(aggregateVerifier.anchorStateRegistry()),
-            address(_output.opChain.anchorStateRegistryProxy),
-            "aggregate verifier asr"
-        );
-        assertEq(address(aggregateVerifier.DISPUTE_GAME_FACTORY()), address(_output.opChain.disputeGameFactoryProxy));
-        assertEq(address(aggregateVerifier.DELAYED_WETH()), address(_output.opChain.delayedWETHProxy));
-        assertEq(address(aggregateVerifier.TEE_VERIFIER()), teeVerifierAddr);
-        assertEq(address(aggregateVerifier.ZK_VERIFIER()), zkVerifierAddr);
-        assertEq(aggregateVerifier.TEE_IMAGE_HASH(), _input.implementationsInput.teeImageHash);
-        assertEq(aggregateVerifier.ZK_RANGE_HASH(), _input.implementationsInput.zkRangeHash);
-        assertEq(aggregateVerifier.ZK_AGGREGATE_HASH(), _input.implementationsInput.zkAggregationHash);
-        assertEq(aggregateVerifier.CONFIG_HASH(), _input.implementationsInput.multiproofConfigHash);
-        assertEq(aggregateVerifier.L2_CHAIN_ID(), _input.opChainInput.l2ChainId);
 
         TEEProverRegistry teeProverRegistry = TEEProverRegistry(teeProverRegistryProxyAddr);
         assertEq(teeProverRegistry.owner(), _input.opChainInput.roles.opChainProxyAdminOwner, "tee registry owner");
@@ -290,58 +264,10 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
             teeProverRegistryProxyAddr,
             "tee verifier registry"
         );
-        assertEq(address(ZKVerifier(zkVerifierAddr).SP1_VERIFIER()), address(_input.implementationsInput.sp1Verifier));
-    }
-
-    function _assertUpgradedProxyImplementations(SystemDeploy.DeployOutput memory _output) internal view {
-        IProxyAdmin superchainProxyAdmin = _output.superchain.superchainProxyAdmin;
-        IProxyAdmin opChainProxyAdmin = _output.opChain.opChainProxyAdmin;
-        Types.Implementations memory impls = _output.impls;
-
         assertEq(
-            superchainProxyAdmin.getProxyImplementation(address(_output.superchain.superchainConfigProxy)),
-            impls.superchainConfigImpl,
-            "superchain config impl"
-        );
-        assertEq(
-            opChainProxyAdmin.getProxyImplementation(address(_output.opChain.systemConfigProxy)),
-            impls.systemConfigImpl,
-            "system config impl"
-        );
-        assertEq(
-            opChainProxyAdmin.getProxyImplementation(address(_output.opChain.optimismPortalProxy)),
-            impls.optimismPortalImpl,
-            "portal impl"
-        );
-        assertEq(
-            opChainProxyAdmin.getProxyImplementation(address(_output.opChain.anchorStateRegistryProxy)),
-            impls.anchorStateRegistryImpl,
-            "anchor state registry impl"
-        );
-        assertEq(
-            opChainProxyAdmin.getProxyImplementation(address(_output.opChain.optimismMintableERC20FactoryProxy)),
-            impls.optimismMintableERC20FactoryImpl,
-            "erc20 factory impl"
-        );
-        assertEq(
-            opChainProxyAdmin.getProxyImplementation(address(_output.opChain.disputeGameFactoryProxy)),
-            impls.disputeGameFactoryImpl,
-            "dispute game factory impl"
-        );
-        assertEq(
-            opChainProxyAdmin.getProxyImplementation(address(_output.opChain.l1CrossDomainMessengerProxy)),
-            impls.l1CrossDomainMessengerImpl,
-            "messenger impl"
-        );
-        assertEq(
-            opChainProxyAdmin.getProxyImplementation(address(_output.opChain.l1StandardBridgeProxy)),
-            impls.l1StandardBridgeImpl,
-            "standard bridge impl"
-        );
-        assertEq(
-            opChainProxyAdmin.getProxyImplementation(address(_output.opChain.l1ERC721BridgeProxy)),
-            impls.l1ERC721BridgeImpl,
-            "erc721 bridge impl"
+            address(ZKVerifier(zkVerifierAddr).SP1_VERIFIER()),
+            address(_input.implementationsInput.sp1Verifier),
+            "zk verifier sp1"
         );
     }
 

--- a/test/deploy/SystemDeployAssertions.sol
+++ b/test/deploy/SystemDeployAssertions.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test, console } from "lib/forge-std/src/Test.sol";
+import { Test } from "lib/forge-std/src/Test.sol";
 
 import { Types } from "scripts/libraries/Types.sol";
 
@@ -172,8 +172,7 @@ abstract contract SystemDeployAssertions is Test {
         );
         assertEq(address(portal.disputeGameFactory()), address(dgf), "PORTAL-30");
         assertEq(address(portal.systemConfig()), address(sysCfg), "PORTAL-40");
-        IDisputeGame av = dgf.gameImpls(_expected.multiproofGameType);
-        assertEq(address(portal.anchorStateRegistry()), address(av.anchorStateRegistry()), "PORTAL-50");
+        assertEq(address(portal.anchorStateRegistry()), address(_expected.anchorStateRegistry), "PORTAL-50");
         assertEq(portal.l2Sender(), Constants.DEFAULT_L2_SENDER, "PORTAL-80");
         assertEq(address(_proxyAdminFor(address(portal))), address(_proxyAdmin), "PORTAL-90");
     }
@@ -208,9 +207,7 @@ abstract contract SystemDeployAssertions is Test {
         IDisputeGame game = factory.gameImpls(_gameType);
 
         assertNotEq(address(game), address(0), "AV-10");
-        address expectedImpl = _expected.implementations.aggregateVerifierImpl;
-        assertEq(address(game), expectedImpl, "AV-15");
-        assertEq(_version(address(game)), _version(expectedImpl), "AV-20");
+        assertEq(address(game), _expected.implementations.aggregateVerifierImpl, "AV-15");
 
         _assertGameArgsAndContracts({
             _expected: _expected,
@@ -272,19 +269,14 @@ abstract contract SystemDeployAssertions is Test {
         private
         view
     {
-        string memory prefix = "AV-DWETH";
+        assertEq(_version(address(_weth)), _version(_expected.implementations.delayedWETHImpl), "AV-DWETH-10");
         assertEq(
-            _version(address(_weth)), _version(_expected.implementations.delayedWETHImpl), string.concat(prefix, "-10")
+            _proxyAdmin.getProxyImplementation(address(_weth)), _expected.implementations.delayedWETHImpl, "AV-DWETH-20"
         );
-        assertEq(
-            _proxyAdmin.getProxyImplementation(address(_weth)),
-            _expected.implementations.delayedWETHImpl,
-            string.concat(prefix, "-20")
-        );
-        assertEq(_weth.proxyAdminOwner(), _expected.proxyAdminOwner, string.concat(prefix, "-30"));
-        assertEq(_weth.delay(), _expected.withdrawalDelaySeconds, string.concat(prefix, "-40"));
-        assertEq(address(_weth.systemConfig()), address(_expected.systemConfig), string.concat(prefix, "-50"));
-        assertEq(address(_proxyAdminFor(address(_weth))), address(_proxyAdmin), string.concat(prefix, "-60"));
+        assertEq(_weth.proxyAdminOwner(), _expected.proxyAdminOwner, "AV-DWETH-30");
+        assertEq(_weth.delay(), _expected.withdrawalDelaySeconds, "AV-DWETH-40");
+        assertEq(address(_weth.systemConfig()), address(_expected.systemConfig), "AV-DWETH-50");
+        assertEq(address(_proxyAdminFor(address(_weth))), address(_proxyAdmin), "AV-DWETH-60");
     }
 
     function _assertAnchorStateRegistry(
@@ -296,21 +288,16 @@ abstract contract SystemDeployAssertions is Test {
         private
         view
     {
-        string memory prefix = "AV-ANCHORP";
-        assertEq(
-            _version(address(_asr)),
-            _version(_expected.implementations.anchorStateRegistryImpl),
-            string.concat(prefix, "-10")
-        );
+        assertEq(_version(address(_asr)), _version(_expected.implementations.anchorStateRegistryImpl), "AV-ANCHORP-10");
         assertEq(
             _proxyAdmin.getProxyImplementation(address(_asr)),
             _expected.implementations.anchorStateRegistryImpl,
-            string.concat(prefix, "-20")
+            "AV-ANCHORP-20"
         );
-        assertEq(address(_asr.disputeGameFactory()), address(_factory), string.concat(prefix, "-30"));
-        assertEq(address(_asr.systemConfig()), address(_expected.systemConfig), string.concat(prefix, "-40"));
-        assertEq(address(_proxyAdminFor(address(_asr))), address(_proxyAdmin), string.concat(prefix, "-50"));
-        assertGt(_asr.retirementTimestamp(), 0, string.concat(prefix, "-60"));
+        assertEq(address(_asr.disputeGameFactory()), address(_factory), "AV-ANCHORP-30");
+        assertEq(address(_asr.systemConfig()), address(_expected.systemConfig), "AV-ANCHORP-40");
+        assertEq(address(_proxyAdminFor(address(_asr))), address(_proxyAdmin), "AV-ANCHORP-50");
+        assertGt(_asr.retirementTimestamp(), 0, "AV-ANCHORP-60");
     }
 
     function _assertETHLockbox(ExpectedSystemDeployState memory _expected, IProxyAdmin _proxyAdmin) private view {


### PR DESCRIPTION
## Summary
- Simplify `SystemDeploy.t.sol` by removing redundant helper `_assertUpgradedProxyImplementations` and inlining the single needed check
- Use `EIP1967Helper` instead of pranking address(0) to read proxy implementation/admin slots
- Add assertions for `incidentResponder` on `SuperchainConfig` proxy/impl and tighten existing null-input revert cases
- Drop now-unused references to `IDisputeGame`, `IProxy`, `IProxyAdmin`, `AggregateVerifier`, and `Claim` (and the unused `absolutePrestate` constant)
- Inline the aggregate verifier wiring checks that are already covered by `SystemDeployAssertions`
- Replace `string.concat` prefix patterns in `SystemDeployAssertions` with literal labels and drop unused `console` import and version check for game impl