### PR TITLE
fix: enforce balance-delta accounting in StandardBridge

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -12,8 +12,8 @@
     "sourceCodeHash": "0xb20a9176e07c550466ccea8f131d74e98112133e1e833a72cbae5da93039392c"
   },
   "src/L1/L1StandardBridge.sol:L1StandardBridge": {
-    "initCodeHash": "0xadd7863f0d14360be0f0c575d07aa304457b190b64a91a8976770fb7c34b28a3",
-    "sourceCodeHash": "0xd9f576a79e97bc541b3d7a2ee928f34223edaaecb074eeb9e6e2ecee857ce6a0"
+    "initCodeHash": "0xaa5a38f6abb8102055e2289c39ee8d345251b9bafebcad47b7e569dc4a297d33",
+    "sourceCodeHash": "0xf79f507285f836bd5871669eac2eebad5bd18c90dbfc734258dfdace6872edd3"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x2c01bc6c0a55a1a27263224e05c1b28703ff85c61075bae7ab384b3043820ed2",
@@ -88,8 +88,8 @@
     "sourceCodeHash": "0x032bda19a2c0a05e8abfdac182982ad14256cbcebc1896ba503bb1a2a681e81f"
   },
   "src/L2/L2StandardBridge.sol:L2StandardBridge": {
-    "initCodeHash": "0xba5b288a396b34488ba7be68473305529c7da7c43e5f1cfc48d6a4aecd014103",
-    "sourceCodeHash": "0xc53a2f1fc472b15aa2891d48845b078ef12fdae869a4b74bef19b19d9d20ed5f"
+    "initCodeHash": "0x71061060e1cf2d0768e0500b0d8300980fbe13b02cde8c09e812bf7f63bfac09",
+    "sourceCodeHash": "0xe21cf335fb23c8781bd9f4c53fe42b1c03a3e555465bfa0ddc2b611886b0ac2b"
   },
   "src/L2/L2ToL1MessagePasser.sol:L2ToL1MessagePasser": {
     "initCodeHash": "0xe30675ea6623cd7390dd2cd1e9a523c92c66956dfab86d06e318eb410cd1989b",

--- a/src/L1/L1StandardBridge.sol
+++ b/src/L1/L1StandardBridge.sol
@@ -77,8 +77,8 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     );
 
     /// @notice Semantic version.
-    /// @custom:semver 2.8.0
-    string public constant version = "2.8.0";
+    /// @custom:semver 2.9.0
+    string public constant version = "2.9.0";
 
     /// @custom:legacy
     /// @custom:spacer superchainConfig

--- a/src/L2/L2StandardBridge.sol
+++ b/src/L2/L2StandardBridge.sol
@@ -57,9 +57,9 @@ contract L2StandardBridge is StandardBridge, ISemver {
     );
 
     /// @notice Semantic version.
-    /// @custom:semver 1.13.0
+    /// @custom:semver 1.14.0
     function version() public pure virtual returns (string memory) {
-        return "1.13.0";
+        return "1.14.0";
     }
 
     /// @notice Constructs the L2StandardBridge contract.

--- a/src/universal/StandardBridge.sol
+++ b/src/universal/StandardBridge.sol
@@ -358,7 +358,14 @@ abstract contract StandardBridge is Initializable {
 
             IOptimismMintableERC20(_localToken).burn(_from, _amount);
         } else {
+            // Reject fee-on-transfer and rebasing tokens by requiring the bridge's balance to
+            // increase by exactly `_amount`. Without this check, the bridge would credit and
+            // forward `_amount` to the remote chain while holding less than `_amount` in escrow,
+            // leading to under-collateralized representations and eventual withdrawal failures.
+            uint256 balanceBefore = IERC20(_localToken).balanceOf(address(this));
             IERC20(_localToken).safeTransferFrom(_from, address(this), _amount);
+            uint256 received = IERC20(_localToken).balanceOf(address(this)) - balanceBefore;
+            require(received == _amount, "StandardBridge: amount received does not match amount transferred");
             deposits[_localToken][_remoteToken] = deposits[_localToken][_remoteToken] + _amount;
         }
 


### PR DESCRIPTION
## Summary

Closes #289.

`StandardBridge._initiateBridgeERC20` credited `deposits[_localToken][_remoteToken]` and forwarded `_amount` to the remote bridge without verifying that the escrow balance actually increased by `_amount`. Fee-on-transfer and rebasing tokens are documented as unsupported, but they were still accepted permissionlessly — leaving the local escrow short while the full `_amount` is minted/released on the remote chain, eventually breaking withdrawals once the escrow is drained.

This PR measures the bridge's balance before and after `safeTransferFrom` and requires the delta to equal `_amount`. Unsupported tokens now revert at deposit time (fail closed) rather than silently underfunding the bridge.

- `src/universal/StandardBridge.sol`: balance-delta check around `safeTransferFrom`
- `src/L1/L1StandardBridge.sol`: semver bump 2.8.0 → 2.9.0
- `src/L2/L2StandardBridge.sol`: semver bump 1.13.0 → 1.14.0
- `snapshots/semver-lock.json`: regenerated

## Test plan

- [x] `forge test --match-contract "L1StandardBridge|L2StandardBridge|StandardBridge"` — 59 passed, 0 failed
- [x] `forge build --force` clean
- [x] `just semver-lock` regenerated
- [ ] CI green