### PR TITLE
chore: simplify proof tests

### DIFF
--- a/test/L1/proofs/AggregateVerifier.t.sol
+++ b/test/L1/proofs/AggregateVerifier.t.sol
@@ -12,68 +12,32 @@ import { Claim, Timestamp } from "src/libraries/bridge/LibUDT.sol";
 import { AggregateVerifier } from "src/L1/proofs/AggregateVerifier.sol";
 import { IVerifier } from "interfaces/L1/proofs/IVerifier.sol";
 
+import { LibClone } from "lib/solady/src/utils/LibClone.sol";
+
 import { BaseTest } from "./BaseTest.t.sol";
 
 contract AggregateVerifierTest is BaseTest {
+    using LibClone for address;
+
+    AggregateVerifier private aggregateVerifierImpl;
+
+    function setUp() public override {
+        super.setUp();
+        aggregateVerifierImpl = AggregateVerifier(address(factory.gameImpls(AGGREGATE_VERIFIER_GAME_TYPE)));
+    }
+
     function testInitializeWithTEEProof() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
-        bytes memory proof = _generateProof("tee-proof", AggregateVerifier.ProofType.TEE);
-
-        AggregateVerifier game = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proof
+        _createAndAssertInitializedGame(
+            "tee-proof", AggregateVerifier.ProofType.TEE, TEE_PROVER, TEE_PROVER, address(0)
         );
-
-        assertEq(game.wasRespectedGameTypeWhenCreated(), true);
-        assertEq(address(game.teeProver()), TEE_PROVER);
-        assertEq(address(game.zkProver()), address(0));
-        assertEq(uint8(game.status()), uint8(GameStatus.IN_PROGRESS));
-        assertEq(game.l2SequenceNumber(), currentL2BlockNumber);
-        assertEq(game.rootClaim().raw(), rootClaim.raw());
-        assertEq(game.parentAddress(), address(anchorStateRegistry));
-        assertEq(game.gameType().raw(), AGGREGATE_VERIFIER_GAME_TYPE.raw());
-        assertEq(game.gameCreator(), TEE_PROVER);
-        assertEq(
-            game.extraData(),
-            abi.encodePacked(currentL2BlockNumber, address(anchorStateRegistry), game.intermediateOutputRoots())
-        );
-        assertEq(game.bondRecipient(), TEE_PROVER);
-        assertEq(anchorStateRegistry.isGameProper(IDisputeGame(address(game))), true);
-        assertEq(delayedWETH.balanceOf(address(game)), INIT_BOND);
-        assertEq(game.proofCount(), 1);
     }
 
     function testInitializeWithZKProof() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
-        bytes memory proof = _generateProof("zk-proof", AggregateVerifier.ProofType.ZK);
-
-        AggregateVerifier game = _createAggregateVerifierGame(
-            ZK_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proof
-        );
-
-        assertEq(game.wasRespectedGameTypeWhenCreated(), true);
-        assertEq(address(game.teeProver()), address(0));
-        assertEq(address(game.zkProver()), ZK_PROVER);
-        assertEq(uint8(game.status()), uint8(GameStatus.IN_PROGRESS));
-        assertEq(game.l2SequenceNumber(), currentL2BlockNumber);
-        assertEq(game.rootClaim().raw(), rootClaim.raw());
-        assertEq(game.parentAddress(), address(anchorStateRegistry));
-        assertEq(game.gameType().raw(), AGGREGATE_VERIFIER_GAME_TYPE.raw());
-        assertEq(game.gameCreator(), ZK_PROVER);
-        assertEq(
-            game.extraData(),
-            abi.encodePacked(currentL2BlockNumber, address(anchorStateRegistry), game.intermediateOutputRoots())
-        );
-        assertEq(game.bondRecipient(), ZK_PROVER);
-        assertEq(anchorStateRegistry.isGameProper(IDisputeGame(address(game))), true);
-        assertEq(delayedWETH.balanceOf(address(game)), INIT_BOND);
-        assertEq(game.proofCount(), 1);
+        _createAndAssertInitializedGame("zk-proof", AggregateVerifier.ProofType.ZK, ZK_PROVER, address(0), ZK_PROVER);
     }
 
     function testInitializeFailsIfInvalidCallDataSize() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
+        Claim rootClaim = _advanceL2BlockAndClaim();
 
         vm.deal(TEE_PROVER, INIT_BOND);
         bytes memory extraData = "";
@@ -85,72 +49,48 @@ contract AggregateVerifierTest is BaseTest {
     }
 
     function testUpdatingAnchorStateRegistryWithTEEProof() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
+        Claim rootClaim = _advanceL2BlockAndClaim();
         bytes memory proof = _generateProof("tee-proof", AggregateVerifier.ProofType.TEE);
 
         AggregateVerifier game = _createAggregateVerifierGame(
             TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proof
         );
 
-        // Cannot claim bond before game is over
         vm.expectRevert(GameNotResolved.selector);
         game.claimCredit();
 
-        // Resolve after SLOW_FINALIZATION_DELAY
-        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
+        vm.warp(block.timestamp + aggregateVerifierImpl.SLOW_FINALIZATION_DELAY());
         game.resolve();
-        assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
+        _assertStatus(game, GameStatus.DEFENDER_WINS);
 
-        // Unlock and reclaim bond after resolving
-        uint256 balanceBefore = game.gameCreator().balance;
-        game.claimCredit();
-        vm.warp(block.timestamp + DELAYED_WETH_DELAY);
-        game.claimCredit();
-        assertEq(game.gameCreator().balance, balanceBefore + INIT_BOND);
-        assertEq(delayedWETH.balanceOf(address(game)), 0);
+        _claimCreditAfterDelay(game);
 
-        // Update AnchorStateRegistry
         vm.warp(block.timestamp + 1);
         game.closeGame();
-        (Hash root, uint256 l2SequenceNumber) = anchorStateRegistry.getAnchorRoot();
-        assertEq(root.raw(), rootClaim.raw());
-        assertEq(l2SequenceNumber, currentL2BlockNumber);
+        _assertAnchorRoot(rootClaim);
     }
 
     function testUpdatingAnchorStateRegistryWithZKProof() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
+        Claim rootClaim = _advanceL2BlockAndClaim();
         bytes memory proof = _generateProof("zk-proof", AggregateVerifier.ProofType.ZK);
 
         AggregateVerifier game = _createAggregateVerifierGame(
             ZK_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proof
         );
 
-        // Resolve after SLOW_FINALIZATION_DELAY
-        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
+        vm.warp(block.timestamp + aggregateVerifierImpl.SLOW_FINALIZATION_DELAY());
         game.resolve();
-        assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
+        _assertStatus(game, GameStatus.DEFENDER_WINS);
 
-        // Unlock and reclaim bond after delay
-        uint256 balanceBefore = game.gameCreator().balance;
-        game.claimCredit();
-        vm.warp(block.timestamp + DELAYED_WETH_DELAY);
-        game.claimCredit();
-        assertEq(game.gameCreator().balance, balanceBefore + INIT_BOND);
-        assertEq(delayedWETH.balanceOf(address(game)), 0);
+        _claimCreditAfterDelay(game);
 
-        // Update AnchorStateRegistry
         vm.warp(block.timestamp + 1);
         game.closeGame();
-        (Hash root, uint256 l2SequenceNumber) = anchorStateRegistry.getAnchorRoot();
-        assertEq(root.raw(), rootClaim.raw());
-        assertEq(l2SequenceNumber, currentL2BlockNumber);
+        _assertAnchorRoot(rootClaim);
     }
 
     function testUpdatingAnchorStateRegistryWithBothProofs() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
+        Claim rootClaim = _advanceL2BlockAndClaim();
         bytes memory teeProof = _generateProof("tee-proof", AggregateVerifier.ProofType.TEE);
         bytes memory zkProof = _generateProof("zk-proof", AggregateVerifier.ProofType.ZK);
 
@@ -161,61 +101,44 @@ contract AggregateVerifierTest is BaseTest {
         _provideProof(game, ZK_PROVER, zkProof);
         assertEq(game.proofCount(), 2);
 
-        // Resolve after FAST_FINALIZATION_DELAY (2 proofs)
-        vm.warp(block.timestamp + FAST_FINALIZATION_DELAY);
+        vm.warp(block.timestamp + aggregateVerifierImpl.FAST_FINALIZATION_DELAY());
         game.resolve();
-        assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
+        _assertStatus(game, GameStatus.DEFENDER_WINS);
 
-        // Update AnchorStateRegistry
         vm.warp(block.timestamp + 1);
         game.closeGame();
-        (Hash root, uint256 l2SequenceNumber) = anchorStateRegistry.getAnchorRoot();
-        assertEq(root.raw(), rootClaim.raw());
-        assertEq(l2SequenceNumber, currentL2BlockNumber);
+        _assertAnchorRoot(rootClaim);
 
-        // Unlock and reclaim bond after delay
-        uint256 balanceBefore = game.gameCreator().balance;
-        game.claimCredit();
-        vm.warp(block.timestamp + DELAYED_WETH_DELAY);
-        game.claimCredit();
-        assertEq(game.gameCreator().balance, balanceBefore + INIT_BOND);
-        assertEq(delayedWETH.balanceOf(address(game)), 0);
+        _claimCreditAfterDelay(game);
     }
 
     function testProofCannotIncreaseExpectedResolution() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
+        Claim rootClaim = _advanceL2BlockAndClaim();
         bytes memory teeProof = _generateProof("tee-proof", AggregateVerifier.ProofType.TEE);
         bytes memory zkProof = _generateProof("zk-proof", AggregateVerifier.ProofType.ZK);
+        uint256 slowDelay = aggregateVerifierImpl.SLOW_FINALIZATION_DELAY();
 
         AggregateVerifier game = _createAggregateVerifierGame(
             TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), teeProof
         );
 
         Timestamp originalExpectedResolution = game.expectedResolution();
-        assertEq(originalExpectedResolution.raw(), block.timestamp + SLOW_FINALIZATION_DELAY);
+        assertEq(originalExpectedResolution.raw(), block.timestamp + slowDelay);
 
-        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY - 1);
-        // Cannot resolve yet
+        vm.warp(block.timestamp + slowDelay - 1);
         vm.expectRevert(AggregateVerifier.GameNotOver.selector);
         game.resolve();
 
-        // Provide ZK proof
         _provideProof(game, ZK_PROVER, zkProof);
+        assertEq(game.expectedResolution().raw(), originalExpectedResolution.raw());
 
-        // Proof should not have increased expected resolution
-        Timestamp expectedResolution = game.expectedResolution();
-        assertEq(expectedResolution.raw(), originalExpectedResolution.raw());
-
-        // Resolve after 1 second
         vm.warp(block.timestamp + 1);
         game.resolve();
-        assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
+        _assertStatus(game, GameStatus.DEFENDER_WINS);
     }
 
     function testCannotCreateSameProposal() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
+        Claim rootClaim = _advanceL2BlockAndClaim();
         bytes memory teeProof = _generateProof("tee-proof", AggregateVerifier.ProofType.TEE);
         bytes memory zkProof = _generateProof("zk-proof", AggregateVerifier.ProofType.ZK);
 
@@ -223,12 +146,8 @@ contract AggregateVerifierTest is BaseTest {
             TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), teeProof
         );
 
-        Hash uuid = factory.getGameUUID(
-            AGGREGATE_VERIFIER_GAME_TYPE,
-            rootClaim,
-            abi.encodePacked(currentL2BlockNumber, address(anchorStateRegistry), game.intermediateOutputRoots())
-        );
-        vm.expectRevert(abi.encodeWithSelector(IDisputeGameFactory.GameAlreadyExists.selector, uuid));
+        Hash gameId = factory.getGameUUID(AGGREGATE_VERIFIER_GAME_TYPE, rootClaim, game.extraData());
+        vm.expectRevert(abi.encodeWithSelector(IDisputeGameFactory.GameAlreadyExists.selector, gameId));
         _createAggregateVerifierGame(ZK_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), zkProof);
     }
 
@@ -262,72 +181,60 @@ contract AggregateVerifierTest is BaseTest {
     }
 
     function testVerifyFailsWithL1OriginInFuture() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        // Use a future block number
+        Claim rootClaim = _advanceL2BlockAndClaim();
         uint256 l1OriginNumber = block.number + 1;
-        bytes32 l1OriginHash = bytes32(uint256(1)); // Fake hash
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
+        bytes32 l1OriginHash = bytes32(uint256(1));
 
-        bytes memory proofBytes =
-            abi.encodePacked(uint8(AggregateVerifier.ProofType.TEE), l1OriginHash, l1OriginNumber, rootClaim.raw());
+        bytes memory proofBytes = _teeProof(l1OriginHash, l1OriginNumber, rootClaim);
 
-        vm.expectRevert(
+        _expectCreateGameRevertsForTeeProof(
+            rootClaim,
+            proofBytes,
             abi.encodeWithSelector(AggregateVerifier.L1OriginInFuture.selector, l1OriginNumber, block.number)
-        );
-        _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proofBytes
         );
     }
 
     function testVerifyFailsWithL1OriginTooOld() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
+        Claim rootClaim = _advanceL2BlockAndClaim();
 
-        // Roll forward many blocks to make old blocks unavailable
         vm.roll(block.number + 300);
 
-        // Use a block number that's too old (outside both blockhash window and EIP-2935 window)
         uint256 l1OriginNumber = 1;
-        bytes32 l1OriginHash = bytes32(uint256(1)); // Fake hash
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
+        bytes32 l1OriginHash = bytes32(uint256(1));
 
-        bytes memory proofBytes =
-            abi.encodePacked(uint8(AggregateVerifier.ProofType.TEE), l1OriginHash, l1OriginNumber, rootClaim.raw());
+        bytes memory proofBytes = _teeProof(l1OriginHash, l1OriginNumber, rootClaim);
 
-        vm.expectRevert(abi.encodeWithSelector(AggregateVerifier.L1OriginTooOld.selector, l1OriginNumber, block.number));
-        _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proofBytes
+        _expectCreateGameRevertsForTeeProof(
+            rootClaim,
+            proofBytes,
+            abi.encodeWithSelector(AggregateVerifier.L1OriginTooOld.selector, l1OriginNumber, block.number)
         );
     }
 
     function testVerifyFailsWithL1OriginHashMismatch() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
+        Claim rootClaim = _advanceL2BlockAndClaim();
         uint256 l1OriginNumber = block.number - 1;
-        bytes32 wrongHash = bytes32(uint256(0xdeadbeef)); // Wrong hash
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
+        bytes32 wrongHash = bytes32(uint256(0xdeadbeef));
 
-        bytes memory proofBytes =
-            abi.encodePacked(uint8(AggregateVerifier.ProofType.TEE), wrongHash, l1OriginNumber, rootClaim.raw());
+        bytes memory proofBytes = _teeProof(wrongHash, l1OriginNumber, rootClaim);
 
         bytes32 actualHash = blockhash(l1OriginNumber);
-        vm.expectRevert(abi.encodeWithSelector(AggregateVerifier.L1OriginHashMismatch.selector, wrongHash, actualHash));
-        _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proofBytes
+        _expectCreateGameRevertsForTeeProof(
+            rootClaim,
+            proofBytes,
+            abi.encodeWithSelector(AggregateVerifier.L1OriginHashMismatch.selector, wrongHash, actualHash)
         );
     }
 
     function testVerifyWithBlockhashWindow() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
+        Claim rootClaim = _advanceL2BlockAndClaim();
 
-        // Test verification within the 256 block window
         vm.roll(block.number + 100);
 
-        // Use a block that's within the 256 block window
         uint256 l1OriginNumber = block.number - 50;
         bytes32 l1OriginHash = blockhash(l1OriginNumber);
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
 
-        bytes memory proofBytes =
-            abi.encodePacked(uint8(AggregateVerifier.ProofType.TEE), l1OriginHash, l1OriginNumber, rootClaim.raw());
+        bytes memory proofBytes = _teeProof(l1OriginHash, l1OriginNumber, rootClaim);
 
         _createAggregateVerifierGame(
             TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proofBytes
@@ -335,25 +242,16 @@ contract AggregateVerifierTest is BaseTest {
     }
 
     function testVerifyWithEIP2935Window() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
+        Claim rootClaim = _advanceL2BlockAndClaim();
 
-        // Roll forward past the 256 blockhash window
         vm.roll(block.number + 300);
 
-        // Use a block that's outside blockhash window but within EIP-2935 window
-        uint256 l1OriginNumber = block.number - 260; // 260 > 256, so blockhash() returns 0
+        uint256 l1OriginNumber = block.number - 260;
         bytes32 expectedHash = keccak256(abi.encodePacked("mock-blockhash", l1OriginNumber));
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
 
-        // Mock the EIP-2935 contract response
-        vm.mockCall(
-            0x0000F90827F1C53a10cb7A02335B175320002935, // EIP-2935 contract address
-            abi.encode(l1OriginNumber), // raw 32-byte calldata
-            abi.encode(expectedHash) // returns the blockhash
-        );
+        vm.mockCall(aggregateVerifierImpl.EIP2935_CONTRACT(), abi.encode(l1OriginNumber), abi.encode(expectedHash));
 
-        bytes memory proofBytes =
-            abi.encodePacked(uint8(AggregateVerifier.ProofType.TEE), expectedHash, l1OriginNumber, rootClaim.raw());
+        bytes memory proofBytes = _teeProof(expectedHash, l1OriginNumber, rootClaim);
 
         _createAggregateVerifierGame(
             TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proofBytes
@@ -361,43 +259,154 @@ contract AggregateVerifierTest is BaseTest {
     }
 
     function testDeployWithInvalidBlockIntervals() public {
-        // Case 1: BLOCK_INTERVAL is 0
+        _expectDeployWithInvalidBlockIntervalsReverts(0, INTERMEDIATE_BLOCK_INTERVAL);
+        _expectDeployWithInvalidBlockIntervalsReverts(BLOCK_INTERVAL, 0);
+        _expectDeployWithInvalidBlockIntervalsReverts(3, 2);
+    }
+
+    function _advanceL2BlockAndClaim() private returns (Claim rootClaim) {
+        currentL2BlockNumber += BLOCK_INTERVAL;
+        return Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
+    }
+
+    function _createAndAssertInitializedGame(
+        bytes memory proofSalt,
+        AggregateVerifier.ProofType proofType,
+        address prover,
+        address expectedTeeProver,
+        address expectedZkProver
+    )
+        private
+    {
+        Claim rootClaim = _advanceL2BlockAndClaim();
+        bytes memory proof = _generateProof(proofSalt, proofType);
+
+        AggregateVerifier game = _createAggregateVerifierGame(
+            prover, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proof
+        );
+
+        _assertInitializedGame(game, rootClaim, prover, expectedTeeProver, expectedZkProver);
+    }
+
+    function _assertInitializedGame(
+        AggregateVerifier game,
+        Claim rootClaim,
+        address expectedCreator,
+        address expectedTeeProver,
+        address expectedZkProver
+    )
+        private
+        view
+    {
+        assertTrue(game.wasRespectedGameTypeWhenCreated());
+        assertEq(game.teeProver(), expectedTeeProver);
+        assertEq(game.zkProver(), expectedZkProver);
+        _assertStatus(game, GameStatus.IN_PROGRESS);
+        assertEq(game.l2SequenceNumber(), currentL2BlockNumber);
+        assertEq(game.rootClaim().raw(), rootClaim.raw());
+        assertEq(game.parentAddress(), address(anchorStateRegistry));
+        assertEq(game.gameType().raw(), AGGREGATE_VERIFIER_GAME_TYPE.raw());
+        assertEq(game.gameCreator(), expectedCreator);
+        bytes memory intermediateOutputRoots = game.intermediateOutputRoots();
+        assertEq(
+            game.extraData(),
+            abi.encodePacked(currentL2BlockNumber, address(anchorStateRegistry), intermediateOutputRoots)
+        );
+        assertEq(game.bondRecipient(), expectedCreator);
+        assertTrue(anchorStateRegistry.isGameProper(IDisputeGame(address(game))));
+        assertEq(delayedWETH.balanceOf(address(game)), INIT_BOND);
+        assertEq(game.proofCount(), 1);
+    }
+
+    function _assertStatus(AggregateVerifier game, GameStatus expectedStatus) private view {
+        assertEq(uint8(game.status()), uint8(expectedStatus));
+    }
+
+    function _assertAnchorRoot(Claim rootClaim) private view {
+        (Hash root, uint256 l2SequenceNumber) = anchorStateRegistry.getAnchorRoot();
+        assertEq(root.raw(), rootClaim.raw());
+        assertEq(l2SequenceNumber, currentL2BlockNumber);
+    }
+
+    function _claimCreditAfterDelay(AggregateVerifier game) private {
+        uint256 balanceBefore = game.gameCreator().balance;
+        game.claimCredit();
+        vm.warp(block.timestamp + DELAYED_WETH_DELAY);
+        game.claimCredit();
+        assertEq(game.gameCreator().balance, balanceBefore + INIT_BOND);
+        assertEq(delayedWETH.balanceOf(address(game)), 0);
+    }
+
+    function _expectCreateGameRevertsForTeeProof(
+        Claim rootClaim,
+        bytes memory proofBytes,
+        bytes memory revertData
+    )
+        private
+    {
+        vm.expectRevert(revertData);
+        _createAggregateVerifierGame(
+            TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proofBytes
+        );
+    }
+
+    function _teeProof(
+        bytes32 l1OriginHash,
+        uint256 l1OriginNumber,
+        Claim rootClaim
+    )
+        private
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(uint8(AggregateVerifier.ProofType.TEE), l1OriginHash, l1OriginNumber, rootClaim.raw());
+    }
+
+    function _expectDeployWithInvalidBlockIntervalsReverts(
+        uint256 blockInterval,
+        uint256 intermediateBlockInterval
+    )
+        private
+    {
         vm.expectRevert(
-            abi.encodeWithSelector(AggregateVerifier.InvalidBlockInterval.selector, 0, INTERMEDIATE_BLOCK_INTERVAL)
+            abi.encodeWithSelector(
+                AggregateVerifier.InvalidBlockInterval.selector, blockInterval, intermediateBlockInterval
+            )
         );
-        new AggregateVerifier(
-            AGGREGATE_VERIFIER_GAME_TYPE,
-            IAnchorStateRegistry(address(anchorStateRegistry)),
-            IDelayedWETH(payable(address(delayedWETH))),
-            IVerifier(address(teeVerifier)),
-            IVerifier(address(zkVerifier)),
-            TEE_IMAGE_HASH,
-            AggregateVerifier.ZkHashes(ZK_RANGE_HASH, ZK_AGGREGATE_HASH),
-            CONFIG_HASH,
-            L2_CHAIN_ID,
-            0,
-            INTERMEDIATE_BLOCK_INTERVAL
-        );
+        _deployAggregateVerifierWithIntervals(blockInterval, intermediateBlockInterval);
+    }
 
-        // Case 2: INTERMEDIATE_BLOCK_INTERVAL is 0
-        vm.expectRevert(abi.encodeWithSelector(AggregateVerifier.InvalidBlockInterval.selector, BLOCK_INTERVAL, 0));
-        new AggregateVerifier(
-            AGGREGATE_VERIFIER_GAME_TYPE,
-            IAnchorStateRegistry(address(anchorStateRegistry)),
-            IDelayedWETH(payable(address(delayedWETH))),
-            IVerifier(address(teeVerifier)),
-            IVerifier(address(zkVerifier)),
-            TEE_IMAGE_HASH,
-            AggregateVerifier.ZkHashes(ZK_RANGE_HASH, ZK_AGGREGATE_HASH),
-            CONFIG_HASH,
-            L2_CHAIN_ID,
-            BLOCK_INTERVAL,
-            0
-        );
+    /// @notice Clones the implementation like the factory, but skips `_finalizeGameCreation`.
+    function _deployAggregateVerifierCloneWithoutFactoryRegistration(
+        address creator,
+        Claim rootClaim,
+        uint256 l2BlockNumber,
+        address parentAddress,
+        bytes memory proof
+    )
+        private
+        returns (AggregateVerifier)
+    {
+        IDisputeGame impl = factory.gameImpls(AGGREGATE_VERIFIER_GAME_TYPE);
+        bytes memory extraData = _aggregateVerifierExtraData(rootClaim, l2BlockNumber, parentAddress);
+        bytes32 l1Head = blockhash(block.number - 1);
+        address clone = address(impl).clone(abi.encodePacked(creator, rootClaim, l1Head, extraData));
 
-        // Case 3: BLOCK_INTERVAL is not divisible by INTERMEDIATE_BLOCK_INTERVAL
-        vm.expectRevert(abi.encodeWithSelector(AggregateVerifier.InvalidBlockInterval.selector, 3, 2));
-        new AggregateVerifier(
+        vm.deal(creator, INIT_BOND);
+        vm.prank(creator);
+        AggregateVerifier(payable(clone)).initializeWithInitData{ value: INIT_BOND }(proof);
+
+        return AggregateVerifier(payable(clone));
+    }
+
+    function _deployAggregateVerifierWithIntervals(
+        uint256 blockInterval,
+        uint256 intermediateBlockInterval
+    )
+        private
+        returns (AggregateVerifier)
+    {
+        return new AggregateVerifier(
             AGGREGATE_VERIFIER_GAME_TYPE,
             IAnchorStateRegistry(address(anchorStateRegistry)),
             IDelayedWETH(payable(address(delayedWETH))),
@@ -407,8 +416,8 @@ contract AggregateVerifierTest is BaseTest {
             AggregateVerifier.ZkHashes(ZK_RANGE_HASH, ZK_AGGREGATE_HASH),
             CONFIG_HASH,
             L2_CHAIN_ID,
-            3,
-            2
+            blockInterval,
+            intermediateBlockInterval
         );
     }
 }

--- a/test/L1/proofs/AggregateVerifier.t.sol
+++ b/test/L1/proofs/AggregateVerifier.t.sol
@@ -6,7 +6,7 @@ import { IAnchorStateRegistry } from "interfaces/L1/proofs/IAnchorStateRegistry.
 import { IDelayedWETH } from "interfaces/L1/proofs/IDelayedWETH.sol";
 import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
 import { IDisputeGameFactory } from "interfaces/L1/proofs/IDisputeGameFactory.sol";
-import { GameStatus, Hash } from "src/libraries/bridge/Types.sol";
+import { GameStatus, GameTypes, Hash } from "src/libraries/bridge/Types.sol";
 import { Claim, Timestamp } from "src/libraries/bridge/LibUDT.sol";
 
 import { AggregateVerifier } from "src/L1/proofs/AggregateVerifier.sol";
@@ -23,7 +23,7 @@ contract AggregateVerifierTest is BaseTest {
 
     function setUp() public override {
         super.setUp();
-        aggregateVerifierImpl = AggregateVerifier(address(factory.gameImpls(AGGREGATE_VERIFIER_GAME_TYPE)));
+        aggregateVerifierImpl = AggregateVerifier(address(factory.gameImpls(GameTypes.AGGREGATE_VERIFIER)));
     }
 
     function testInitializeWithTEEProof() public {
@@ -45,7 +45,7 @@ contract AggregateVerifierTest is BaseTest {
 
         vm.prank(TEE_PROVER);
         vm.expectRevert(BadExtraData.selector);
-        factory.createWithInitData{ value: INIT_BOND }(AGGREGATE_VERIFIER_GAME_TYPE, rootClaim, extraData, initData);
+        factory.createWithInitData{ value: INIT_BOND }(GameTypes.AGGREGATE_VERIFIER, rootClaim, extraData, initData);
     }
 
     function testUpdatingAnchorStateRegistryWithTEEProof() public {
@@ -146,7 +146,7 @@ contract AggregateVerifierTest is BaseTest {
             TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), teeProof
         );
 
-        Hash gameId = factory.getGameUUID(AGGREGATE_VERIFIER_GAME_TYPE, rootClaim, game.extraData());
+        Hash gameId = factory.getGameUUID(GameTypes.AGGREGATE_VERIFIER, rootClaim, game.extraData());
         vm.expectRevert(abi.encodeWithSelector(IDisputeGameFactory.GameAlreadyExists.selector, gameId));
         _createAggregateVerifierGame(ZK_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), zkProof);
     }
@@ -305,7 +305,7 @@ contract AggregateVerifierTest is BaseTest {
         assertEq(game.l2SequenceNumber(), currentL2BlockNumber);
         assertEq(game.rootClaim().raw(), rootClaim.raw());
         assertEq(game.parentAddress(), address(anchorStateRegistry));
-        assertEq(game.gameType().raw(), AGGREGATE_VERIFIER_GAME_TYPE.raw());
+        assertEq(game.gameType().raw(), GameTypes.AGGREGATE_VERIFIER.raw());
         assertEq(game.gameCreator(), expectedCreator);
         bytes memory intermediateOutputRoots = game.intermediateOutputRoots();
         assertEq(
@@ -387,7 +387,7 @@ contract AggregateVerifierTest is BaseTest {
         private
         returns (AggregateVerifier)
     {
-        IDisputeGame impl = factory.gameImpls(AGGREGATE_VERIFIER_GAME_TYPE);
+        IDisputeGame impl = factory.gameImpls(GameTypes.AGGREGATE_VERIFIER);
         bytes memory extraData = _aggregateVerifierExtraData(rootClaim, l2BlockNumber, parentAddress);
         bytes32 l1Head = blockhash(block.number - 1);
         address clone = address(impl).clone(abi.encodePacked(creator, rootClaim, l1Head, extraData));
@@ -407,7 +407,7 @@ contract AggregateVerifierTest is BaseTest {
         returns (AggregateVerifier)
     {
         return new AggregateVerifier(
-            AGGREGATE_VERIFIER_GAME_TYPE,
+            GameTypes.AGGREGATE_VERIFIER,
             IAnchorStateRegistry(address(anchorStateRegistry)),
             IDelayedWETH(payable(address(delayedWETH))),
             IVerifier(address(teeVerifier)),

--- a/test/L1/proofs/AnchorStateRegistry.t.sol
+++ b/test/L1/proofs/AnchorStateRegistry.t.sol
@@ -22,6 +22,10 @@ import { AggregateVerifier } from "src/L1/proofs/AggregateVerifier.sol";
 /// @title AnchorStateRegistry_TestInit
 /// @notice Reusable test initialization for `AnchorStateRegistry` tests.
 abstract contract AnchorStateRegistry_TestInit is BaseTest {
+    string internal constant ANCHOR_STATE_REGISTRY_NAME = "AnchorStateRegistry";
+    bytes32 internal constant DUMMY_STARTING_ANCHOR_ROOT =
+        0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF;
+
     IDisputeGameFactory disputeGameFactory;
     ISuperchainConfig superchainConfig;
     IDisputeGame gameProxy;
@@ -58,10 +62,117 @@ abstract contract AnchorStateRegistry_TestInit is BaseTest {
         );
     }
 
-    function skipIfForkTest(string memory) public pure { }
-
     function _setPaused(bool _paused) internal {
         vm.mockCall(address(systemConfig), abi.encodeCall(systemConfig.paused, ()), abi.encode(_paused));
+    }
+
+    function _mockGameStatus(GameStatus _status) internal {
+        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(_status));
+    }
+
+    function _mockGameResolvedAt(uint256 _timestamp) internal {
+        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(_timestamp));
+    }
+
+    function _mockGamePastFinalityWithStatus(GameStatus _status) internal {
+        _mockGameResolvedAt(block.timestamp);
+        _warpByFinalityDelay();
+        vm.warp(block.timestamp + 1);
+        _mockGameStatus(_status);
+    }
+
+    function _warpByFinalityDelay() internal returns (uint256 finalityDelay_) {
+        finalityDelay_ = anchorStateRegistry.disputeGameFinalityDelaySeconds();
+        vm.warp(block.timestamp + finalityDelay_);
+    }
+
+    function _mockGameWasRespected(bool _wasRespected) internal {
+        vm.mockCall(
+            address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(_wasRespected)
+        );
+    }
+
+    function _mockGameNotRegistered() internal {
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(
+                disputeGameFactory.games, (gameProxy.gameType(), gameProxy.rootClaim(), gameProxy.extraData())
+            ),
+            abi.encode(address(0), 0)
+        );
+    }
+
+    function _initializeWithDummyStartingAnchorRoot() internal {
+        anchorStateRegistry.initialize(
+            systemConfig,
+            disputeGameFactory,
+            Proposal({ root: Hash.wrap(DUMMY_STARTING_ANCHOR_ROOT), l2SequenceNumber: 0 }),
+            GameType.wrap(0)
+        );
+    }
+
+    function _assumeNotGuardian(address _caller) internal view {
+        vm.assume(_caller != superchainConfig.guardian());
+    }
+
+    function _expectUnauthorizedGuardianRevert(address _caller) internal {
+        _assumeNotGuardian(_caller);
+        vm.prank(_caller);
+        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_Unauthorized.selector);
+    }
+
+    function _updateRetirementTimestampAsGuardian() internal {
+        vm.prank(superchainConfig.guardian());
+        anchorStateRegistry.updateRetirementTimestamp();
+    }
+
+    function _blacklistDisputeGameAsGuardian(IDisputeGame _game) internal {
+        vm.prank(superchainConfig.guardian());
+        anchorStateRegistry.blacklistDisputeGame(_game);
+    }
+
+    function _mockGameCreatedAt(uint64 _createdAtTimestamp) internal {
+        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.createdAt, ()), abi.encode(_createdAtTimestamp));
+    }
+
+    function _mockRetiredGame(uint64 _createdAtTimestamp) internal returns (uint64) {
+        _updateRetirementTimestampAsGuardian();
+        uint64 createdAtTimestamp = uint64(bound(_createdAtTimestamp, 0, anchorStateRegistry.retirementTimestamp()));
+        _mockGameCreatedAt(createdAtTimestamp);
+        return createdAtTimestamp;
+    }
+
+    function _mockGameL2SequenceNumber(uint256 _l2BlockNumber) internal {
+        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(_l2BlockNumber));
+    }
+
+    function _expectSetAnchorStateInvalid(IDisputeGame _game, address _caller) internal {
+        vm.prank(_caller);
+        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_InvalidAnchorGame.selector);
+        anchorStateRegistry.setAnchorState(_game);
+    }
+
+    function _setAnchorStateToGameProxy() internal {
+        _mockGamePastFinalityWithStatus(GameStatus.DEFENDER_WINS);
+        anchorStateRegistry.setAnchorState(gameProxy);
+    }
+
+    function _assertAnchorRootEqGame(IDisputeGame _game) internal view {
+        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
+        assertEq(root.raw(), _game.rootClaim().raw());
+        assertEq(l2BlockNumber, _game.l2SequenceNumber());
+    }
+
+    function _assertCurrentAnchorRootEq(Hash _root, uint256 _l2BlockNumber) internal view {
+        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.getAnchorRoot();
+        assertEq(updatedL2BlockNumber, _l2BlockNumber);
+        assertEq(updatedRoot.raw(), _root.raw());
+    }
+
+    function _assertAnchorEq(GameType _gameType, Hash _root, uint256 _l2BlockNumber) internal view {
+        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.anchors(_gameType);
+        assertEq(updatedL2BlockNumber, _l2BlockNumber);
+        assertEq(updatedRoot.raw(), _root.raw());
     }
 }
 
@@ -77,50 +188,49 @@ contract AnchorStateRegistry_Version_Test is AnchorStateRegistry_TestInit {
 /// @title AnchorStateRegistry_Initialize_Test
 /// @notice Tests the `initialize` function of the `AnchorStateRegistry` contract.
 contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
+    StorageSlot internal initializedSlot;
+    StorageSlot internal retirementTimestampSlot;
+
+    function setUp() public override {
+        super.setUp();
+
+        initializedSlot = ForgeArtifacts.getSlot(ANCHOR_STATE_REGISTRY_NAME, "_initialized");
+        retirementTimestampSlot = ForgeArtifacts.getSlot(ANCHOR_STATE_REGISTRY_NAME, "retirementTimestamp");
+    }
+
     /// @notice Tests that initialization is successful.
     function test_initialize_succeeds() public view {
-        skipIfForkTest("State has changed since initialization on a forked network.");
-
         // Verify starting anchor root.
         (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
         assertEq(root.raw(), keccak256(abi.encode(uint256(0))));
         assertEq(l2BlockNumber, 0);
 
         // Verify contract addresses.
-        assert(anchorStateRegistry.systemConfig() == systemConfig);
-        assert(anchorStateRegistry.disputeGameFactory() == disputeGameFactory);
-        assert(anchorStateRegistry.superchainConfig() == superchainConfig);
+        assertEq(address(anchorStateRegistry.systemConfig()), address(systemConfig));
+        assertEq(address(anchorStateRegistry.disputeGameFactory()), address(disputeGameFactory));
+        assertEq(address(anchorStateRegistry.superchainConfig()), address(superchainConfig));
     }
 
     /// @notice Tests that the initializer value is correct. Trivial test for normal
     ///         initialization but confirms that the initValue is not incremented incorrectly if
     ///         an upgrade function is not present.
     function test_initialize_correctInitializerValue_succeeds() public view {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("AnchorStateRegistry", "_initialized");
-
-        // Get the initializer value.
-        bytes32 slotVal = vm.load(address(anchorStateRegistry), bytes32(slot.slot));
+        bytes32 slotVal = vm.load(address(anchorStateRegistry), bytes32(initializedSlot.slot));
         uint8 val = uint8(uint256(slotVal) & 0xFF);
 
-        // Assert that the initializer value matches the expected value.
         assertEq(val, anchorStateRegistry.initVersion());
     }
 
     /// @notice Tests that the retirement timestamp is set on the first initialization.
     function test_initialize_setsRetirementTimestamp_succeeds() public {
-        skipIfForkTest("State has changed since initialization on a forked network.");
-
         (Hash root, uint256 l2SequenceNumber) = anchorStateRegistry.getAnchorRoot();
         GameType startingGameType = anchorStateRegistry.respectedGameType();
 
-        StorageSlot memory initSlot = ForgeArtifacts.getSlot("AnchorStateRegistry", "_initialized");
-        StorageSlot memory retirementSlot = ForgeArtifacts.getSlot("AnchorStateRegistry", "retirementTimestamp");
         address proxyAdminOwner = anchorStateRegistry.proxyAdminOwner();
 
         // Reset initialization and retirement timestamp state.
-        vm.store(address(anchorStateRegistry), bytes32(initSlot.slot), bytes32(0));
-        vm.store(address(anchorStateRegistry), bytes32(retirementSlot.slot), bytes32(0));
+        vm.store(address(anchorStateRegistry), bytes32(initializedSlot.slot), bytes32(0));
+        vm.store(address(anchorStateRegistry), bytes32(retirementTimestampSlot.slot), bytes32(0));
 
         uint256 newTimestamp = block.timestamp + 100;
         vm.warp(newTimestamp);
@@ -139,24 +249,20 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
 
     /// @notice Tests that the retirement timestamp is unchanged during re-initialization.
     function test_initialize_reinitializationDoesNotChangeRetirementTimestamp_succeeds() public {
-        skipIfForkTest("State has changed since initialization on a forked network.");
-
         (Hash root, uint256 l2SequenceNumber) = anchorStateRegistry.getAnchorRoot();
         GameType startingGameType = anchorStateRegistry.respectedGameType();
 
-        StorageSlot memory initSlot = ForgeArtifacts.getSlot("AnchorStateRegistry", "_initialized");
         address proxyAdminOwner = anchorStateRegistry.proxyAdminOwner();
 
         uint256 initialTimestamp = block.timestamp + 200;
         vm.warp(initialTimestamp);
-        vm.prank(superchainConfig.guardian());
-        anchorStateRegistry.updateRetirementTimestamp();
+        _updateRetirementTimestampAsGuardian();
         uint64 originalTimestamp = anchorStateRegistry.retirementTimestamp();
 
         uint256 reinitTimestamp = block.timestamp + 200;
         vm.warp(reinitTimestamp);
 
-        vm.store(address(anchorStateRegistry), bytes32(initSlot.slot), bytes32(0));
+        vm.store(address(anchorStateRegistry), bytes32(initializedSlot.slot), bytes32(0));
 
         vm.prank(proxyAdminOwner);
         anchorStateRegistry.initialize(
@@ -172,14 +278,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
     /// @notice Tests that initialization cannot be done twice
     function test_initialize_twice_reverts() public {
         vm.expectRevert("Initializable: contract is already initialized");
-        anchorStateRegistry.initialize(
-            systemConfig,
-            disputeGameFactory,
-            Proposal({
-                root: Hash.wrap(0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF), l2SequenceNumber: 0
-            }),
-            GameType.wrap(0)
-        );
+        _initializeWithDummyStartingAnchorRoot();
     }
 
     /// @notice Tests that initialization reverts if called by a non-proxy admin or owner.
@@ -190,25 +289,15 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
             _sender != address(anchorStateRegistry.proxyAdmin()) && _sender != anchorStateRegistry.proxyAdminOwner()
         );
 
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("AnchorStateRegistry", "_initialized");
-
         // Set the initialized slot to 0.
-        vm.store(address(anchorStateRegistry), bytes32(slot.slot), bytes32(0));
+        vm.store(address(anchorStateRegistry), bytes32(initializedSlot.slot), bytes32(0));
 
         // Expect the revert with `ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner` selector.
         vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
 
         // Call the `initialize` function with the sender
         vm.prank(_sender);
-        anchorStateRegistry.initialize(
-            systemConfig,
-            disputeGameFactory,
-            Proposal({
-                root: Hash.wrap(0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF), l2SequenceNumber: 0
-            }),
-            GameType.wrap(0)
-        );
+        _initializeWithDummyStartingAnchorRoot();
     }
 }
 
@@ -251,12 +340,7 @@ contract AnchorStateRegistry_SetRespectedGameType_Test is AnchorStateRegistry_Te
     /// @param _gameType The game type to attempt to set
     /// @param _caller The address attempting to call the function
     function testFuzz_setRespectedGameType_notGuardian_reverts(GameType _gameType, address _caller) public {
-        // Ensure caller is not the guardian
-        vm.assume(_caller != superchainConfig.guardian());
-
-        // Attempt to call as non-guardian
-        vm.prank(_caller);
-        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_Unauthorized.selector);
+        _expectUnauthorizedGuardianRevert(_caller);
         anchorStateRegistry.setRespectedGameType(_gameType);
     }
 }
@@ -266,11 +350,9 @@ contract AnchorStateRegistry_SetRespectedGameType_Test is AnchorStateRegistry_Te
 contract AnchorStateRegistry_UpdateRetirementTimestamp_Test is AnchorStateRegistry_TestInit {
     /// @notice Tests that updateRetirementTimestamp succeeds when called by the guardian
     function test_updateRetirementTimestamp_succeeds() public {
-        // Call as guardian
-        vm.prank(superchainConfig.guardian());
         vm.expectEmit(address(anchorStateRegistry));
         emit RetirementTimestampSet(block.timestamp);
-        anchorStateRegistry.updateRetirementTimestamp();
+        _updateRetirementTimestampAsGuardian();
 
         // Verify the timestamp was set
         assertEq(anchorStateRegistry.retirementTimestamp(), block.timestamp);
@@ -278,32 +360,25 @@ contract AnchorStateRegistry_UpdateRetirementTimestamp_Test is AnchorStateRegist
 
     /// @notice Tests that updateRetirementTimestamp can be called multiple times by the guardian
     function test_updateRetirementTimestamp_multipleUpdates_succeeds() public {
-        // First update
-        vm.prank(superchainConfig.guardian());
-        anchorStateRegistry.updateRetirementTimestamp();
+        _updateRetirementTimestampAsGuardian();
         uint64 firstTimestamp = anchorStateRegistry.retirementTimestamp();
 
         // Warp forward and update again
         vm.warp(block.timestamp + 1000);
-        vm.prank(superchainConfig.guardian());
         vm.expectEmit(address(anchorStateRegistry));
         emit RetirementTimestampSet(block.timestamp);
-        anchorStateRegistry.updateRetirementTimestamp();
+        _updateRetirementTimestampAsGuardian();
 
         // Verify the timestamp was updated
-        assertEq(anchorStateRegistry.retirementTimestamp(), block.timestamp);
-        assertGt(anchorStateRegistry.retirementTimestamp(), firstTimestamp);
+        uint64 secondTimestamp = anchorStateRegistry.retirementTimestamp();
+        assertEq(secondTimestamp, block.timestamp);
+        assertGt(secondTimestamp, firstTimestamp);
     }
 
     /// @notice Tests that updateRetirementTimestamp reverts when not called by the guardian
     /// @param _caller The address attempting to call the function
     function testFuzz_updateRetirementTimestamp_notGuardian_reverts(address _caller) public {
-        // Ensure caller is not the guardian
-        vm.assume(_caller != superchainConfig.guardian());
-
-        // Attempt to call as non-guardian
-        vm.prank(_caller);
-        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_Unauthorized.selector);
+        _expectUnauthorizedGuardianRevert(_caller);
         anchorStateRegistry.updateRetirementTimestamp();
     }
 }
@@ -313,11 +388,9 @@ contract AnchorStateRegistry_UpdateRetirementTimestamp_Test is AnchorStateRegist
 contract AnchorStateRegistry_BlacklistDisputeGame_Test is AnchorStateRegistry_TestInit {
     /// @notice Tests that blacklistDisputeGame succeeds when called by the guardian
     function test_blacklistDisputeGame_succeeds() public {
-        // Call as guardian
-        vm.prank(superchainConfig.guardian());
         vm.expectEmit(address(anchorStateRegistry));
         emit DisputeGameBlacklisted(gameProxy);
-        anchorStateRegistry.blacklistDisputeGame(gameProxy);
+        _blacklistDisputeGameAsGuardian(gameProxy);
 
         // Verify the game was blacklisted
         assertTrue(anchorStateRegistry.disputeGameBlacklist(gameProxy));
@@ -326,7 +399,7 @@ contract AnchorStateRegistry_BlacklistDisputeGame_Test is AnchorStateRegistry_Te
     /// @notice Tests that multiple games can be blacklisted
     function test_blacklistDisputeGame_multipleGames_succeeds() public {
         // Create a second game proxy
-        IDisputeGame secondGame = IDisputeGame(address(0x123));
+        IDisputeGame secondGame = IDisputeGame(makeAddr("second-game"));
 
         // Blacklist both games
         vm.startPrank(superchainConfig.guardian());
@@ -342,12 +415,7 @@ contract AnchorStateRegistry_BlacklistDisputeGame_Test is AnchorStateRegistry_Te
     /// @notice Tests that blacklistDisputeGame reverts when not called by the guardian
     /// @param _caller The address attempting to call the function
     function testFuzz_blacklistDisputeGame_notGuardian_reverts(address _caller) public {
-        // Ensure caller is not the guardian
-        vm.assume(_caller != superchainConfig.guardian());
-
-        // Attempt to call as non-guardian
-        vm.prank(_caller);
-        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_Unauthorized.selector);
+        _expectUnauthorizedGuardianRevert(_caller);
         anchorStateRegistry.blacklistDisputeGame(gameProxy);
     }
 
@@ -393,10 +461,7 @@ contract AnchorStateRegistry_GetAnchorRoot_Test is AnchorStateRegistry_TestInit 
     /// @notice Tests that getAnchorRoot will return the value of the starting anchor root when no
     ///         anchor game exists yet.
     function test_getAnchorRoot_noAnchorGame_succeeds() public view {
-        skipIfForkTest("On a forked network, there would most likely be an anchor game already.");
-
-        // Assert that we nave no anchor game yet.
-        assert(address(anchorStateRegistry.anchorGame()) == address(0));
+        assertEq(address(anchorStateRegistry.anchorGame()), address(0));
 
         // We should get the starting anchor root back.
         (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
@@ -406,64 +471,29 @@ contract AnchorStateRegistry_GetAnchorRoot_Test is AnchorStateRegistry_TestInit 
 
     /// @notice Tests that getAnchorRoot will return the correct anchor root if an anchor game exists.
     function test_getAnchorRoot_anchorGameExists_succeeds() public {
-        // Mock the game to be resolved.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds() + 1);
-
-        // Mock the game to be the defender wins.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
-
-        // Set the anchor game to the game proxy.
-        anchorStateRegistry.setAnchorState(gameProxy);
-
-        // We should get the anchor root back.
-        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
-        assertEq(root.raw(), gameProxy.rootClaim().raw());
-        assertEq(l2BlockNumber, gameProxy.l2SequenceNumber());
+        _setAnchorStateToGameProxy();
+        _assertAnchorRootEqGame(gameProxy);
     }
 
     /// @notice Tests that getAnchorRoot will return the latest anchor root even if the superchain
     ///         is paused.
     function test_getAnchorRoot_superchainPaused_succeeds() public {
-        // Mock the game to be resolved.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds() + 1);
-
-        // Mock the game to be the defender wins.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
-
-        // Set the anchor game to the game proxy.
-        anchorStateRegistry.setAnchorState(gameProxy);
+        _setAnchorStateToGameProxy();
 
         // Pause the superchain.
         _setPaused(true);
 
-        // We should get the anchor root back.
-        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
-        assertEq(root.raw(), gameProxy.rootClaim().raw());
-        assertEq(l2BlockNumber, gameProxy.l2SequenceNumber());
+        _assertAnchorRootEqGame(gameProxy);
     }
 
     /// @notice Tests that getAnchorRoot returns even if the anchor game is blacklisted.
     function test_getAnchorRoot_blacklistedGame_succeeds() public {
-        // Mock the game to be resolved.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds() + 1);
-
-        // Mock the game to be the defender wins.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
-
-        // Set the anchor game to the game proxy.
-        anchorStateRegistry.setAnchorState(gameProxy);
+        _setAnchorStateToGameProxy();
 
         // Blacklist the game.
-        vm.prank(superchainConfig.guardian());
-        anchorStateRegistry.blacklistDisputeGame(gameProxy);
+        _blacklistDisputeGameAsGuardian(gameProxy);
 
-        // Get the anchor root.
-        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
-        assertEq(root.raw(), gameProxy.rootClaim().raw());
-        assertEq(l2BlockNumber, gameProxy.l2SequenceNumber());
+        _assertAnchorRootEqGame(gameProxy);
     }
 }
 
@@ -473,44 +503,32 @@ contract AnchorStateRegistry_GetStartingAnchorRoot_Test is AnchorStateRegistry_T
     /// @notice Tests that getStartingAnchorRoot remains unchanged even if the current anchor root
     ///         changes.
     function test_getStartingAnchorRoot_afterUpdate_succeeds() public {
-        // Mock the game to be resolved.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds() + 1);
-
-        // Mock the game to be the defender wins.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
+        _mockGamePastFinalityWithStatus(GameStatus.DEFENDER_WINS);
+        uint256 expectedL2BlockNumber = validL2BlockNumber + 1;
+        Claim expectedRoot = Claim.wrap(keccak256(abi.encode(123)));
+        Proposal memory startingAnchorRootBeforeUpdate = anchorStateRegistry.getStartingAnchorRoot();
 
         // Mock the game's L2 block number to be greater than the starting anchor root block number.
-        vm.mockCall(
-            address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(validL2BlockNumber + 1)
-        );
+        _mockGameL2SequenceNumber(expectedL2BlockNumber);
 
         // Mock the game's anchor root to be different from the starting anchor root.
-        vm.mockCall(
-            address(gameProxy),
-            abi.encodeCall(gameProxy.rootClaim, ()),
-            abi.encode(Claim.wrap(keccak256(abi.encode(123))))
-        );
+        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.rootClaim, ()), abi.encode(expectedRoot));
 
         // Set the anchor game to the game proxy.
         anchorStateRegistry.setAnchorState(gameProxy);
 
-        // Grab the value of the starting anchor root before the update.
-        Proposal memory startingAnchorRootBeforeUpdate = anchorStateRegistry.getStartingAnchorRoot();
-
         // Verify the CURRENT anchor root has changed.
         (Hash currentRoot, uint256 currentL2BlockNumber) = anchorStateRegistry.getAnchorRoot();
-        assertEq(currentRoot.raw(), gameProxy.rootClaim().raw());
-        assertEq(currentL2BlockNumber, gameProxy.l2SequenceNumber());
+        assertEq(currentRoot.raw(), expectedRoot.raw());
+        assertEq(currentL2BlockNumber, expectedL2BlockNumber);
 
         // Verify the STARTING anchor root has NOT changed.
         Proposal memory startingAnchorRootAfterUpdate = anchorStateRegistry.getStartingAnchorRoot();
         assertEq(startingAnchorRootAfterUpdate.root.raw(), startingAnchorRootBeforeUpdate.root.raw());
         assertEq(startingAnchorRootAfterUpdate.l2SequenceNumber, startingAnchorRootBeforeUpdate.l2SequenceNumber);
 
-        // Explicitly assert they are different (assuming the new game has different values).
-        assertFalse(currentRoot.raw() == startingAnchorRootAfterUpdate.root.raw());
-        assertFalse(currentL2BlockNumber == startingAnchorRootAfterUpdate.l2SequenceNumber);
+        assertNotEq(currentRoot.raw(), startingAnchorRootAfterUpdate.root.raw());
+        assertNotEq(currentL2BlockNumber, startingAnchorRootAfterUpdate.l2SequenceNumber);
     }
 }
 
@@ -524,14 +542,7 @@ contract AnchorStateRegistry_IsGameRegistered_Test is AnchorStateRegistry_TestIn
 
     /// @notice Tests that isGameRegistered will return false if the game is not registered.
     function test_isGameRegistered_isNotFactoryRegistered_succeeds() public {
-        // Mock the DisputeGameFactory to make it seem that the game was not registered.
-        vm.mockCall(
-            address(disputeGameFactory),
-            abi.encodeCall(
-                disputeGameFactory.games, (gameProxy.gameType(), gameProxy.rootClaim(), gameProxy.extraData())
-            ),
-            abi.encode(address(0), 0)
-        );
+        _mockGameNotRegistered();
 
         // Game should not be registered.
         assertFalse(anchorStateRegistry.isGameRegistered(gameProxy));
@@ -560,18 +571,14 @@ contract AnchorStateRegistry_IsGameRespected_Test is AnchorStateRegistry_TestIni
     /// @notice Tests that isGameRespected will return true if the game is of the respected game
     ///         type.
     function test_isGameRespected_isRespected_succeeds() public {
-        // Mock that the game was respected.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(true));
+        _mockGameWasRespected(true);
         assertTrue(anchorStateRegistry.isGameRespected(gameProxy));
     }
 
     /// @notice Tests that isGameRespected will return false if the game is not of the respected
     ///         game type.
     function test_isGameRespected_isNotRespected_succeeds() public {
-        // Mock that the game was not respected.
-        vm.mockCall(
-            address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(false)
-        );
+        _mockGameWasRespected(false);
         assertFalse(anchorStateRegistry.isGameRespected(gameProxy));
     }
 }
@@ -582,21 +589,14 @@ contract AnchorStateRegistry_IsGameBlacklisted_Test is AnchorStateRegistry_TestI
     /// @notice Tests that isGameBlacklisted will return true if the game is blacklisted.
     function test_isGameBlacklisted_isActuallyBlacklisted_succeeds() public {
         // Blacklist the game.
-        vm.prank(superchainConfig.guardian());
-        anchorStateRegistry.blacklistDisputeGame(gameProxy);
+        _blacklistDisputeGameAsGuardian(gameProxy);
 
         // Should return true.
         assertTrue(anchorStateRegistry.isGameBlacklisted(gameProxy));
     }
 
     /// @notice Tests that isGameBlacklisted will return false if the game is not blacklisted.
-    function test_isGameBlacklisted_isNotBlacklisted_succeeds() public {
-        // Mock the disputeGameBlacklist call to return false.
-        vm.mockCall(
-            address(anchorStateRegistry),
-            abi.encodeCall(anchorStateRegistry.disputeGameBlacklist, (gameProxy)),
-            abi.encode(false)
-        );
+    function test_isGameBlacklisted_isNotBlacklisted_succeeds() public view {
         assertFalse(anchorStateRegistry.isGameBlacklisted(gameProxy));
     }
 }
@@ -607,15 +607,7 @@ contract AnchorStateRegistry_IsGameRetired_Test is AnchorStateRegistry_TestInit 
     /// @notice Tests that isGameRetired will return true if the game is retired.
     /// @param _createdAtTimestamp The createdAt timestamp to use for the test.
     function testFuzz_isGameRetired_isRetired_succeeds(uint64 _createdAtTimestamp) public {
-        // Set the retirement timestamp to now.
-        vm.prank(superchainConfig.guardian());
-        anchorStateRegistry.updateRetirementTimestamp();
-
-        // Make sure createdAt timestamp is less than or equal to the retirementTimestamp.
-        _createdAtTimestamp = uint64(bound(_createdAtTimestamp, 0, anchorStateRegistry.retirementTimestamp()));
-
-        // Mock the createdAt call.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.createdAt, ()), abi.encode(_createdAtTimestamp));
+        _mockRetiredGame(_createdAtTimestamp);
 
         // Game should be retired.
         assertTrue(anchorStateRegistry.isGameRetired(gameProxy));
@@ -625,15 +617,14 @@ contract AnchorStateRegistry_IsGameRetired_Test is AnchorStateRegistry_TestInit 
     /// @param _createdAtTimestamp The createdAt timestamp to use for the test.
     function testFuzz_isGameRetired_isNotRetired_succeeds(uint64 _createdAtTimestamp) public {
         // Set the retirement timestamp to now.
-        vm.prank(superchainConfig.guardian());
-        anchorStateRegistry.updateRetirementTimestamp();
+        _updateRetirementTimestampAsGuardian();
 
         // Make sure createdAt timestamp is greater than the retirementTimestamp.
         _createdAtTimestamp =
             uint64(bound(_createdAtTimestamp, anchorStateRegistry.retirementTimestamp() + 1, type(uint64).max));
 
         // Mock the call to createdAt.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.createdAt, ()), abi.encode(_createdAtTimestamp));
+        _mockGameCreatedAt(_createdAtTimestamp);
 
         // Game should not be retired.
         assertFalse(anchorStateRegistry.isGameRetired(gameProxy));
@@ -643,17 +634,16 @@ contract AnchorStateRegistry_IsGameRetired_Test is AnchorStateRegistry_TestInit 
 /// @title AnchorStateRegistry_IsGameResolved_Test
 /// @notice Tests the `isGameResolved` function of the `AnchorStateRegistry` contract.
 contract AnchorStateRegistry_IsGameResolved_Test is AnchorStateRegistry_TestInit {
+    function _mockResolvedGame(uint256 _resolvedAtTimestamp, GameStatus _status) internal {
+        _resolvedAtTimestamp = bound(_resolvedAtTimestamp, 1, block.timestamp);
+        _mockGameResolvedAt(_resolvedAtTimestamp);
+        _mockGameStatus(_status);
+    }
+
     /// @notice Tests that isGameResolved will return true if the game is resolved.
     /// @param _resolvedAtTimestamp The resolvedAt timestamp to use for the test.
     function testFuzz_isGameResolved_challengerWins_succeeds(uint256 _resolvedAtTimestamp) public {
-        // Bound resolvedAt to be less than or equal to current timestamp.
-        _resolvedAtTimestamp = bound(_resolvedAtTimestamp, 1, block.timestamp);
-
-        // Mock the resolvedAt timestamp.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(_resolvedAtTimestamp));
-
-        // Mock the status to be CHALLENGER_WINS.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.CHALLENGER_WINS));
+        _mockResolvedGame(_resolvedAtTimestamp, GameStatus.CHALLENGER_WINS);
 
         // Game should be resolved.
         assertTrue(anchorStateRegistry.isGameResolved(gameProxy));
@@ -662,14 +652,7 @@ contract AnchorStateRegistry_IsGameResolved_Test is AnchorStateRegistry_TestInit
     /// @notice Tests that isGameResolved will return true if the game is resolved.
     /// @param _resolvedAtTimestamp The resolvedAt timestamp to use for the test.
     function testFuzz_isGameResolved_defenderWins_succeeds(uint256 _resolvedAtTimestamp) public {
-        // Bound resolvedAt to be less than or equal to current timestamp.
-        _resolvedAtTimestamp = bound(_resolvedAtTimestamp, 1, block.timestamp);
-
-        // Mock the resolvedAt timestamp.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(_resolvedAtTimestamp));
-
-        // Mock the status to be DEFENDER_WINS.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
+        _mockResolvedGame(_resolvedAtTimestamp, GameStatus.DEFENDER_WINS);
 
         // Game should be resolved.
         assertTrue(anchorStateRegistry.isGameResolved(gameProxy));
@@ -679,14 +662,7 @@ contract AnchorStateRegistry_IsGameResolved_Test is AnchorStateRegistry_TestInit
     ///         resolved.
     /// @param _resolvedAtTimestamp The resolvedAt timestamp to use for the test.
     function testFuzz_isGameResolved_inProgressNotResolved_succeeds(uint256 _resolvedAtTimestamp) public {
-        // Bound resolvedAt to be less than or equal to current timestamp.
-        _resolvedAtTimestamp = bound(_resolvedAtTimestamp, 1, block.timestamp);
-
-        // Mock the resolvedAt timestamp.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(_resolvedAtTimestamp));
-
-        // Mock the status to be IN_PROGRESS.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.IN_PROGRESS));
+        _mockResolvedGame(_resolvedAtTimestamp, GameStatus.IN_PROGRESS);
 
         // Game should not be resolved.
         assertFalse(anchorStateRegistry.isGameResolved(gameProxy));
@@ -704,40 +680,22 @@ contract AnchorStateRegistry_IsGameProper_Test is AnchorStateRegistry_TestInit {
 
     /// @notice Tests that isGameProper will return false if the game is not registered.
     function test_isGameProper_isNotFactoryRegistered_succeeds() public {
-        // Mock the DisputeGameFactory to make it seem that the game was not registered.
-        vm.mockCall(
-            address(disputeGameFactory),
-            abi.encodeCall(
-                disputeGameFactory.games, (gameProxy.gameType(), gameProxy.rootClaim(), gameProxy.extraData())
-            ),
-            abi.encode(address(0), 0)
-        );
+        _mockGameNotRegistered();
 
         assertFalse(anchorStateRegistry.isGameProper(gameProxy));
     }
 
-    /// @notice Tests that isGameProper will return false if the game is not the respected game
+    /// @notice Tests that isGameProper still returns true if the game was not the respected game
     ///         type.
-    /// @param _gameType The game type to use for the test.
-    function testFuzz_isGameProper_anyGameType_succeeds(GameType _gameType) public {
-        if (_gameType.raw() == gameProxy.gameType().raw()) {
-            _gameType = GameType.wrap(_gameType.raw() + 1);
-        }
-
-        // Mock that the game was not respected.
-        vm.mockCall(
-            address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(false)
-        );
-
-        // Still a proper game.
+    function test_isGameProper_notRespected_succeeds() public {
+        _mockGameWasRespected(false);
         assertTrue(anchorStateRegistry.isGameProper(gameProxy));
     }
 
     /// @notice Tests that isGameProper will return false if the game is blacklisted.
     function test_isGameProper_isBlacklisted_succeeds() public {
         // Blacklist the game.
-        vm.prank(superchainConfig.guardian());
-        anchorStateRegistry.blacklistDisputeGame(gameProxy);
+        _blacklistDisputeGameAsGuardian(gameProxy);
 
         // Should return false.
         assertFalse(anchorStateRegistry.isGameProper(gameProxy));
@@ -755,15 +713,7 @@ contract AnchorStateRegistry_IsGameProper_Test is AnchorStateRegistry_TestInit {
     /// @notice Tests that isGameProper will return false if the game is retired.
     /// @param _createdAtTimestamp The createdAt timestamp to use for the test.
     function testFuzz_isGameProper_isRetired_succeeds(uint64 _createdAtTimestamp) public {
-        // Set the retirement timestamp to now.
-        vm.prank(superchainConfig.guardian());
-        anchorStateRegistry.updateRetirementTimestamp();
-
-        // Make sure createdAt timestamp is less than or equal to the retirementTimestamp.
-        _createdAtTimestamp = uint64(bound(_createdAtTimestamp, 0, anchorStateRegistry.retirementTimestamp()));
-
-        // Mock the call to createdAt.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.createdAt, ()), abi.encode(_createdAtTimestamp));
+        _mockRetiredGame(_createdAtTimestamp);
 
         // Game should not be proper.
         assertFalse(anchorStateRegistry.isGameProper(gameProxy));
@@ -776,19 +726,14 @@ contract AnchorStateRegistry_IsGameFinalized_Test is AnchorStateRegistry_TestIni
     /// @notice Tests that isGameFinalized will return true if the game is finalized.
     /// @param _resolvedAtTimestamp The resolvedAt timestamp to use for the test.
     function testFuzz_isGameFinalized_isFinalized_succeeds(uint256 _resolvedAtTimestamp) public {
-        // Warp forward by disputeGameFinalityDelaySeconds.
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds());
+        uint256 finalityDelay = _warpByFinalityDelay();
 
         // Bound resolvedAt to be at least disputeGameFinalityDelaySeconds in the past.
         // Must be greater than 0.
-        _resolvedAtTimestamp =
-            bound(_resolvedAtTimestamp, 1, block.timestamp - anchorStateRegistry.disputeGameFinalityDelaySeconds() - 1);
+        _resolvedAtTimestamp = bound(_resolvedAtTimestamp, 1, block.timestamp - finalityDelay - 1);
 
-        // Mock the resolvedAt timestamp.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(_resolvedAtTimestamp));
-
-        // Mock the status to be DEFENDER_WINS.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
+        _mockGameResolvedAt(_resolvedAtTimestamp);
+        _mockGameStatus(GameStatus.DEFENDER_WINS);
 
         // Game should be finalized.
         assertTrue(anchorStateRegistry.isGameFinalized(gameProxy));
@@ -796,19 +741,13 @@ contract AnchorStateRegistry_IsGameFinalized_Test is AnchorStateRegistry_TestIni
 
     /// @notice Tests that isGameFinalized will return false if the game is not finalized.
     /// @param _resolvedAtTimestamp The resolvedAt timestamp to use for the test.
-    function testFuzz_isGameFinalized_isNotAirgapped_succeeds(uint256 _resolvedAtTimestamp) public {
-        // Warp forward by disputeGameFinalityDelaySeconds.
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds());
+    function testFuzz_isGameFinalized_isNotFinalized_succeeds(uint256 _resolvedAtTimestamp) public {
+        uint256 finalityDelay = _warpByFinalityDelay();
 
         // Bound resolvedAt to be less than disputeGameFinalityDelaySeconds in the past.
-        _resolvedAtTimestamp = bound(
-            _resolvedAtTimestamp,
-            block.timestamp - anchorStateRegistry.disputeGameFinalityDelaySeconds(),
-            block.timestamp
-        );
+        _resolvedAtTimestamp = bound(_resolvedAtTimestamp, block.timestamp - finalityDelay, block.timestamp);
 
-        // Mock the resolvedAt timestamp.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(_resolvedAtTimestamp));
+        _mockGameResolvedAt(_resolvedAtTimestamp);
 
         // Game should not be finalized.
         assertFalse(anchorStateRegistry.isGameFinalized(gameProxy));
@@ -816,11 +755,9 @@ contract AnchorStateRegistry_IsGameFinalized_Test is AnchorStateRegistry_TestIni
 
     /// @notice Tests that isGameFinalized will return false if the game is not resolved.
     function test_isGameFinalized_isNotResolved_succeeds() public {
-        // Warp forward by disputeGameFinalityDelaySeconds.
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds());
+        _warpByFinalityDelay();
 
-        // Mock the status call to be IN_PROGRESS.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.IN_PROGRESS));
+        _mockGameStatus(GameStatus.IN_PROGRESS);
 
         // Game should not be finalized.
         assertFalse(anchorStateRegistry.isGameFinalized(gameProxy));
@@ -833,65 +770,38 @@ contract AnchorStateRegistry_IsGameClaimValid_Test is AnchorStateRegistry_TestIn
     /// @notice Tests that isGameClaimValid will return true if the game claim is valid.
     /// @param _resolvedAtTimestamp The resolvedAt timestamp to use for the test.
     function testFuzz_isGameClaimValid_claimIsValid_succeeds(uint256 _resolvedAtTimestamp) public {
-        // Warp forward by disputeGameFinalityDelaySeconds.
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds());
+        uint256 finalityDelay = _warpByFinalityDelay();
 
         // Bound resolvedAt to be at least disputeGameFinalityDelaySeconds in the past.
-        _resolvedAtTimestamp =
-            bound(_resolvedAtTimestamp, 1, block.timestamp - anchorStateRegistry.disputeGameFinalityDelaySeconds() - 1);
+        _resolvedAtTimestamp = bound(_resolvedAtTimestamp, 1, block.timestamp - finalityDelay - 1);
 
-        // Mock that the game was respected.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(true));
-
-        // Mock the resolvedAt timestamp.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(_resolvedAtTimestamp));
-
-        // Mock the status to be DEFENDER_WINS.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
+        _mockGameWasRespected(true);
+        _mockGameResolvedAt(_resolvedAtTimestamp);
+        _mockGameStatus(GameStatus.DEFENDER_WINS);
 
         // Claim should be valid.
         assertTrue(anchorStateRegistry.isGameClaimValid(gameProxy));
     }
 
     /// @notice Tests that isGameClaimValid will return false if the game is not registered.
-    function testFuzz_isGameClaimValid_notRegistered_succeeds() public {
-        // Mock the DisputeGameFactory to make it seem that the game was not registered.
-        vm.mockCall(
-            address(disputeGameFactory),
-            abi.encodeCall(
-                disputeGameFactory.games, (gameProxy.gameType(), gameProxy.rootClaim(), gameProxy.extraData())
-            ),
-            abi.encode(address(0), 0)
-        );
+    function test_isGameClaimValid_notRegistered_succeeds() public {
+        _mockGameNotRegistered();
 
         // Claim should not be valid.
         assertFalse(anchorStateRegistry.isGameClaimValid(gameProxy));
     }
 
     /// @notice Tests that isGameClaimValid will return false if the game is not respected.
-    /// @param _gameType The game type to use for the test.
-    function testFuzz_isGameClaimValid_isNotRespected_succeeds(GameType _gameType) public {
-        if (_gameType.raw() == gameProxy.gameType().raw()) {
-            _gameType = GameType.wrap(_gameType.raw() + 1);
-        }
-
-        // Mock that the game was not respected.
-        vm.mockCall(
-            address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(false)
-        );
+    function test_isGameClaimValid_isNotRespected_succeeds() public {
+        _mockGameWasRespected(false);
 
         // Claim should not be valid.
         assertFalse(anchorStateRegistry.isGameClaimValid(gameProxy));
     }
 
     /// @notice Tests that isGameClaimValid will return false if the game is blacklisted.
-    function testFuzz_isGameClaimValid_isBlacklisted_succeeds() public {
-        // Mock the disputeGameBlacklist call to return true.
-        vm.mockCall(
-            address(anchorStateRegistry),
-            abi.encodeCall(anchorStateRegistry.disputeGameBlacklist, (gameProxy)),
-            abi.encode(true)
-        );
+    function test_isGameClaimValid_isBlacklisted_succeeds() public {
+        _blacklistDisputeGameAsGuardian(gameProxy);
 
         // Claim should not be valid.
         assertFalse(anchorStateRegistry.isGameClaimValid(gameProxy));
@@ -899,45 +809,30 @@ contract AnchorStateRegistry_IsGameClaimValid_Test is AnchorStateRegistry_TestIn
 
     /// @notice Tests that isGameClaimValid will return false if the game is retired.
     /// @param _createdAtTimestamp The createdAt timestamp to use for the test.
-    function testFuzz_isGameClaimValid_isRetired_succeeds(uint256 _createdAtTimestamp) public {
-        // Set the retirement timestamp to now.
-        vm.prank(superchainConfig.guardian());
-        anchorStateRegistry.updateRetirementTimestamp();
-
-        // Make sure createdAt timestamp is less than or equal to the retirementTimestamp.
-        _createdAtTimestamp = uint64(bound(_createdAtTimestamp, 0, anchorStateRegistry.retirementTimestamp()));
-
-        // Mock the call to createdAt.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.createdAt, ()), abi.encode(_createdAtTimestamp));
+    function testFuzz_isGameClaimValid_isRetired_succeeds(uint64 _createdAtTimestamp) public {
+        _mockRetiredGame(_createdAtTimestamp);
 
         // Claim should not be valid.
         assertFalse(anchorStateRegistry.isGameClaimValid(gameProxy));
     }
 
     /// @notice Tests that isGameClaimValid will return false if the game is not resolved.
-    function testFuzz_isGameClaimValid_notResolved_succeeds() public {
-        // Mock the status to be IN_PROGRESS.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.IN_PROGRESS));
+    function test_isGameClaimValid_notResolved_succeeds() public {
+        _mockGameStatus(GameStatus.IN_PROGRESS);
 
         // Claim should not be valid.
         assertFalse(anchorStateRegistry.isGameClaimValid(gameProxy));
     }
 
-    /// @notice Tests that isGameClaimValid will return false if the game is not airgapped.
+    /// @notice Tests that isGameClaimValid will return false if the game is not finalized.
     /// @param _resolvedAtTimestamp The resolvedAt timestamp to use for the test.
-    function testFuzz_isGameClaimValid_notAirgapped_succeeds(uint256 _resolvedAtTimestamp) public {
-        // Warp forward by disputeGameFinalityDelaySeconds.
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds());
+    function testFuzz_isGameClaimValid_notFinalized_succeeds(uint256 _resolvedAtTimestamp) public {
+        uint256 finalityDelay = _warpByFinalityDelay();
 
         // Bound resolvedAt to be less than disputeGameFinalityDelaySeconds in the past.
-        _resolvedAtTimestamp = bound(
-            _resolvedAtTimestamp,
-            block.timestamp - anchorStateRegistry.disputeGameFinalityDelaySeconds(),
-            block.timestamp
-        );
+        _resolvedAtTimestamp = bound(_resolvedAtTimestamp, block.timestamp - finalityDelay, block.timestamp);
 
-        // Mock the resolvedAt timestamp.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(_resolvedAtTimestamp));
+        _mockGameResolvedAt(_resolvedAtTimestamp);
 
         // Claim should not be valid.
         assertFalse(anchorStateRegistry.isGameClaimValid(gameProxy));
@@ -961,24 +856,14 @@ contract AnchorStateRegistry_SetAnchorState_Test is AnchorStateRegistry_TestInit
     ///         respected game type.
     /// @param _l2BlockNumber The L2 block number to use for the game.
     function testFuzz_setAnchorState_validNewerState_succeeds(uint256 _l2BlockNumber) public {
-        // Grab block number of the existing anchor root.
-        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
-
         // Bound the new block number.
         _l2BlockNumber = bound(_l2BlockNumber, validL2BlockNumber, type(uint256).max);
 
         // Mock the l2BlockNumber call.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(_l2BlockNumber));
+        _mockGameL2SequenceNumber(_l2BlockNumber);
 
-        // Mock the DEFENDER_WINS state.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
-
-        // Mock that the game was respected.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(true));
-
-        // Mock the resolvedAt timestamp and fast forward to beyond the delay.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds() + 1);
+        _mockGamePastFinalityWithStatus(GameStatus.DEFENDER_WINS);
+        _mockGameWasRespected(true);
 
         // Update the anchor state.
         vm.prank(address(gameProxy));
@@ -987,9 +872,7 @@ contract AnchorStateRegistry_SetAnchorState_Test is AnchorStateRegistry_TestInit
         anchorStateRegistry.setAnchorState(gameProxy);
 
         // Confirm that the anchor state is now the same as the game state.
-        (root, l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
-        assertEq(l2BlockNumber, gameProxy.l2SequenceNumber());
-        assertEq(root.raw(), gameProxy.rootClaim().raw());
+        _assertAnchorRootEqGame(gameProxy);
 
         // Confirm that the anchor game is now set.
         IDisputeGame anchorGame = anchorStateRegistry.anchorGame();
@@ -1007,250 +890,102 @@ contract AnchorStateRegistry_SetAnchorState_Test is AnchorStateRegistry_TestInit
         _l2BlockNumber = bound(_l2BlockNumber, 0, l2BlockNumber);
 
         // Mock the l2BlockNumber call.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(_l2BlockNumber));
+        _mockGameL2SequenceNumber(_l2BlockNumber);
 
-        // Mock the DEFENDER_WINS state.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
+        _mockGamePastFinalityWithStatus(GameStatus.DEFENDER_WINS);
+        _mockGameWasRespected(true);
 
-        // Mock that the game was respected.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(true));
+        _expectSetAnchorStateInvalid(gameProxy, address(gameProxy));
 
-        // Mock the resolvedAt timestamp and fast forward to beyond the delay.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds() + 1);
-
-        // Try to update the anchor state.
-        vm.prank(address(gameProxy));
-        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_InvalidAnchorGame.selector);
-        anchorStateRegistry.setAnchorState(gameProxy);
-
-        // Confirm that the anchor state has not updated.
-        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.getAnchorRoot();
-        assertEq(updatedL2BlockNumber, l2BlockNumber);
-        assertEq(updatedRoot.raw(), root.raw());
+        _assertCurrentAnchorRootEq(root, l2BlockNumber);
     }
 
     /// @notice Tests that setAnchorState will revert if the game is not registered.
-    /// @param _l2BlockNumber The L2 block number to use for the game.
-    function testFuzz_setAnchorState_notFactoryRegisteredGame_fails(uint256 _l2BlockNumber) public {
+    function test_setAnchorState_notFactoryRegisteredGame_fails() public {
         // Grab block number of the existing anchor root.
         (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
 
-        // Bound the new block number.
-        _l2BlockNumber = bound(_l2BlockNumber, l2BlockNumber, type(uint256).max);
+        _mockGameNotRegistered();
 
-        // Mock the l2BlockNumber call.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(_l2BlockNumber));
+        _expectSetAnchorStateInvalid(gameProxy, superchainConfig.guardian());
 
-        // Mock the DEFENDER_WINS state.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
-
-        // Mock that the game was respected.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(true));
-
-        // Mock the DisputeGameFactory to make it seem that the game was not registered.
-        vm.mockCall(
-            address(disputeGameFactory),
-            abi.encodeCall(
-                disputeGameFactory.games, (gameProxy.gameType(), gameProxy.rootClaim(), gameProxy.extraData())
-            ),
-            abi.encode(address(0), 0)
-        );
-
-        // Try to update the anchor state.
-        vm.prank(superchainConfig.guardian());
-        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_InvalidAnchorGame.selector);
-        anchorStateRegistry.setAnchorState(gameProxy);
-
-        // Confirm that the anchor state has not updated.
-        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.getAnchorRoot();
-        assertEq(updatedL2BlockNumber, l2BlockNumber);
-        assertEq(updatedRoot.raw(), root.raw());
+        _assertCurrentAnchorRootEq(root, l2BlockNumber);
     }
 
     /// @notice Tests that setAnchorState will revert if the game is valid and the game status is
     ///         CHALLENGER_WINS.
-    /// @param _l2BlockNumber The L2 block number to use for the game.
-    function testFuzz_setAnchorState_challengerWins_fails(uint256 _l2BlockNumber) public {
+    function test_setAnchorState_challengerWins_fails() public {
         // Grab block number of the existing anchor root.
         (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
 
-        // Bound the new block number.
-        _l2BlockNumber = bound(_l2BlockNumber, l2BlockNumber, type(uint256).max);
+        _mockGamePastFinalityWithStatus(GameStatus.CHALLENGER_WINS);
+        _mockGameWasRespected(true);
 
-        // Mock the l2BlockNumber call.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(_l2BlockNumber));
+        _expectSetAnchorStateInvalid(gameProxy, address(gameProxy));
 
-        // Mock the CHALLENGER_WINS state.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.CHALLENGER_WINS));
-
-        // Mock that the game was respected.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(true));
-
-        // Mock the resolvedAt timestamp and fast forward to beyond the delay.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds() + 1);
-
-        // Try to update the anchor state.
-        vm.prank(address(gameProxy));
-        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_InvalidAnchorGame.selector);
-        anchorStateRegistry.setAnchorState(gameProxy);
-
-        // Confirm that the anchor state has not updated.
-        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.getAnchorRoot();
-        assertEq(updatedL2BlockNumber, l2BlockNumber);
-        assertEq(updatedRoot.raw(), root.raw());
+        _assertCurrentAnchorRootEq(root, l2BlockNumber);
     }
 
     /// @notice Tests that setAnchorState will revert if the game is valid and the game status is
     ///         IN_PROGRESS.
-    /// @param _l2BlockNumber The L2 block number to use for the game.
-    function testFuzz_setAnchorState_inProgress_fails(uint256 _l2BlockNumber) public {
+    function test_setAnchorState_inProgress_fails() public {
         // Grab block number of the existing anchor root.
         (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
 
-        // Bound the new block number.
-        _l2BlockNumber = bound(_l2BlockNumber, l2BlockNumber, type(uint256).max);
+        _mockGamePastFinalityWithStatus(GameStatus.IN_PROGRESS);
+        _mockGameWasRespected(true);
 
-        // Mock the l2BlockNumber call.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(_l2BlockNumber));
+        _expectSetAnchorStateInvalid(gameProxy, address(gameProxy));
 
-        // Mock the CHALLENGER_WINS state.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.IN_PROGRESS));
-
-        // Mock that the game was respected.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(true));
-
-        // Mock the resolvedAt timestamp and fast forward to beyond the delay.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds() + 1);
-
-        // Try to update the anchor state.
-        vm.prank(address(gameProxy));
-        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_InvalidAnchorGame.selector);
-        anchorStateRegistry.setAnchorState(gameProxy);
-
-        // Confirm that the anchor state has not updated.
-        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.getAnchorRoot();
-        assertEq(updatedL2BlockNumber, l2BlockNumber);
-        assertEq(updatedRoot.raw(), root.raw());
+        _assertCurrentAnchorRootEq(root, l2BlockNumber);
     }
 
     /// @notice Tests that setAnchorState will revert if the game is not respected.
-    /// @param _l2BlockNumber The L2 block number to use for the game.
-    function testFuzz_setAnchorState_isNotRespectedGame_fails(uint256 _l2BlockNumber) public {
+    function test_setAnchorState_isNotRespectedGame_fails() public {
         // Grab block number of the existing anchor root.
         (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
 
-        // Bound the new block number.
-        _l2BlockNumber = bound(_l2BlockNumber, l2BlockNumber, type(uint256).max);
+        _mockGameWasRespected(false);
 
-        // Mock the l2BlockNumber call.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(_l2BlockNumber));
+        _expectSetAnchorStateInvalid(gameProxy, address(gameProxy));
 
-        // Mock the DEFENDER_WINS state.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
-
-        // Mock the resolvedAt timestamp and fast forward to beyond the delay.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds() + 1);
-
-        // Mock that the game was not respected when created.
-        vm.mockCall(
-            address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(false)
-        );
-
-        // Try to update the anchor state.
-        vm.prank(address(gameProxy));
-        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_InvalidAnchorGame.selector);
-        anchorStateRegistry.setAnchorState(gameProxy);
-
-        // Confirm that the anchor state has not updated.
-        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
-        assertEq(updatedL2BlockNumber, l2BlockNumber);
-        assertEq(updatedRoot.raw(), root.raw());
+        _assertAnchorEq(gameProxy.gameType(), root, l2BlockNumber);
     }
 
     /// @notice Tests that setAnchorState will revert if the game is valid and the game is
     ///         blacklisted.
-    /// @param _l2BlockNumber The L2 block number to use for the game.
-    function testFuzz_setAnchorState_blacklistedGame_fails(uint256 _l2BlockNumber) public {
+    function test_setAnchorState_blacklistedGame_fails() public {
         // Grab block number of the existing anchor root.
         (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
 
-        // Bound the new block number.
-        _l2BlockNumber = bound(_l2BlockNumber, validL2BlockNumber, type(uint256).max);
-
-        // Mock the DEFENDER_WINS state.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
-
-        // Mock that the game was respected.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(true));
-
-        // Mock the resolvedAt timestamp and fast forward to beyond the delay.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
-        vm.warp(block.timestamp + anchorStateRegistry.disputeGameFinalityDelaySeconds() + 1);
-
         // Blacklist the game.
-        vm.prank(superchainConfig.guardian());
-        anchorStateRegistry.blacklistDisputeGame(gameProxy);
+        _blacklistDisputeGameAsGuardian(gameProxy);
 
-        // Update the anchor state.
-        vm.prank(address(gameProxy));
-        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_InvalidAnchorGame.selector);
-        anchorStateRegistry.setAnchorState(gameProxy);
+        _expectSetAnchorStateInvalid(gameProxy, address(gameProxy));
 
-        // Confirm that the anchor state has not updated.
-        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
-        assertEq(updatedL2BlockNumber, l2BlockNumber);
-        assertEq(updatedRoot.raw(), root.raw());
+        _assertAnchorEq(gameProxy.gameType(), root, l2BlockNumber);
     }
 
     /// @notice Tests that setAnchorState will revert if the game is retired.
-    /// @param _l2BlockNumber The L2 block number to use for the game.
-    function testFuzz_setAnchorState_retiredGame_fails(uint256 _l2BlockNumber) public {
+    function test_setAnchorState_retiredGame_fails() public {
         // Grab block number of the existing anchor root.
         (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
 
-        // Bound the new block number.
-        _l2BlockNumber = bound(_l2BlockNumber, validL2BlockNumber, type(uint256).max);
+        _mockRetiredGame(0);
+        _expectSetAnchorStateInvalid(gameProxy, address(gameProxy));
 
-        // Mock the DEFENDER_WINS state.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
-
-        // Mock that the game was respected.
-        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.wasRespectedGameTypeWhenCreated, ()), abi.encode(true));
-
-        // Set the retirement timestamp.
-        vm.prank(superchainConfig.guardian());
-        anchorStateRegistry.updateRetirementTimestamp();
-
-        // Mock the call to createdAt.
-        vm.mockCall(
-            address(gameProxy),
-            abi.encodeCall(gameProxy.createdAt, ()),
-            abi.encode(anchorStateRegistry.retirementTimestamp() - 1)
-        );
-
-        // Update the anchor state.
-        vm.prank(address(gameProxy));
-        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_InvalidAnchorGame.selector);
-        anchorStateRegistry.setAnchorState(gameProxy);
-
-        // Confirm that the anchor state has not updated.
-        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
-        assertEq(updatedL2BlockNumber, l2BlockNumber);
-        assertEq(updatedRoot.raw(), root.raw());
+        _assertAnchorEq(gameProxy.gameType(), root, l2BlockNumber);
     }
 
     /// @notice Tests that setAnchorState will revert if the superchain is paused.
     function test_setAnchorState_superchainPaused_fails() public {
+        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
+
         // Pause the superchain.
         _setPaused(true);
 
-        // Update the anchor state.
-        vm.prank(address(gameProxy));
-        vm.expectRevert(IAnchorStateRegistry.AnchorStateRegistry_InvalidAnchorGame.selector);
-        anchorStateRegistry.setAnchorState(gameProxy);
+        _expectSetAnchorStateInvalid(gameProxy, address(gameProxy));
+
+        _assertCurrentAnchorRootEq(root, l2BlockNumber);
     }
 }

--- a/test/L1/proofs/BaseTest.t.sol
+++ b/test/L1/proofs/BaseTest.t.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.15;
 
 import { Test } from "lib/forge-std/src/Test.sol";
 
-// Optimism
 import { AnchorStateRegistry } from "src/L1/proofs/AnchorStateRegistry.sol";
 import { DelayedWETH } from "src/L1/proofs/DelayedWETH.sol";
 import { DisputeGameFactory } from "src/L1/proofs/DisputeGameFactory.sol";
@@ -12,10 +11,9 @@ import { IDelayedWETH } from "interfaces/L1/proofs/IDelayedWETH.sol";
 import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
 import { IDisputeGameFactory } from "interfaces/L1/proofs/IDisputeGameFactory.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
-import { GameStatus, GameType, Hash, Proposal } from "src/libraries/bridge/Types.sol";
-import { Claim, Timestamp } from "src/libraries/bridge/LibUDT.sol";
+import { GameType, Hash, Proposal } from "src/libraries/bridge/Types.sol";
+import { Claim } from "src/libraries/bridge/LibUDT.sol";
 
-// OpenZeppelin
 import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
 import {
     TransparentUpgradeableProxy
@@ -26,61 +24,49 @@ import { IVerifier } from "interfaces/L1/proofs/IVerifier.sol";
 
 import { MockVerifier } from "test/mocks/MockVerifier.sol";
 
-import { LibClone } from "lib/solady/src/utils/LibClone.sol";
-
 contract BaseTest is Test {
-    using LibClone for address;
-    // Constants
-    GameType public constant AGGREGATE_VERIFIER_GAME_TYPE = GameType.wrap(621);
-    uint256 public constant L2_CHAIN_ID = 8453;
+    GameType internal constant AGGREGATE_VERIFIER_GAME_TYPE = GameType.wrap(621);
+    uint256 internal constant L2_CHAIN_ID = 8453;
 
-    // MUST HAVE: BLOCK_INTERVAL % INTERMEDIATE_BLOCK_INTERVAL == 0
-    uint256 public constant BLOCK_INTERVAL = 100;
-    uint256 public constant INTERMEDIATE_BLOCK_INTERVAL = 10;
+    // AggregateVerifier expects evenly spaced intermediate roots.
+    uint256 internal constant BLOCK_INTERVAL = 100;
+    uint256 internal constant INTERMEDIATE_BLOCK_INTERVAL = 10;
+    uint256 private constant INTERMEDIATE_ROOTS_COUNT = BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL;
 
-    uint256 public constant INIT_BOND = 1 ether;
-    uint256 public constant DELAYED_WETH_DELAY = 1 days;
+    uint256 internal constant INIT_BOND = 1 ether;
+    uint256 internal constant DELAYED_WETH_DELAY = 1 days;
     // Finality delay handled by the AggregateVerifier
-    uint256 public constant FINALITY_DELAY = 0 days;
-    uint256 public SLOW_FINALIZATION_DELAY;
-    uint256 public FAST_FINALIZATION_DELAY;
+    uint256 internal constant FINALITY_DELAY = 0 days;
 
-    uint256 public currentL2BlockNumber = 0;
+    uint256 internal currentL2BlockNumber;
 
-    address public immutable TEE_PROVER = makeAddr("tee-prover");
-    address public immutable ZK_PROVER = makeAddr("zk-prover");
-    address public immutable ATTACKER = makeAddr("attacker");
+    address internal immutable TEE_PROVER = makeAddr("tee-prover");
+    address internal immutable ZK_PROVER = makeAddr("zk-prover");
 
-    bytes32 public immutable TEE_IMAGE_HASH = keccak256("tee-image");
-    bytes32 public immutable ZK_RANGE_HASH = keccak256("zk-range");
-    bytes32 public immutable ZK_AGGREGATE_HASH = keccak256("zk-aggregate");
-    bytes32 public immutable CONFIG_HASH = keccak256("config");
+    bytes32 internal immutable TEE_IMAGE_HASH = keccak256("tee-image");
+    bytes32 internal immutable ZK_RANGE_HASH = keccak256("zk-range");
+    bytes32 internal immutable ZK_AGGREGATE_HASH = keccak256("zk-aggregate");
+    bytes32 internal immutable CONFIG_HASH = keccak256("config");
 
-    ProxyAdmin public proxyAdmin;
-    ISystemConfig public systemConfig;
+    ProxyAdmin internal proxyAdmin;
+    ISystemConfig internal systemConfig;
 
-    DisputeGameFactory public factory;
-    AnchorStateRegistry public anchorStateRegistry;
-    DelayedWETH public delayedWETH;
+    DisputeGameFactory internal factory;
+    AnchorStateRegistry internal anchorStateRegistry;
+    DelayedWETH internal delayedWETH;
 
-    MockVerifier public teeVerifier;
-    MockVerifier public zkVerifier;
+    MockVerifier internal teeVerifier;
+    MockVerifier internal zkVerifier;
 
     function setUp() public virtual {
         _deployContractsAndProxies();
         _initializeProxies();
 
-        // Deploy the implementations
         _deployAndSetAggregateVerifier();
-
-        AggregateVerifier aggregateVerifierImpl =
-            AggregateVerifier(address(factory.gameImpls(AGGREGATE_VERIFIER_GAME_TYPE)));
-        SLOW_FINALIZATION_DELAY = aggregateVerifierImpl.SLOW_FINALIZATION_DELAY();
-        FAST_FINALIZATION_DELAY = aggregateVerifierImpl.FAST_FINALIZATION_DELAY();
 
         anchorStateRegistry.setRespectedGameType(AGGREGATE_VERIFIER_GAME_TYPE);
 
-        // Set the timestamp to after the retirement timestamp
+        // Games created at or before the registry's retirement timestamp are invalid.
         vm.warp(block.timestamp + 1);
     }
 
@@ -88,38 +74,26 @@ contract BaseTest is Test {
         systemConfig = ISystemConfig(makeAddr("system-config"));
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.guardian, ()), abi.encode(address(this)));
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.paused, ()), abi.encode(false));
-        // Deploy the relay anchor state registry
+
         AnchorStateRegistry _anchorStateRegistry = new AnchorStateRegistry(FINALITY_DELAY);
-        // Deploy the delayed WETH
         DelayedWETH _delayedWETH = new DelayedWETH(DELAYED_WETH_DELAY);
-        // Deploy the dispute game factory
         DisputeGameFactory _factory = new DisputeGameFactory();
 
-        // Deploy proxy admin
         proxyAdmin = new ProxyAdmin(address(this));
 
-        // Deploy proxy for anchor state registry
-        TransparentUpgradeableProxy anchorStateRegistryProxy =
-            new TransparentUpgradeableProxy(address(_anchorStateRegistry), address(proxyAdmin), "");
-        anchorStateRegistry = AnchorStateRegistry(address(anchorStateRegistryProxy));
+        anchorStateRegistry = AnchorStateRegistry(_deployProxy(address(_anchorStateRegistry)));
+        factory = DisputeGameFactory(_deployProxy(address(_factory)));
+        delayedWETH = DelayedWETH(payable(_deployProxy(address(_delayedWETH))));
 
-        // Deploy proxy for factory
-        TransparentUpgradeableProxy factoryProxy =
-            new TransparentUpgradeableProxy(address(_factory), address(proxyAdmin), "");
-        factory = DisputeGameFactory(address(factoryProxy));
-
-        // Deploy proxy for delayed WETH
-        TransparentUpgradeableProxy delayedWETHProxy =
-            new TransparentUpgradeableProxy(address(_delayedWETH), address(proxyAdmin), "");
-        delayedWETH = DelayedWETH(payable(address(delayedWETHProxy)));
-
-        // Deploy the verifiers
         teeVerifier = new MockVerifier(IAnchorStateRegistry(address(anchorStateRegistry)));
         zkVerifier = new MockVerifier(IAnchorStateRegistry(address(anchorStateRegistry)));
     }
 
+    function _deployProxy(address implementation) private returns (address) {
+        return address(new TransparentUpgradeableProxy(implementation, address(proxyAdmin), ""));
+    }
+
     function _initializeProxies() internal {
-        // Initialize the proxies
         anchorStateRegistry.initialize(
             systemConfig,
             IDisputeGameFactory(address(factory)),
@@ -133,7 +107,6 @@ contract BaseTest is Test {
     }
 
     function _deployAndSetAggregateVerifier() internal {
-        // Deploy the dispute game relay implementation
         AggregateVerifier aggregateVerifierImpl = new AggregateVerifier(
             AGGREGATE_VERIFIER_GAME_TYPE,
             IAnchorStateRegistry(address(anchorStateRegistry)),
@@ -148,14 +121,10 @@ contract BaseTest is Test {
             INTERMEDIATE_BLOCK_INTERVAL
         );
 
-        // Set the implementation for the aggregate verifier
         factory.setImplementation(AGGREGATE_VERIFIER_GAME_TYPE, IDisputeGame(address(aggregateVerifierImpl)));
-
-        // Set the bond amount for the aggregate verifier
         factory.setInitBond(AGGREGATE_VERIFIER_GAME_TYPE, INIT_BOND);
     }
 
-    // Helper function to create a game via factory
     function _createAggregateVerifierGame(
         address creator,
         Claim rootClaim,
@@ -166,9 +135,7 @@ contract BaseTest is Test {
         internal
         returns (AggregateVerifier game)
     {
-        bytes memory intermediateRoots =
-            abi.encodePacked(_generateIntermediateRootsExceptLast(l2BlockNumber), rootClaim.raw());
-        bytes memory extraData = abi.encodePacked(uint256(l2BlockNumber), parentAddress, intermediateRoots);
+        bytes memory extraData = _aggregateVerifierExtraData(rootClaim, l2BlockNumber, parentAddress);
 
         vm.deal(creator, INIT_BOND);
         vm.prank(creator);
@@ -181,41 +148,12 @@ contract BaseTest is Test {
         );
     }
 
-    /// @notice Clones the `AggregateVerifier` implementation with the same CWIA layout as `DisputeGameFactory`,
-    ///         initializes it, but does not register the game in the factory (no `_finalizeGameCreation`).
-    function _deployAggregateVerifierCloneWithoutFactoryRegistration(
-        address creator,
-        Claim rootClaim,
-        uint256 l2BlockNumber,
-        address parentAddress,
-        bytes memory proof
-    )
-        internal
-        returns (AggregateVerifier game)
-    {
-        IDisputeGame impl = factory.gameImpls(AGGREGATE_VERIFIER_GAME_TYPE);
-        bytes memory intermediateRoots =
-            abi.encodePacked(_generateIntermediateRootsExceptLast(l2BlockNumber), rootClaim.raw());
-        bytes memory extraData = abi.encodePacked(uint256(l2BlockNumber), parentAddress, intermediateRoots);
-        bytes32 l1Head = blockhash(block.number - 1);
-        address clone = address(impl).clone(abi.encodePacked(creator, rootClaim, l1Head, extraData));
-        vm.deal(creator, INIT_BOND);
-        vm.prank(creator);
-        AggregateVerifier(payable(clone)).initializeWithInitData{ value: INIT_BOND }(proof);
-        return AggregateVerifier(payable(clone));
-    }
-
     function _provideProof(AggregateVerifier game, address prover, bytes memory proofBytes) internal {
         vm.prank(prover);
         game.verifyProposalProof(proofBytes);
     }
 
-    /// @notice Generates a properly formatted proof for testing.
-    /// @dev The proof format is: l1OriginHash (32) + l1OriginNumber (32) + additional data.
-    ///      Since MockVerifier always returns true, we just need the correct structure.
-    /// @param salt A salt to make proofs unique.
-    /// @param proofType The type of proof to generate.
-    /// @return proof The formatted proof bytes.
+    /// @dev Encodes proofType || l1OriginHash || l1OriginNumber || mock verifier payload.
     function _generateProof(
         bytes memory salt,
         AggregateVerifier.ProofType proofType
@@ -224,24 +162,32 @@ contract BaseTest is Test {
         view
         returns (bytes memory)
     {
-        // Use the previous block hash as l1OriginHash
-        bytes32 l1OriginHash = blockhash(block.number - 1);
-        // Use the previous block number as l1OriginNumber
         uint256 l1OriginNumber = block.number - 1;
-        // Add some padding/signature data (65 bytes minimum for a signature)
-        bytes memory signature = abi.encodePacked(salt, bytes32(0), bytes32(0), uint8(27));
+        bytes32 l1OriginHash = blockhash(l1OriginNumber);
 
-        return abi.encodePacked(uint8(proofType), l1OriginHash, l1OriginNumber, signature);
+        return abi.encodePacked(uint8(proofType), l1OriginHash, l1OriginNumber, salt, bytes32(0), bytes32(0), uint8(27));
     }
 
-    function _generateIntermediateRootsExceptLast(uint256 l2BlockNumber) internal pure returns (bytes memory) {
-        bytes memory intermediateRoots;
+    function _aggregateVerifierExtraData(
+        Claim rootClaim,
+        uint256 l2BlockNumber,
+        address parentAddress
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(l2BlockNumber, parentAddress, _generateIntermediateRoots(l2BlockNumber, rootClaim));
+    }
+
+    function _generateIntermediateRoots(uint256 l2BlockNumber, Claim rootClaim) private pure returns (bytes memory) {
+        bytes32[] memory intermediateRoots = new bytes32[](INTERMEDIATE_ROOTS_COUNT);
         uint256 startingL2BlockNumber = l2BlockNumber - BLOCK_INTERVAL;
-        for (uint256 i = 1; i < BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL; i++) {
-            intermediateRoots = abi.encodePacked(
-                intermediateRoots, keccak256(abi.encode(startingL2BlockNumber + INTERMEDIATE_BLOCK_INTERVAL * i))
-            );
+        for (uint256 i = 1; i < INTERMEDIATE_ROOTS_COUNT; i++) {
+            intermediateRoots[i - 1] = keccak256(abi.encode(startingL2BlockNumber + INTERMEDIATE_BLOCK_INTERVAL * i));
         }
-        return intermediateRoots;
+        intermediateRoots[INTERMEDIATE_ROOTS_COUNT - 1] = rootClaim.raw();
+
+        return abi.encodePacked(intermediateRoots);
     }
 }

--- a/test/L1/proofs/BaseTest.t.sol
+++ b/test/L1/proofs/BaseTest.t.sol
@@ -14,10 +14,8 @@ import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { GameType, GameTypes, Hash, Proposal } from "src/libraries/bridge/Types.sol";
 import { Claim } from "src/libraries/bridge/LibUDT.sol";
 
+import { Proxy } from "src/universal/Proxy.sol";
 import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
-import {
-    TransparentUpgradeableProxy
-} from "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import { AggregateVerifier } from "src/L1/proofs/AggregateVerifier.sol";
 import { IVerifier } from "interfaces/L1/proofs/IVerifier.sol";
@@ -89,7 +87,9 @@ contract BaseTest is Test {
     }
 
     function _deployProxy(address implementation) private returns (address) {
-        return address(new TransparentUpgradeableProxy(implementation, address(proxyAdmin), ""));
+        Proxy proxy = new Proxy(address(proxyAdmin));
+        proxyAdmin.upgrade(payable(address(proxy)), implementation);
+        return address(proxy);
     }
 
     function _initializeProxies() internal {

--- a/test/L1/proofs/BaseTest.t.sol
+++ b/test/L1/proofs/BaseTest.t.sol
@@ -11,7 +11,7 @@ import { IDelayedWETH } from "interfaces/L1/proofs/IDelayedWETH.sol";
 import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
 import { IDisputeGameFactory } from "interfaces/L1/proofs/IDisputeGameFactory.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
-import { GameType, Hash, Proposal } from "src/libraries/bridge/Types.sol";
+import { GameType, GameTypes, Hash, Proposal } from "src/libraries/bridge/Types.sol";
 import { Claim } from "src/libraries/bridge/LibUDT.sol";
 
 import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
@@ -25,7 +25,6 @@ import { IVerifier } from "interfaces/L1/proofs/IVerifier.sol";
 import { MockVerifier } from "test/mocks/MockVerifier.sol";
 
 contract BaseTest is Test {
-    GameType internal constant AGGREGATE_VERIFIER_GAME_TYPE = GameType.wrap(621);
     uint256 internal constant L2_CHAIN_ID = 8453;
 
     // AggregateVerifier expects evenly spaced intermediate roots.
@@ -64,7 +63,7 @@ contract BaseTest is Test {
 
         _deployAndSetAggregateVerifier();
 
-        anchorStateRegistry.setRespectedGameType(AGGREGATE_VERIFIER_GAME_TYPE);
+        anchorStateRegistry.setRespectedGameType(GameTypes.AGGREGATE_VERIFIER);
 
         // Games created at or before the registry's retirement timestamp are invalid.
         vm.warp(block.timestamp + 1);
@@ -108,7 +107,7 @@ contract BaseTest is Test {
 
     function _deployAndSetAggregateVerifier() internal {
         AggregateVerifier aggregateVerifierImpl = new AggregateVerifier(
-            AGGREGATE_VERIFIER_GAME_TYPE,
+            GameTypes.AGGREGATE_VERIFIER,
             IAnchorStateRegistry(address(anchorStateRegistry)),
             IDelayedWETH(payable(address(delayedWETH))),
             IVerifier(address(teeVerifier)),
@@ -121,8 +120,8 @@ contract BaseTest is Test {
             INTERMEDIATE_BLOCK_INTERVAL
         );
 
-        factory.setImplementation(AGGREGATE_VERIFIER_GAME_TYPE, IDisputeGame(address(aggregateVerifierImpl)));
-        factory.setInitBond(AGGREGATE_VERIFIER_GAME_TYPE, INIT_BOND);
+        factory.setImplementation(GameTypes.AGGREGATE_VERIFIER, IDisputeGame(address(aggregateVerifierImpl)));
+        factory.setInitBond(GameTypes.AGGREGATE_VERIFIER, INIT_BOND);
     }
 
     function _createAggregateVerifierGame(
@@ -142,7 +141,7 @@ contract BaseTest is Test {
         return AggregateVerifier(
             address(
                 factory.createWithInitData{ value: INIT_BOND }(
-                    AGGREGATE_VERIFIER_GAME_TYPE, rootClaim, extraData, proof
+                    GameTypes.AGGREGATE_VERIFIER, rootClaim, extraData, proof
                 )
             )
         );

--- a/test/L1/proofs/Challenge.t.sol
+++ b/test/L1/proofs/Challenge.t.sol
@@ -2,9 +2,8 @@
 pragma solidity 0.8.15;
 
 import { ClaimAlreadyResolved } from "src/libraries/bridge/Errors.sol";
-import { IAnchorStateRegistry } from "interfaces/L1/proofs/IAnchorStateRegistry.sol";
 import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
-import { GameStatus, Hash } from "src/libraries/bridge/Types.sol";
+import { GameStatus } from "src/libraries/bridge/Types.sol";
 import { Claim } from "src/libraries/bridge/LibUDT.sol";
 
 import { AggregateVerifier } from "src/L1/proofs/AggregateVerifier.sol";
@@ -13,298 +12,207 @@ import { Verifier } from "src/L1/proofs/Verifier.sol";
 import { BaseTest } from "./BaseTest.t.sol";
 
 contract ChallengeTest is BaseTest {
+    uint256 private constant LAST_INTERMEDIATE_ROOT_INDEX = BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1;
+
     function testChallengeTEEProofWithZKProof() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
+        AggregateVerifier game =
+            _createGame(TEE_PROVER, "tee", "tee-proof", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry));
 
-        // Create game with TEE proof
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee")));
-        bytes memory teeProof = _generateProof("tee-proof", AggregateVerifier.ProofType.TEE);
-
-        AggregateVerifier game = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), teeProof
-        );
-
-        // Challenge game with ZK proof
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk")));
-        bytes memory zkProof = _generateProof("zk-proof", AggregateVerifier.ProofType.ZK);
-
-        vm.prank(ZK_PROVER);
-        game.challenge(zkProof, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim2.raw());
-
+        _challengeWithZk(game, "zk");
         assertEq(uint8(game.status()), uint8(GameStatus.IN_PROGRESS));
-        // 2 proofs so that it can decrease to 1 if ZK is nullified and then the TEE proof can resolve
         assertEq(game.proofCount(), 2);
 
-        // Resolve after SLOW_FINALIZATION_DELAY
-        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
-        game.resolve();
-
-        assertEq(uint8(game.status()), uint8(GameStatus.CHALLENGER_WINS));
-        assertEq(game.bondRecipient(), ZK_PROVER);
-
-        uint256 balanceBefore = ZK_PROVER.balance;
-        game.claimCredit();
-        vm.warp(block.timestamp + DELAYED_WETH_DELAY);
-        game.claimCredit();
-        assertEq(ZK_PROVER.balance, balanceBefore + INIT_BOND);
-        assertEq(delayedWETH.balanceOf(address(game)), 0);
+        _resolveAfterSlowDelayAndClaim(game, GameStatus.CHALLENGER_WINS, ZK_PROVER);
     }
 
     function testChallengeFailsIfNoTEEProof() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        // Create first game with ZK proof (no TEE proof)
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk1")));
-        bytes memory zkProof1 = _generateProof("zk-proof-1", AggregateVerifier.ProofType.ZK);
-
-        AggregateVerifier game1 = _createAggregateVerifierGame(
-            ZK_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), zkProof1
-        );
-
-        // Challenge game with ZK proof
-        bytes memory zkProof2 = _generateProof("zk-proof-2", AggregateVerifier.ProofType.ZK);
+        AggregateVerifier game =
+            _createGame(ZK_PROVER, "zk1", "zk-proof-1", AggregateVerifier.ProofType.ZK, address(anchorStateRegistry));
 
         vm.expectRevert(
             abi.encodeWithSelector(AggregateVerifier.MissingProof.selector, AggregateVerifier.ProofType.TEE)
         );
-        game1.challenge(zkProof2, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim1.raw());
+        _challenge(game, AggregateVerifier.ProofType.ZK, bytes32(0));
     }
 
     function testChallengeFailsIfNotZKProof() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee1")));
-        bytes memory teeProof1 = _generateProof("tee-proof-1", AggregateVerifier.ProofType.TEE);
-
-        AggregateVerifier game1 = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), teeProof1
+        AggregateVerifier game = _createGame(
+            TEE_PROVER, "tee1", "tee-proof-1", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry)
         );
 
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee2")));
-        bytes memory teeProof2 = _generateProof("tee-proof-2", AggregateVerifier.ProofType.TEE);
-
         vm.expectRevert(AggregateVerifier.InvalidProofType.selector);
-        game1.challenge(teeProof2, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim2.raw());
+        _challenge(game, AggregateVerifier.ProofType.TEE, bytes32(0));
     }
 
     function testChallengeFailsIfGameAlreadyResolved() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
+        AggregateVerifier game =
+            _createGame(TEE_PROVER, "tee", "tee-proof", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry));
 
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee")));
-        bytes memory teeProof = _generateProof("tee-proof", AggregateVerifier.ProofType.TEE);
-
-        AggregateVerifier game1 = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), teeProof
-        );
-
-        // Resolve game1
-        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY + 1);
-        game1.resolve();
-
-        // Try to challenge game1
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk1")));
-        bytes memory zkProof = _generateProof("zk-proof", AggregateVerifier.ProofType.ZK);
+        vm.warp(block.timestamp + game.SLOW_FINALIZATION_DELAY() + 1);
+        game.resolve();
 
         vm.expectRevert(ClaimAlreadyResolved.selector);
-        game1.challenge(zkProof, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim2.raw());
+        _challenge(game, AggregateVerifier.ProofType.ZK, bytes32(0));
     }
 
     function testChallengeFailsIfParentGameStatusIsChallenged() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        // create parent game
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee")));
-        bytes memory parentProof = _generateProof("parent-proof", AggregateVerifier.ProofType.TEE);
-
-        AggregateVerifier parentGame = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), parentProof
+        AggregateVerifier parentGame = _createGame(
+            TEE_PROVER, "tee", "parent-proof", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry)
         );
 
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        // create child game
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee2")));
-        bytes memory childProof = _generateProof("child-proof", AggregateVerifier.ProofType.TEE);
-
         AggregateVerifier childGame =
-            _createAggregateVerifierGame(TEE_PROVER, rootClaim2, currentL2BlockNumber, address(parentGame), childProof);
+            _createGame(TEE_PROVER, "tee2", "child-proof", AggregateVerifier.ProofType.TEE, address(parentGame));
 
-        // blacklist parent game
         anchorStateRegistry.blacklistDisputeGame(IDisputeGame(address(parentGame)));
 
-        // challenge child game with ZK proof
-        Claim rootClaim3 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk")));
-        bytes memory zkProof = _generateProof("zk-proof", AggregateVerifier.ProofType.ZK);
-
         vm.expectRevert(AggregateVerifier.InvalidParentGame.selector);
-        childGame.challenge(zkProof, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim3.raw());
+        _challenge(childGame, AggregateVerifier.ProofType.ZK, bytes32(0));
     }
 
     function testChallengeFailsIfGameItselfIsBlacklisted() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaim = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee")));
-        bytes memory proof = _generateProof("tee-proof", AggregateVerifier.ProofType.TEE);
+        AggregateVerifier game =
+            _createGame(TEE_PROVER, "tee", "tee-proof", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry));
 
-        AggregateVerifier game = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proof
-        );
-
-        // blacklist game
         anchorStateRegistry.blacklistDisputeGame(IDisputeGame(address(game)));
 
-        // challenge game
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk")));
-        bytes memory zkProof = _generateProof("zk-proof", AggregateVerifier.ProofType.ZK);
-
         vm.expectRevert(AggregateVerifier.InvalidGame.selector);
-        game.challenge(zkProof, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim2.raw());
+        _challenge(game, AggregateVerifier.ProofType.ZK, bytes32(0));
     }
 
     function testChallengeFailsAfterTEENullification() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee1")));
-        bytes memory teeProof1 = _generateProof("tee-proof-1", AggregateVerifier.ProofType.TEE);
-
-        AggregateVerifier game = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), teeProof1
+        AggregateVerifier game = _createGame(
+            TEE_PROVER, "tee1", "tee-proof-1", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry)
         );
 
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee2")));
-        bytes memory teeProof2 = _generateProof("tee-proof-2", AggregateVerifier.ProofType.TEE);
-
-        game.nullify(teeProof2, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim2.raw());
-
-        // challenge game — TEE proof was nullified, so MissingProof(TEE) is expected
-        Claim rootClaim3 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk")));
-        bytes memory zkProof = _generateProof("zk-proof", AggregateVerifier.ProofType.ZK);
-
+        _nullify(game, AggregateVerifier.ProofType.TEE, "tee2");
         vm.expectRevert(
             abi.encodeWithSelector(AggregateVerifier.MissingProof.selector, AggregateVerifier.ProofType.TEE)
         );
-        game.challenge(zkProof, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim3.raw());
+        _challenge(game, AggregateVerifier.ProofType.ZK, bytes32(0));
     }
 
     function testChallengeFailsAfterZKNullification() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee")));
-        bytes memory teeProof = _generateProof("tee-proof", AggregateVerifier.ProofType.TEE);
-        bytes memory zkProof1 = _generateProof("zk-proof-1", AggregateVerifier.ProofType.ZK);
+        AggregateVerifier game =
+            _createGame(ZK_PROVER, "tee", "tee-proof", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry));
 
-        // create game with both proofs
-        AggregateVerifier game = _createAggregateVerifierGame(
-            ZK_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), teeProof
-        );
-        game.verifyProposalProof(zkProof1);
-
-        // nullify ZK proof
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk2")));
-        bytes memory zkProof2 = _generateProof("zk-proof-2", AggregateVerifier.ProofType.ZK);
-        game.nullify(zkProof2, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim2.raw());
-
-        // challenge game — ZK is nullified so Nullified() is expected
-        Claim rootClaim3 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk3")));
-        bytes memory zkProof3 = _generateProof("zk-proof-3", AggregateVerifier.ProofType.ZK);
-
+        _provideProof(game, ZK_PROVER, _proofOfType(AggregateVerifier.ProofType.ZK));
+        _nullify(game, AggregateVerifier.ProofType.ZK, "zk2");
         vm.expectRevert(Verifier.Nullified.selector);
-        game.challenge(zkProof3, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim3.raw());
+        _challenge(game, AggregateVerifier.ProofType.ZK, _claim("zk3").raw());
     }
 
-    /// @notice A TEE+ZK challenge on game A is cleared when another game nullifies the shared ZK verifier; A then
-    ///         resolves as defender after `SLOW_FINALIZATION_DELAY`.
     function testChallengeRemovedWhenZkVerifierNullifiedByOtherGame() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaimA = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee-challenge")));
-        bytes memory teeProofA = _generateProof("tee-ch-a", AggregateVerifier.ProofType.TEE);
-        AggregateVerifier gameA = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaimA, currentL2BlockNumber, address(anchorStateRegistry), teeProofA
+        AggregateVerifier gameA = _createGame(
+            TEE_PROVER, "tee-challenge", "tee-ch-a", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry)
         );
 
-        Claim rootChallenge = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk-challenge")));
-        bytes memory zkChallenge = _generateProof("zk-challenge", AggregateVerifier.ProofType.ZK);
-        vm.prank(ZK_PROVER);
-        gameA.challenge(zkChallenge, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootChallenge.raw());
+        _challengeWithZk(gameA, "zk-challenge");
+        _assertChallengeRecorded(gameA);
 
-        assertEq(gameA.proofCount(), 2);
-        assertGt(gameA.counteredByIntermediateRootIndexPlusOne(), 0);
-
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaimB = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk-only-b")));
-        bytes memory zkProofB = _generateProof("zk-init-b", AggregateVerifier.ProofType.ZK);
         AggregateVerifier gameB =
-            _createAggregateVerifierGame(ZK_PROVER, rootClaimB, currentL2BlockNumber, address(gameA), zkProofB);
-
-        Claim rootNullifyB = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk-nullify-b")));
-        bytes memory zkNullifyB = _generateProof("zk-nullify-b", AggregateVerifier.ProofType.ZK);
-        uint256 lastIdx = BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1;
-        gameB.nullify(zkNullifyB, lastIdx, rootNullifyB.raw());
+            _createGame(ZK_PROVER, "zk-only-b", "zk-init-b", AggregateVerifier.ProofType.ZK, address(gameA));
+        _nullify(gameB, AggregateVerifier.ProofType.ZK, "zk-nullify-b");
         assertTrue(zkVerifier.nullified());
 
-        assertEq(uint8(gameA.resolve()), uint8(GameStatus.IN_PROGRESS));
+        _resolveAndAssertStatus(gameA, GameStatus.IN_PROGRESS);
         assertEq(gameA.proofCount(), 1);
         assertEq(gameA.counteredByIntermediateRootIndexPlusOne(), 0);
         assertEq(address(gameA.zkProver()), address(0));
 
-        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
-        assertEq(uint8(gameA.resolve()), uint8(GameStatus.DEFENDER_WINS));
-        assertEq(gameA.bondRecipient(), TEE_PROVER);
-
-        uint256 balanceBefore = TEE_PROVER.balance;
-        gameA.claimCredit();
-        vm.warp(block.timestamp + DELAYED_WETH_DELAY);
-        gameA.claimCredit();
-        assertEq(TEE_PROVER.balance, balanceBefore + INIT_BOND);
-        assertEq(delayedWETH.balanceOf(address(gameA)), 0);
+        _resolveAfterSlowDelayAndClaim(gameA, GameStatus.DEFENDER_WINS, TEE_PROVER);
     }
 
-    /// @notice Game A is created with TEE and challenged with ZK. Another game nullifies the shared TEE verifier.
-    ///         The first `resolve` persists the TEE refutation; after `SLOW_FINALIZATION_DELAY`, A finalizes as
-    ///         challenger wins and the bond goes to the ZK challenger.
     function testChallengeWinsWhenSharedTeeVerifierNullifiedByOtherGame() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaimA = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee-challenge-tee-null")));
-        bytes memory teeProofA = _generateProof("tee-proof-a", AggregateVerifier.ProofType.TEE);
-        AggregateVerifier gameA = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaimA, currentL2BlockNumber, address(anchorStateRegistry), teeProofA
+        AggregateVerifier gameA = _createGame(
+            TEE_PROVER,
+            "tee-challenge-tee-null",
+            "tee-proof-a",
+            AggregateVerifier.ProofType.TEE,
+            address(anchorStateRegistry)
         );
 
-        Claim rootChallenge = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk-challenge")));
-        bytes memory zkChallenge = _generateProof("zk-challenge", AggregateVerifier.ProofType.ZK);
-        vm.prank(ZK_PROVER);
-        gameA.challenge(zkChallenge, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootChallenge.raw());
+        _challengeWithZk(gameA, "zk-challenge");
+        _assertChallengeRecorded(gameA);
 
-        assertEq(gameA.proofCount(), 2);
-        assertGt(gameA.counteredByIntermediateRootIndexPlusOne(), 0);
-
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaimB = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee-only-b")));
-        bytes memory teeProofB = _generateProof("tee-init-b", AggregateVerifier.ProofType.TEE);
         AggregateVerifier gameB =
-            _createAggregateVerifierGame(TEE_PROVER, rootClaimB, currentL2BlockNumber, address(gameA), teeProofB);
-
-        Claim rootNullifyB = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee-nullify-b")));
-        bytes memory teeNullifyB = _generateProof("tee-nullify-b", AggregateVerifier.ProofType.TEE);
-        uint256 lastIdx = BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1;
-        gameB.nullify(teeNullifyB, lastIdx, rootNullifyB.raw());
+            _createGame(TEE_PROVER, "tee-only-b", "tee-init-b", AggregateVerifier.ProofType.TEE, address(gameA));
+        _nullify(gameB, AggregateVerifier.ProofType.TEE, "tee-nullify-b");
         assertTrue(teeVerifier.nullified());
 
-        assertEq(uint8(gameA.resolve()), uint8(GameStatus.IN_PROGRESS));
+        _resolveAndAssertStatus(gameA, GameStatus.IN_PROGRESS);
         assertEq(gameA.proofCount(), 1);
         assertGt(gameA.counteredByIntermediateRootIndexPlusOne(), 0);
         assertEq(address(gameA.teeProver()), address(0));
         assertEq(gameA.zkProver(), ZK_PROVER);
 
-        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
-        assertEq(uint8(gameA.resolve()), uint8(GameStatus.CHALLENGER_WINS));
-        assertEq(gameA.bondRecipient(), ZK_PROVER);
+        _resolveAfterSlowDelayAndClaim(gameA, GameStatus.CHALLENGER_WINS, ZK_PROVER);
+    }
 
-        uint256 balanceBefore = ZK_PROVER.balance;
-        gameA.claimCredit();
+    function _createGame(
+        address prover,
+        bytes memory claimSalt,
+        bytes memory proofSalt,
+        AggregateVerifier.ProofType proofType,
+        address parent
+    )
+        private
+        returns (AggregateVerifier)
+    {
+        currentL2BlockNumber += BLOCK_INTERVAL;
+        Claim rootClaim = _claim(claimSalt);
+        bytes memory proof = _generateProof(proofSalt, proofType);
+        return _createAggregateVerifierGame(prover, rootClaim, currentL2BlockNumber, parent, proof);
+    }
+
+    function _challenge(AggregateVerifier game, AggregateVerifier.ProofType proofType, bytes32 claimRoot) private {
+        game.challenge(_proofOfType(proofType), LAST_INTERMEDIATE_ROOT_INDEX, claimRoot);
+    }
+
+    function _challengeWithZk(AggregateVerifier game, bytes memory claimSalt) private {
+        vm.prank(ZK_PROVER);
+        _challenge(game, AggregateVerifier.ProofType.ZK, _claim(claimSalt).raw());
+    }
+
+    function _nullify(AggregateVerifier game, AggregateVerifier.ProofType proofType, bytes memory claimSalt) private {
+        game.nullify(_proofOfType(proofType), LAST_INTERMEDIATE_ROOT_INDEX, _claim(claimSalt).raw());
+    }
+
+    function _proofOfType(AggregateVerifier.ProofType proofType) private pure returns (bytes memory) {
+        return abi.encodePacked(uint8(proofType), bytes1(0));
+    }
+
+    function _claim(bytes memory salt) private view returns (Claim) {
+        return Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, salt)));
+    }
+
+    function _assertChallengeRecorded(AggregateVerifier game) private view {
+        assertEq(game.proofCount(), 2);
+        assertGt(game.counteredByIntermediateRootIndexPlusOne(), 0);
+    }
+
+    function _resolveAndAssertStatus(AggregateVerifier game, GameStatus expectedStatus) private {
+        assertEq(uint8(game.resolve()), uint8(expectedStatus));
+    }
+
+    function _resolveAfterSlowDelayAndClaim(
+        AggregateVerifier game,
+        GameStatus expectedStatus,
+        address recipient
+    )
+        private
+    {
+        vm.warp(block.timestamp + game.SLOW_FINALIZATION_DELAY());
+        _resolveAndAssertStatus(game, expectedStatus);
+        assertEq(game.bondRecipient(), recipient);
+        _claimCreditAfterDelay(game, recipient);
+    }
+
+    function _claimCreditAfterDelay(AggregateVerifier game, address recipient) private {
+        uint256 balanceBefore = recipient.balance;
+        game.claimCredit();
         vm.warp(block.timestamp + DELAYED_WETH_DELAY);
-        gameA.claimCredit();
-        assertEq(ZK_PROVER.balance, balanceBefore + INIT_BOND);
-        assertEq(delayedWETH.balanceOf(address(gameA)), 0);
+        game.claimCredit();
+        assertEq(recipient.balance, balanceBefore + INIT_BOND);
+        assertEq(delayedWETH.balanceOf(address(game)), 0);
     }
 }

--- a/test/L1/proofs/DelayedWETH.t.sol
+++ b/test/L1/proofs/DelayedWETH.t.sol
@@ -3,71 +3,44 @@ pragma solidity ^0.8.15;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
+import { GasBurner, Reverter } from "test/mocks/Callers.sol";
 
 // Libraries
 import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
-import { Burn } from "src/libraries/Burn.sol";
-import "src/libraries/bridge/Types.sol";
-import "src/libraries/bridge/Errors.sol";
 
 // Interfaces
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 
-/// @title DelayedWETH_FallbackGasUser_Harness
-/// @notice Contract that burns gas in the fallback function.
-contract DelayedWETH_FallbackGasUser_Harness {
-    /// @notice Amount of gas to use in the fallback function.
-    uint256 public gas;
+/// @title DelayedWETH_TestBase
+/// @notice Reusable test utilities for `DelayedWETH` tests.
+abstract contract DelayedWETH_TestBase is CommonTest {
+    address internal constant DUMMY_SYSTEM_CONFIG = address(1234);
+    uint256 internal constant DEFAULT_AMOUNT = 1 ether;
 
-    /// @param _gas Amount of gas to use in the fallback function.
-    constructor(uint256 _gas) {
-        gas = _gas;
-    }
-
-    /// @notice Burn gas on fallback;
-    fallback() external payable {
-        Burn.gas(gas);
-    }
-
-    /// @notice Burn gas on receive.
-    receive() external payable {
-        Burn.gas(gas);
-    }
-}
-
-/// @title DelayedWETH_FallbackReverter_Harness
-/// @notice Contract that reverts in the fallback function.
-contract DelayedWETH_FallbackReverter_Harness {
-    /// @notice Revert on fallback.
-    fallback() external payable {
-        revert("FallbackReverter: revert");
-    }
-
-    /// @notice Revert on receive.
-    receive() external payable {
-        revert("FallbackReverter: revert");
-    }
-}
-
-/// @title DelayedWETH_TestInit
-/// @notice Reusable test initialization for `DelayedWETH` tests.
-abstract contract DelayedWETH_TestInit is CommonTest {
     event Approval(address indexed src, address indexed guy, uint256 wad);
-    event Transfer(address indexed src, address indexed dst, uint256 wad);
-    event Deposit(address indexed dst, uint256 wad);
     event Withdrawal(address indexed src, uint256 wad);
-    event Unwrap(address indexed src, uint256 wad);
 
-    function setUp() public virtual override {
-        super.setUp();
+    function _depositAlice(uint256 _amount) internal returns (uint256 balanceAfterDeposit_) {
+        vm.prank(alice);
+        delayedWeth.deposit{ value: _amount }();
+        balanceAfterDeposit_ = address(alice).balance;
     }
 }
 
 /// @title DelayedWETH_Initialize_Test
 /// @notice Tests the `initialize` function of the `DelayedWETH` contract.
-contract DelayedWETH_Initialize_Test is DelayedWETH_TestInit {
+contract DelayedWETH_Initialize_Test is DelayedWETH_TestBase {
+    bytes32 internal initializedSlot;
+
+    function setUp() public override {
+        super.setUp();
+
+        StorageSlot memory slot = ForgeArtifacts.getSlot("DelayedWETH", "_initialized");
+        initializedSlot = bytes32(slot.slot);
+    }
+
     /// @notice Tests that initialization is successful.
     function test_initialize_succeeds() public view {
         assertEq(delayedWeth.proxyAdminOwner(), proxyAdminOwner);
@@ -79,14 +52,9 @@ contract DelayedWETH_Initialize_Test is DelayedWETH_TestInit {
     ///         but confirms that the initValue is not incremented incorrectly if an upgrade
     ///         function is not present.
     function test_initialize_correctInitializerValue_succeeds() public view {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("DelayedWETH", "_initialized");
-
-        // Get the initializer value.
-        bytes32 slotVal = vm.load(address(delayedWeth), bytes32(slot.slot));
+        bytes32 slotVal = vm.load(address(delayedWeth), initializedSlot);
         uint8 val = uint8(uint256(slotVal) & 0xFF);
 
-        // Assert that the initializer value matches the expected value.
         assertEq(val, delayedWeth.initVersion());
     }
 
@@ -94,88 +62,86 @@ contract DelayedWETH_Initialize_Test is DelayedWETH_TestInit {
     ///         owner.
     /// @param _sender The address of the sender to test.
     function testFuzz_initialize_notProxyAdminOrProxyAdminOwner_reverts(address _sender) public {
-        // Prank as the not ProxyAdmin or ProxyAdmin owner.
         vm.assume(_sender != address(delayedWeth.proxyAdmin()) && _sender != delayedWeth.proxyAdminOwner());
 
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("DelayedWETH", "_initialized");
+        vm.store(address(delayedWeth), initializedSlot, bytes32(0));
 
-        // Set the initialized slot to 0.
-        vm.store(address(delayedWeth), bytes32(slot.slot), bytes32(0));
-
-        // Expect the revert with `ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner` selector.
         vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
-
-        // Call the `initialize` function with the sender.
         vm.prank(_sender);
-        delayedWeth.initialize(ISystemConfig(address(1234)));
+        delayedWeth.initialize(ISystemConfig(DUMMY_SYSTEM_CONFIG));
     }
 }
 
 /// @title DelayedWETH_Unlock_Test
 /// @notice Tests the `unlock` function of the `DelayedWETH` contract.
-contract DelayedWETH_Unlock_Test is DelayedWETH_TestInit {
+contract DelayedWETH_Unlock_Test is DelayedWETH_TestBase {
     /// @notice Tests that unlocking once is successful.
     function test_unlock_once_succeeds() public {
-        delayedWeth.unlock(alice, 1 ether);
+        delayedWeth.unlock(alice, DEFAULT_AMOUNT);
         (uint256 amount, uint256 timestamp) = delayedWeth.withdrawals(address(this), alice);
-        assertEq(amount, 1 ether);
+        assertEq(amount, DEFAULT_AMOUNT);
         assertEq(timestamp, block.timestamp);
     }
 
     /// @notice Tests that unlocking twice is successful and timestamp/amount is updated.
     function test_unlock_twice_succeeds() public {
-        // Unlock once.
         uint256 ts = block.timestamp;
-        delayedWeth.unlock(alice, 1 ether);
+        delayedWeth.unlock(alice, DEFAULT_AMOUNT);
         (uint256 amount1, uint256 timestamp1) = delayedWeth.withdrawals(address(this), alice);
-        assertEq(amount1, 1 ether);
+        assertEq(amount1, DEFAULT_AMOUNT);
         assertEq(timestamp1, ts);
 
-        // Go forward in time.
         vm.warp(ts + 1);
 
-        // Unlock again works.
-        delayedWeth.unlock(alice, 1 ether);
+        delayedWeth.unlock(alice, DEFAULT_AMOUNT);
         (uint256 amount2, uint256 timestamp2) = delayedWeth.withdrawals(address(this), alice);
-        assertEq(amount2, 2 ether);
+        assertEq(amount2, 2 * DEFAULT_AMOUNT);
         assertEq(timestamp2, ts + 1);
     }
 }
 
 /// @title DelayedWETH_Withdraw_Test
 /// @notice Tests the `withdraw` function of the `DelayedWETH` contract.
-contract DelayedWETH_Withdraw_Test is DelayedWETH_TestInit {
+contract DelayedWETH_Withdraw_Test is DelayedWETH_TestBase {
+    function _unlockAlice(uint256 _amount) internal {
+        vm.prank(alice);
+        delayedWeth.unlock(alice, _amount);
+    }
+
+    function _warpPastDelay() internal {
+        vm.warp(block.timestamp + delayedWeth.delay() + 1);
+    }
+
+    function _warpBeforeDelay() internal {
+        vm.warp(block.timestamp + delayedWeth.delay() - 1);
+    }
+
+    function _pauseSuperchain() internal {
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(address(0));
+    }
+
+    function _prepareUnlockedWithdrawal() internal returns (uint256 balanceAfterDeposit_) {
+        balanceAfterDeposit_ = _depositAlice(DEFAULT_AMOUNT);
+        _unlockAlice(DEFAULT_AMOUNT);
+        _warpPastDelay();
+    }
+
     /// @notice Tests that withdrawing while unlocked and delay has passed is successful.
     function test_withdraw_whileUnlocked_succeeds() public {
-        // Deposit some WETH.
-        vm.prank(alice);
-        delayedWeth.deposit{ value: 1 ether }();
-        uint256 balance = address(alice).balance;
+        uint256 balance = _prepareUnlockedWithdrawal();
 
-        // Unlock the withdrawal.
+        vm.expectEmit(address(delayedWeth));
+        emit Withdrawal(address(alice), DEFAULT_AMOUNT);
         vm.prank(alice);
-        delayedWeth.unlock(alice, 1 ether);
-
-        // Wait for the delay.
-        vm.warp(block.timestamp + delayedWeth.delay() + 1);
-
-        // Withdraw the WETH.
-        vm.expectEmit(true, true, false, false);
-        emit Withdrawal(address(alice), 1 ether);
-        vm.prank(alice);
-        delayedWeth.withdraw(1 ether);
-        assertEq(address(alice).balance, balance + 1 ether);
+        delayedWeth.withdraw(DEFAULT_AMOUNT);
+        assertEq(address(alice).balance, balance + DEFAULT_AMOUNT);
     }
 
     /// @notice Tests that withdrawing when unlock was not called fails.
     function test_withdraw_whileLocked_fails() public {
-        // Deposit some WETH.
-        vm.prank(alice);
-        delayedWeth.deposit{ value: 1 ether }();
-        uint256 balance = address(alice).balance;
+        uint256 balance = _depositAlice(DEFAULT_AMOUNT);
 
-        // Withdraw fails when unlock not called.
         vm.expectRevert("DelayedWETH: withdrawal not unlocked");
         vm.prank(alice);
         delayedWeth.withdraw(0 ether);
@@ -184,100 +150,50 @@ contract DelayedWETH_Withdraw_Test is DelayedWETH_TestInit {
 
     /// @notice Tests that withdrawing while locked and delay has not passed fails.
     function test_withdraw_whileLockedNotLongEnough_fails() public {
-        // Deposit some WETH.
-        vm.prank(alice);
-        delayedWeth.deposit{ value: 1 ether }();
-        uint256 balance = address(alice).balance;
+        uint256 balance = _depositAlice(DEFAULT_AMOUNT);
+        _unlockAlice(DEFAULT_AMOUNT);
+        _warpBeforeDelay();
 
-        // Call unlock.
-        vm.prank(alice);
-        delayedWeth.unlock(alice, 1 ether);
-
-        // Wait for the delay, but not long enough.
-        vm.warp(block.timestamp + delayedWeth.delay() - 1);
-
-        // Withdraw fails when delay not met.
         vm.expectRevert("DelayedWETH: withdrawal delay not met");
         vm.prank(alice);
-        delayedWeth.withdraw(1 ether);
+        delayedWeth.withdraw(DEFAULT_AMOUNT);
         assertEq(address(alice).balance, balance);
     }
 
     /// @notice Tests that withdrawing more than unlocked amount fails.
     function test_withdraw_tooMuch_fails() public {
-        // Deposit some WETH.
-        vm.prank(alice);
-        delayedWeth.deposit{ value: 1 ether }();
-        uint256 balance = address(alice).balance;
+        uint256 balance = _prepareUnlockedWithdrawal();
 
-        // Unlock the withdrawal.
-        vm.prank(alice);
-        delayedWeth.unlock(alice, 1 ether);
-
-        // Wait for the delay.
-        vm.warp(block.timestamp + delayedWeth.delay() + 1);
-
-        // Withdraw too much fails.
         vm.expectRevert("DelayedWETH: insufficient unlocked withdrawal");
         vm.prank(alice);
-        delayedWeth.withdraw(2 ether);
+        delayedWeth.withdraw(2 * DEFAULT_AMOUNT);
         assertEq(address(alice).balance, balance);
     }
 
     /// @notice Tests that withdrawing while paused fails.
     function test_withdraw_whenPaused_fails() public {
-        // Deposit some WETH.
-        vm.prank(alice);
-        delayedWeth.deposit{ value: 1 ether }();
+        _pauseSuperchain();
 
-        // Unlock the withdrawal.
-        vm.prank(alice);
-        delayedWeth.unlock(alice, 1 ether);
-
-        // Wait for the delay.
-        vm.warp(block.timestamp + delayedWeth.delay() + 1);
-
-        // Pause the contract.
-        address guardian = optimismPortal2.guardian();
-        vm.prank(guardian);
-        superchainConfig.pause(address(0));
-
-        // Withdraw fails.
         vm.expectRevert("DelayedWETH: contract is paused");
         vm.prank(alice);
-        delayedWeth.withdraw(1 ether);
+        delayedWeth.withdraw(DEFAULT_AMOUNT);
     }
 
     /// @notice Tests that withdrawing while unlocked and delay has passed is successful.
     function test_withdraw_withdrawFromWhileUnlocked_succeeds() public {
-        // Deposit some WETH.
-        vm.prank(alice);
-        delayedWeth.deposit{ value: 1 ether }();
-        uint256 balance = address(alice).balance;
+        uint256 balance = _prepareUnlockedWithdrawal();
 
-        // Unlock the withdrawal.
+        vm.expectEmit(address(delayedWeth));
+        emit Withdrawal(address(alice), DEFAULT_AMOUNT);
         vm.prank(alice);
-        delayedWeth.unlock(alice, 1 ether);
-
-        // Wait for the delay.
-        vm.warp(block.timestamp + delayedWeth.delay() + 1);
-
-        // Withdraw the WETH.
-        vm.expectEmit(true, true, false, false);
-        emit Withdrawal(address(alice), 1 ether);
-        vm.prank(alice);
-        delayedWeth.withdraw(alice, 1 ether);
-        assertEq(address(alice).balance, balance + 1 ether);
+        delayedWeth.withdraw(alice, DEFAULT_AMOUNT);
+        assertEq(address(alice).balance, balance + DEFAULT_AMOUNT);
     }
 
     /// @notice Tests that withdrawing when unlock was not called fails.
     function test_withdraw_withdrawFromWhileLocked_fails() public {
-        // Deposit some WETH.
-        vm.prank(alice);
-        delayedWeth.deposit{ value: 1 ether }();
-        uint256 balance = address(alice).balance;
+        uint256 balance = _depositAlice(DEFAULT_AMOUNT);
 
-        // Withdraw fails when unlock not called.
         vm.expectRevert("DelayedWETH: withdrawal not unlocked");
         vm.prank(alice);
         delayedWeth.withdraw(alice, 0 ether);
@@ -286,210 +202,144 @@ contract DelayedWETH_Withdraw_Test is DelayedWETH_TestInit {
 
     /// @notice Tests that withdrawing while locked and delay has not passed fails.
     function test_withdraw_withdrawFromWhileLockedNotLongEnough_fails() public {
-        // Deposit some WETH.
-        vm.prank(alice);
-        delayedWeth.deposit{ value: 1 ether }();
-        uint256 balance = address(alice).balance;
+        uint256 balance = _depositAlice(DEFAULT_AMOUNT);
+        _unlockAlice(DEFAULT_AMOUNT);
+        _warpBeforeDelay();
 
-        // Call unlock.
-        vm.prank(alice);
-        delayedWeth.unlock(alice, 1 ether);
-
-        // Wait for the delay, but not long enough.
-        vm.warp(block.timestamp + delayedWeth.delay() - 1);
-
-        // Withdraw fails when delay not met.
         vm.expectRevert("DelayedWETH: withdrawal delay not met");
         vm.prank(alice);
-        delayedWeth.withdraw(alice, 1 ether);
+        delayedWeth.withdraw(alice, DEFAULT_AMOUNT);
         assertEq(address(alice).balance, balance);
     }
 
     /// @notice Tests that withdrawing more than unlocked amount fails.
     function test_withdraw_withdrawFromTooMuch_fails() public {
-        // Deposit some WETH.
-        vm.prank(alice);
-        delayedWeth.deposit{ value: 1 ether }();
-        uint256 balance = address(alice).balance;
+        uint256 balance = _prepareUnlockedWithdrawal();
 
-        // Unlock the withdrawal.
-        vm.prank(alice);
-        delayedWeth.unlock(alice, 1 ether);
-
-        // Wait for the delay.
-        vm.warp(block.timestamp + delayedWeth.delay() + 1);
-
-        // Withdraw too much fails.
         vm.expectRevert("DelayedWETH: insufficient unlocked withdrawal");
         vm.prank(alice);
-        delayedWeth.withdraw(alice, 2 ether);
+        delayedWeth.withdraw(alice, 2 * DEFAULT_AMOUNT);
         assertEq(address(alice).balance, balance);
     }
 
     /// @notice Tests that withdrawing while paused fails.
     function test_withdraw_withdrawFromWhenPaused_fails() public {
-        // Deposit some WETH.
-        vm.prank(alice);
-        delayedWeth.deposit{ value: 1 ether }();
+        _pauseSuperchain();
 
-        // Unlock the withdrawal.
-        vm.prank(alice);
-        delayedWeth.unlock(alice, 1 ether);
-
-        // Wait for the delay.
-        vm.warp(block.timestamp + delayedWeth.delay() + 1);
-
-        // Pause the contract.
-        address guardian = optimismPortal2.guardian();
-        vm.prank(guardian);
-        superchainConfig.pause(address(0));
-
-        // Withdraw fails.
         vm.expectRevert("DelayedWETH: contract is paused");
         vm.prank(alice);
-        delayedWeth.withdraw(alice, 1 ether);
+        delayedWeth.withdraw(alice, DEFAULT_AMOUNT);
     }
 }
 
 /// @title DelayedWETH_Recover_Test
 /// @notice Tests the `recover` function of the `DelayedWETH` contract.
-contract DelayedWETH_Recover_Test is DelayedWETH_TestInit {
-    /// @notice Tests that recovering WETH succeeds. Makes sure that doing so succeeds with any
-    ///         amount of ETH in the contract and any amount of gas used in the fallback function
-    ///         up to a maximum of 20,000,000 gas. Owner contract should never be using that much
-    ///         gas but we might as well set a very large upper bound for ourselves.
-    /// @param _amount Amount of WETH to recover.
-    /// @param _fallbackGasUsage Amount of gas to use in the fallback function.
-    function testFuzz_recover_succeeds(uint256 _amount, uint256 _fallbackGasUsage) public {
-        // Assume
-        _fallbackGasUsage = bound(_fallbackGasUsage, 0, 20000000);
+contract DelayedWETH_Recover_Test is DelayedWETH_TestBase {
+    uint256 internal constant MAX_FALLBACK_GAS_USAGE = 20_000_000;
 
-        // Set up the gas burner.
-        DelayedWETH_FallbackGasUser_Harness gasUser = new DelayedWETH_FallbackGasUser_Harness(_fallbackGasUsage);
+    function _mockProxyAdminOwner(address _owner) internal {
+        vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(_owner));
+    }
 
-        // Mock owner to return the gas user.
-        vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(address(gasUser)));
+    function _recoverToGasBurner(uint256 _amount, uint256 _fallbackGasUsage) internal {
+        GasBurner gasUser = new GasBurner(_fallbackGasUsage + 500);
 
-        // Give the contract some WETH to recover.
+        _mockProxyAdminOwner(address(gasUser));
+
         vm.deal(address(delayedWeth), _amount);
 
-        // Record the initial balance.
         uint256 initialBalance = address(gasUser).balance;
 
-        // Recover the WETH.
         vm.prank(address(gasUser));
         delayedWeth.recover(_amount);
 
-        // Verify the WETH was recovered.
         assertEq(address(delayedWeth).balance, 0);
         assertEq(address(gasUser).balance, initialBalance + _amount);
     }
 
+    /// @notice Tests that recovering WETH succeeds. Makes sure that doing so succeeds with any
+    ///         amount of ETH in the contract.
+    /// @param _amount Amount of WETH to recover.
+    function testFuzz_recover_succeeds(uint256 _amount) public {
+        _recoverToGasBurner(_amount, 0);
+    }
+
+    /// @notice Tests that recovering WETH succeeds when the recipient uses the maximum allowed fallback gas.
+    function test_recover_withMaxFallbackGas_succeeds() public {
+        _recoverToGasBurner(DEFAULT_AMOUNT, MAX_FALLBACK_GAS_USAGE);
+    }
+
     /// @notice Tests that recovering WETH by non-owner fails.
     function test_recover_byNonOwner_fails() public {
-        // Pretend to be a non-owner.
         vm.prank(alice);
 
-        // Recover fails.
         vm.expectRevert("DelayedWETH: not owner");
-        delayedWeth.recover(1 ether);
+        delayedWeth.recover(DEFAULT_AMOUNT);
     }
 
     /// @notice Tests that recovering more than the balance recovers what it can.
     function test_recover_moreThanBalance_succeeds() public {
-        // Mock owner to return alice.
-        vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(alice));
+        _mockProxyAdminOwner(alice);
 
-        // Give the contract some WETH to recover.
         vm.deal(address(delayedWeth), 0.5 ether);
 
-        // Record the initial balance.
         uint256 initialBalance = address(alice).balance;
 
-        // Recover the WETH.
         vm.prank(alice);
-        delayedWeth.recover(1 ether);
+        delayedWeth.recover(DEFAULT_AMOUNT);
 
-        // Verify the WETH was recovered.
         assertEq(address(delayedWeth).balance, 0);
         assertEq(address(alice).balance, initialBalance + 0.5 ether);
     }
 
     /// @notice Tests that recover reverts when recipient reverts.
     function test_recover_whenRecipientReverts_fails() public {
-        // Set up the reverter.
-        DelayedWETH_FallbackReverter_Harness reverter = new DelayedWETH_FallbackReverter_Harness();
+        Reverter reverter = new Reverter();
 
-        // Mock owner to return the reverter.
-        vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(address(reverter)));
+        _mockProxyAdminOwner(address(reverter));
 
-        // Give the contract some WETH to recover.
-        vm.deal(address(delayedWeth), 1 ether);
+        vm.deal(address(delayedWeth), DEFAULT_AMOUNT);
 
-        // Recover fails.
         vm.expectRevert("DelayedWETH: recover failed");
         vm.prank(address(reverter));
-        delayedWeth.recover(1 ether);
+        delayedWeth.recover(DEFAULT_AMOUNT);
     }
 }
 
 /// @title DelayedWETH_Hold_Test
 /// @notice Tests the `hold` function of the `DelayedWETH` contract.
-contract DelayedWETH_Hold_Test is DelayedWETH_TestInit {
+contract DelayedWETH_Hold_Test is DelayedWETH_TestBase {
     /// @notice Tests that holding WETH succeeds.
     function test_hold_byOwner_succeeds() public {
-        uint256 amount = 1 ether;
-
-        // Pretend to be alice and deposit some WETH.
-        vm.prank(alice);
-        delayedWeth.deposit{ value: amount }();
-
-        // Get our balance before.
+        _depositAlice(DEFAULT_AMOUNT);
         uint256 initialBalance = delayedWeth.balanceOf(address(proxyAdminOwner));
 
-        // Hold some WETH.
-        vm.expectEmit(true, true, true, false);
-        emit Approval(alice, address(proxyAdminOwner), amount);
+        vm.expectEmit(address(delayedWeth));
+        emit Approval(alice, address(proxyAdminOwner), DEFAULT_AMOUNT);
         vm.prank(proxyAdminOwner);
-        delayedWeth.hold(alice, amount);
+        delayedWeth.hold(alice, DEFAULT_AMOUNT);
 
-        // Get our balance after.
-        uint256 finalBalance = delayedWeth.balanceOf(address(proxyAdminOwner));
-
-        // Verify the transfer.
-        assertEq(finalBalance, initialBalance + amount);
+        assertEq(delayedWeth.balanceOf(address(proxyAdminOwner)), initialBalance + DEFAULT_AMOUNT);
     }
 
+    /// @notice Tests that holding all WETH succeeds when the amount is omitted.
     function test_hold_withoutAmount_succeeds() public {
-        uint256 amount = 1 ether;
-
-        // Pretend to be alice and deposit some WETH.
-        vm.prank(alice);
-        delayedWeth.deposit{ value: amount }();
-
-        // Get our balance before.
+        _depositAlice(DEFAULT_AMOUNT);
         uint256 initialBalance = delayedWeth.balanceOf(address(proxyAdminOwner));
 
-        // Hold some WETH.
-        vm.expectEmit(true, true, true, false);
-        emit Approval(alice, address(proxyAdminOwner), amount);
+        vm.expectEmit(address(delayedWeth));
+        emit Approval(alice, address(proxyAdminOwner), DEFAULT_AMOUNT);
         vm.prank(proxyAdminOwner);
-        delayedWeth.hold(alice); // without amount parameter
+        delayedWeth.hold(alice);
 
-        // Get our balance after.
-        uint256 finalBalance = delayedWeth.balanceOf(address(proxyAdminOwner));
-
-        // Verify the transfer.
-        assertEq(finalBalance, initialBalance + amount);
+        assertEq(delayedWeth.balanceOf(address(proxyAdminOwner)), initialBalance + DEFAULT_AMOUNT);
     }
 
     /// @notice Tests that holding WETH by non-owner fails.
     function test_hold_byNonOwner_fails() public {
-        // Pretend to be a non-owner.
         vm.prank(alice);
 
-        // Hold fails.
         vm.expectRevert("DelayedWETH: not owner");
-        delayedWeth.hold(bob, 1 ether);
+        delayedWeth.hold(bob, DEFAULT_AMOUNT);
     }
 }

--- a/test/L1/proofs/DisputeGameFactory.t.sol
+++ b/test/L1/proofs/DisputeGameFactory.t.sol
@@ -8,9 +8,8 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
 
 // Libraries
-import { Timestamp } from "src/libraries/bridge/LibUDT.sol";
+import { Claim, Timestamp } from "src/libraries/bridge/LibUDT.sol";
 import "src/libraries/bridge/Types.sol";
-import "src/libraries/bridge/Errors.sol";
 import { AggregateVerifier } from "src/L1/proofs/AggregateVerifier.sol";
 
 // Interfaces
@@ -44,14 +43,19 @@ contract DisputeGameFactory_FakeClone_Harness {
 /// @title DisputeGameFactory_TestInit
 /// @notice Reusable test initialization for `DisputeGameFactory` tests.
 abstract contract DisputeGameFactory_TestInit is CommonTest {
+    uint256 internal constant DEFAULT_INIT_BOND = 0.08 ether;
+    uint256 internal constant L2_CHAIN_ID = 111;
+    uint256 internal constant AGGREGATE_BLOCK_INTERVAL = 100;
+    uint256 internal constant AGGREGATE_INTERMEDIATE_BLOCK_INTERVAL = 10;
+    uint32 internal constant MAX_GAME_TYPE = 8;
+    address internal constant NON_OWNER = address(0xBEEF);
+
     DisputeGameFactory_FakeClone_Harness fakeClone;
 
     event DisputeGameCreated(address indexed disputeProxy, GameType indexed gameType, Claim indexed rootClaim);
     event ImplementationSet(address indexed impl, GameType indexed gameType);
     event ImplementationArgsSet(GameType indexed gameType, bytes args);
     event InitBondUpdated(GameType indexed gameType, uint256 indexed newBond);
-
-    uint256 l2ChainId = 111;
 
     function setUp() public virtual override {
         super.setUp();
@@ -63,47 +67,64 @@ abstract contract DisputeGameFactory_TestInit is CommonTest {
     }
 
     function _setGame(address _gameImpl, GameType _gameType) internal {
-        _setGame(_gameImpl, _gameType, false, "");
+        _setGame(_gameImpl, _gameType, DEFAULT_INIT_BOND);
     }
 
-    function _setGame(address _gameImpl, GameType _gameType, bytes memory _implArgs) internal {
-        _setGame(_gameImpl, _gameType, true, _implArgs);
-    }
-
-    function _setGame(address _gameImpl, GameType _gameType, bool _hasImplArgs, bytes memory _implArgs) internal {
+    function _setGame(address _gameImpl, GameType _gameType, uint256 _initBond) internal {
         vm.startPrank(disputeGameFactory.owner());
-        if (_hasImplArgs) {
-            disputeGameFactory.setImplementation(_gameType, IDisputeGame(_gameImpl), _implArgs);
-        } else {
-            disputeGameFactory.setImplementation(_gameType, IDisputeGame(_gameImpl));
-        }
-        disputeGameFactory.setInitBond(_gameType, 0.08 ether);
+        disputeGameFactory.setImplementation(_gameType, IDisputeGame(_gameImpl));
+        disputeGameFactory.setInitBond(_gameType, _initBond);
         vm.stopPrank();
+    }
+
+    function _expectNonOwnerRevert() internal {
+        vm.prank(NON_OWNER);
+        vm.expectRevert("Ownable: caller is not the owner");
+    }
+
+    function _assertCreatedGame(
+        GameType _gameType,
+        Claim _rootClaim,
+        bytes memory _extraData,
+        IDisputeGame _proxy,
+        uint256 _index
+    )
+        internal
+        view
+    {
+        (IDisputeGame game, Timestamp timestamp) = disputeGameFactory.games(_gameType, _rootClaim, _extraData);
+
+        assertEq(address(game), address(_proxy));
+        assertEq(Timestamp.unwrap(timestamp), block.timestamp);
+        assertEq(disputeGameFactory.gameCount(), _index + 1);
+
+        (GameType gameType, Timestamp timestampAtIndex, IDisputeGame gameAtIndex) =
+            disputeGameFactory.gameAtIndex(_index);
+        assertEq(GameType.unwrap(gameType), GameType.unwrap(_gameType));
+        assertEq(address(gameAtIndex), address(_proxy));
+        assertEq(Timestamp.unwrap(timestampAtIndex), block.timestamp);
     }
 }
 
 /// @title DisputeGameFactory_Initialize_Test
 /// @notice Tests the `initialize` function of the `DisputeGameFactory` contract.
 contract DisputeGameFactory_Initialize_Test is DisputeGameFactory_TestInit {
+    function _initializedSlot() internal view returns (bytes32) {
+        StorageSlot memory slot = ForgeArtifacts.getSlot("DisputeGameFactory", "_initialized");
+        return bytes32(slot.slot);
+    }
+
     /// @notice Tests that initialization reverts if called by a non-proxy admin or proxy admin
     ///         owner.
     /// @param _sender The address of the sender to test.
     function testFuzz_initialize_notProxyAdminOrProxyAdminOwner_reverts(address _sender) public {
-        // Prank as the not ProxyAdmin or ProxyAdmin owner.
         vm.assume(
             _sender != address(disputeGameFactory.proxyAdmin()) && _sender != disputeGameFactory.proxyAdminOwner()
         );
 
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("DisputeGameFactory", "_initialized");
+        vm.store(address(disputeGameFactory), _initializedSlot(), bytes32(0));
 
-        // Set the initialized slot to 0.
-        vm.store(address(disputeGameFactory), bytes32(slot.slot), bytes32(0));
-
-        // Expect the revert with `ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner` selector.
         vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
-
-        // Call the `initialize` function with the sender.
         vm.prank(_sender);
         disputeGameFactory.initialize(address(1234));
     }
@@ -112,14 +133,9 @@ contract DisputeGameFactory_Initialize_Test is DisputeGameFactory_TestInit {
     ///         but confirms that the initValue is not incremented incorrectly if an upgrade
     ///         function is not present.
     function test_initialize_correctInitializerValue_succeeds() public view {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("DisputeGameFactory", "_initialized");
-
-        // Get the initializer value.
-        bytes32 slotVal = vm.load(address(disputeGameFactory), bytes32(slot.slot));
+        bytes32 slotVal = vm.load(address(disputeGameFactory), _initializedSlot());
         uint8 val = uint8(uint256(slotVal) & 0xFF);
 
-        // Assert that the initializer value matches the expected value.
         assertEq(val, disputeGameFactory.initVersion());
     }
 }
@@ -137,17 +153,8 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
     )
         public
     {
-        // Ensure that the `gameType` is within the bounds of the `GameType` enum's possible
-        // values.
-        uint32 maxGameType = 8;
-        GameType gt = GameType.wrap(uint8(bound(gameType, 0, maxGameType)));
-
-        // Set all three implementations to the same `FakeClone` contract.
-        for (uint8 i; i < maxGameType + 1; i++) {
-            GameType lgt = GameType.wrap(i);
-            disputeGameFactory.setImplementation(lgt, IDisputeGame(address(fakeClone)));
-            disputeGameFactory.setInitBond(lgt, _value);
-        }
+        GameType gt = GameType.wrap(uint8(bound(gameType, 0, MAX_GAME_TYPE)));
+        _setGame(address(fakeClone), gt, _value);
 
         vm.deal(address(this), _value);
 
@@ -157,18 +164,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
         emit DisputeGameCreated(address(0), gt, rootClaim);
         IDisputeGame proxy = disputeGameFactory.create{ value: _value }(gt, rootClaim, extraData);
 
-        (IDisputeGame game, Timestamp timestamp) = disputeGameFactory.games(gt, rootClaim, extraData);
-
-        // Ensure that the dispute game was assigned to the `disputeGames` mapping.
-        assertEq(address(game), address(proxy));
-        assertEq(Timestamp.unwrap(timestamp), block.timestamp);
-        assertEq(disputeGameFactory.gameCount(), gameCountBefore + 1);
-
-        (, Timestamp timestamp2, IDisputeGame game2) = disputeGameFactory.gameAtIndex(gameCountBefore);
-        assertEq(address(game2), address(proxy));
-        assertEq(Timestamp.unwrap(timestamp2), block.timestamp);
-
-        // Ensure that the game proxy received the bonded ETH.
+        _assertCreatedGame(gt, rootClaim, extraData, proxy, gameCountBefore);
         assertEq(address(proxy).balance, _value);
     }
 
@@ -181,63 +177,41 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
     )
         public
     {
-        // Ensure that the `gameType` is within the bounds of the `GameType` enum's possible
-        // values.
         GameType gt = GameType.wrap(uint8(bound(gameType, 0, 2)));
+        _setGame(address(fakeClone), gt, 1 ether);
 
-        // Set all three implementations to the same `FakeClone` contract.
-        for (uint8 i; i < 3; i++) {
-            GameType lgt = GameType.wrap(i);
-            disputeGameFactory.setImplementation(lgt, IDisputeGame(address(fakeClone)));
-            disputeGameFactory.setInitBond(lgt, 1 ether);
-        }
-
-        vm.expectRevert(IncorrectBondAmount.selector);
+        vm.expectRevert(IDisputeGameFactory.IncorrectBondAmount.selector);
         disputeGameFactory.create(gt, rootClaim, extraData);
     }
 
     /// @notice Tests that the `create` function reverts when there is no implementation set for
     ///         the given `GameType`.
     function testFuzz_create_noImpl_reverts(uint32 gameType, Claim rootClaim, bytes calldata extraData) public {
-        // Ensure that the `gameType` is within the bounds of the `GameType` enum's possible
-        // values. We skip over game type = 0, since the deploy script set the implementation for
-        // that game type.
-        uint32 maxGameType = 8;
-        GameType gt = GameType.wrap(uint32(bound(gameType, maxGameType + 1, type(uint32).max)));
+        GameType gt = GameType.wrap(gameType);
+        vm.assume(address(disputeGameFactory.gameImpls(gt)) == address(0));
 
-        vm.expectRevert(abi.encodeWithSelector(NoImplementation.selector, gt));
+        vm.expectRevert(abi.encodeWithSelector(IDisputeGameFactory.NoImplementation.selector, gt));
         disputeGameFactory.create(gt, rootClaim, extraData);
     }
 
     /// @notice Tests that the `create` function reverts when there exists a dispute game with the
     ///         same UUID.
     function testFuzz_create_sameUUID_reverts(uint32 gameType, Claim rootClaim, bytes calldata extraData) public {
-        // Ensure that the `gameType` is within the bounds of the `GameType` enum's possible
-        // values.
-        uint32 maxGameType = 8;
-        GameType gt = GameType.wrap(uint8(bound(gameType, 0, maxGameType)));
-
-        // Set all three implementations to the same `FakeClone` contract.
-        for (uint8 i; i < maxGameType + 1; i++) {
-            disputeGameFactory.setImplementation(GameType.wrap(i), IDisputeGame(address(fakeClone)));
-        }
+        GameType gt = GameType.wrap(uint8(bound(gameType, 0, MAX_GAME_TYPE)));
+        disputeGameFactory.setImplementation(gt, IDisputeGame(address(fakeClone)));
 
         uint256 bondAmount = disputeGameFactory.initBonds(gt);
 
-        // Create our first dispute game - this should succeed.
         vm.expectEmit(false, true, true, false);
         emit DisputeGameCreated(address(0), gt, rootClaim);
+        uint256 gameCountBefore = disputeGameFactory.gameCount();
         IDisputeGame proxy = disputeGameFactory.create{ value: bondAmount }(gt, rootClaim, extraData);
+        _assertCreatedGame(gt, rootClaim, extraData, proxy, gameCountBefore);
 
-        (IDisputeGame game, Timestamp timestamp) = disputeGameFactory.games(gt, rootClaim, extraData);
-        // Ensure that the dispute game was assigned to the `disputeGames` mapping.
-        assertEq(address(game), address(proxy));
-        assertEq(Timestamp.unwrap(timestamp), block.timestamp);
-
-        // Ensure that the `create` function reverts when called with parameters that would result
-        // in the same UUID.
         vm.expectRevert(
-            abi.encodeWithSelector(GameAlreadyExists.selector, disputeGameFactory.getGameUUID(gt, rootClaim, extraData))
+            abi.encodeWithSelector(
+                IDisputeGameFactory.GameAlreadyExists.selector, disputeGameFactory.getGameUUID(gt, rootClaim, extraData)
+            )
         );
         disputeGameFactory.create{ value: bondAmount }(gt, rootClaim, extraData);
     }
@@ -254,22 +228,26 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
             bytes32(uint256(1)),
             AggregateVerifier.ZkHashes(bytes32(uint256(2)), bytes32(uint256(3))),
             bytes32(uint256(4)),
-            l2ChainId,
-            100,
-            10
+            L2_CHAIN_ID,
+            AGGREGATE_BLOCK_INTERVAL,
+            AGGREGATE_INTERMEDIATE_BLOCK_INTERVAL
         );
         _setGame(address(gameImpl), GameTypes.AGGREGATE_VERIFIER);
 
         Claim rootClaim = Claim.wrap(bytes32(hex"beef"));
         Proposal memory startingRoot = anchorStateRegistry.getStartingAnchorRoot();
         bytes memory intermediateRoots;
-        for (uint256 i = 1; i < gameImpl.intermediateOutputRootsCount(); i++) {
-            intermediateRoots =
-                abi.encodePacked(intermediateRoots, keccak256(abi.encode(startingRoot.l2SequenceNumber + 10 * i)));
+        uint256 intermediateRootsCount = gameImpl.intermediateOutputRootsCount();
+        for (uint256 i = 1; i < intermediateRootsCount; i++) {
+            intermediateRoots = abi.encodePacked(
+                intermediateRoots,
+                keccak256(abi.encode(startingRoot.l2SequenceNumber + AGGREGATE_INTERMEDIATE_BLOCK_INTERVAL * i))
+            );
         }
         intermediateRoots = abi.encodePacked(intermediateRoots, rootClaim.raw());
-        bytes memory extraData =
-            abi.encodePacked(startingRoot.l2SequenceNumber + 100, address(anchorStateRegistry), intermediateRoots);
+        bytes memory extraData = abi.encodePacked(
+            startingRoot.l2SequenceNumber + AGGREGATE_BLOCK_INTERVAL, address(anchorStateRegistry), intermediateRoots
+        );
         bytes memory proof = abi.encodePacked(
             uint8(AggregateVerifier.ProofType.TEE), blockhash(block.number - 1), block.number - 1, bytes32(0)
         );
@@ -277,34 +255,26 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
         uint256 bondAmount = disputeGameFactory.initBonds(GameTypes.AGGREGATE_VERIFIER);
         vm.deal(address(this), bondAmount);
 
-        // Create the game
+        uint256 gameCountBefore = disputeGameFactory.gameCount();
         IDisputeGame proxy = disputeGameFactory.createWithInitData{ value: bondAmount }(
             GameTypes.AGGREGATE_VERIFIER, rootClaim, extraData, proof
         );
 
-        // Verify the game was created and stored
-        (IDisputeGame game, Timestamp timestamp) =
-            disputeGameFactory.games(GameTypes.AGGREGATE_VERIFIER, rootClaim, extraData);
+        _assertCreatedGame(GameTypes.AGGREGATE_VERIFIER, rootClaim, extraData, proxy, gameCountBefore);
 
-        assertEq(address(game), address(proxy));
-        assertEq(Timestamp.unwrap(timestamp), block.timestamp);
-
-        // Verify the game has the correct parameters via CWIA
         AggregateVerifier gameV2 = AggregateVerifier(address(proxy));
 
-        // Test CWIA getters
         assertEq(Claim.unwrap(gameV2.rootClaim()), Claim.unwrap(rootClaim));
         assertEq(gameV2.extraData(), extraData);
-        assertEq(gameV2.L2_CHAIN_ID(), l2ChainId);
+        assertEq(gameV2.L2_CHAIN_ID(), L2_CHAIN_ID);
         assertEq(address(gameV2.gameCreator()), address(this));
-        assertEq(gameV2.l2SequenceNumber(), startingRoot.l2SequenceNumber + 100);
+        assertEq(gameV2.l2SequenceNumber(), startingRoot.l2SequenceNumber + AGGREGATE_BLOCK_INTERVAL);
         assertEq(gameV2.parentAddress(), address(anchorStateRegistry));
         assertEq(address(gameV2.DELAYED_WETH()), address(delayedWeth));
         assertEq(address(gameV2.anchorStateRegistry()), address(anchorStateRegistry));
-        // Test Constructor args
         assertEq(GameType.unwrap(gameV2.gameType()), GameType.unwrap(GameTypes.AGGREGATE_VERIFIER));
-        assertEq(gameV2.BLOCK_INTERVAL(), 100);
-        assertEq(gameV2.INTERMEDIATE_BLOCK_INTERVAL(), 10);
+        assertEq(gameV2.BLOCK_INTERVAL(), AGGREGATE_BLOCK_INTERVAL);
+        assertEq(gameV2.INTERMEDIATE_BLOCK_INTERVAL(), AGGREGATE_INTERMEDIATE_BLOCK_INTERVAL);
     }
 }
 
@@ -317,45 +287,38 @@ contract DisputeGameFactory_SetImplementation_Test is DisputeGameFactory_TestIni
         vm.expectEmit(true, true, true, true, address(disputeGameFactory));
         emit ImplementationSet(address(1), GameTypes.AGGREGATE_VERIFIER);
 
-        // Set the implementation for the `GameTypes.AGGREGATE_VERIFIER` enum value.
         disputeGameFactory.setImplementation(GameTypes.AGGREGATE_VERIFIER, IDisputeGame(address(1)));
 
-        // Ensure that the implementation for the `GameTypes.AGGREGATE_VERIFIER` enum value is set.
         assertEq(address(disputeGameFactory.gameImpls(GameTypes.AGGREGATE_VERIFIER)), address(1));
     }
 
     /// @notice Tests that the `setImplementation` function reverts when called by a non-owner.
     function test_setImplementation_notOwner_reverts() public {
-        // Ensure that the `setImplementation` function reverts when called by a non-owner.
-        vm.prank(address(0));
-        vm.expectRevert("Ownable: caller is not the owner");
+        _expectNonOwnerRevert();
         disputeGameFactory.setImplementation(GameTypes.AGGREGATE_VERIFIER, IDisputeGame(address(1)));
     }
 
     /// @notice Tests that the `setImplementation` function with args properly sets the implementation
     ///         and args for a given `GameType`.
     function test_setImplementation_withArgs_succeeds() public {
-        address fakeGame = address(1);
+        address gameImpl = address(1);
 
         bytes memory args = abi.encodePacked(
             bytes32(hex"dead"), // 32 bytes
             address(0xbeef), // 20 bytes
             anchorStateRegistry, // 20 bytes
             delayedWeth, // 20 bytes
-            l2ChainId // 32 bytes (l2ChainId)
+            L2_CHAIN_ID // 32 bytes
         );
 
         vm.expectEmit(true, true, true, true, address(disputeGameFactory));
-        emit ImplementationSet(address(1), GameTypes.AGGREGATE_VERIFIER);
+        emit ImplementationSet(gameImpl, GameTypes.AGGREGATE_VERIFIER);
         vm.expectEmit(true, true, true, true, address(disputeGameFactory));
         emit ImplementationArgsSet(GameTypes.AGGREGATE_VERIFIER, args);
 
-        // Set the implementation and args for the `GameTypes.AGGREGATE_VERIFIER` enum value.
-        disputeGameFactory.setImplementation(GameTypes.AGGREGATE_VERIFIER, IDisputeGame(fakeGame), args);
+        disputeGameFactory.setImplementation(GameTypes.AGGREGATE_VERIFIER, IDisputeGame(gameImpl), args);
 
-        // Ensure that the implementation for the `GameTypes.AGGREGATE_VERIFIER` enum value is set.
-        assertEq(address(disputeGameFactory.gameImpls(GameTypes.AGGREGATE_VERIFIER)), address(1));
-        // Ensure that the args for the `GameTypes.AGGREGATE_VERIFIER` enum value are set.
+        assertEq(address(disputeGameFactory.gameImpls(GameTypes.AGGREGATE_VERIFIER)), gameImpl);
         assertEq(disputeGameFactory.gameArgs(GameTypes.AGGREGATE_VERIFIER), args);
     }
 
@@ -363,9 +326,7 @@ contract DisputeGameFactory_SetImplementation_Test is DisputeGameFactory_TestIni
     function test_setImplementationArgs_notOwner_reverts() public {
         bytes memory args = abi.encode(uint256(123), address(0xdead));
 
-        // Ensure that the `setImplementation` function reverts when called by a non-owner.
-        vm.prank(address(0));
-        vm.expectRevert("Ownable: caller is not the owner");
+        _expectNonOwnerRevert();
         disputeGameFactory.setImplementation(GameTypes.AGGREGATE_VERIFIER, IDisputeGame(address(1)), args);
     }
 }
@@ -379,27 +340,21 @@ contract DisputeGameFactory_SetInitBond_Test is DisputeGameFactory_TestInit {
         vm.expectEmit(true, true, true, true, address(disputeGameFactory));
         emit InitBondUpdated(GameTypes.AGGREGATE_VERIFIER, 1 ether);
 
-        // Set the init bond for the `GameTypes.AGGREGATE_VERIFIER` enum value.
         disputeGameFactory.setInitBond(GameTypes.AGGREGATE_VERIFIER, 1 ether);
 
-        // Ensure that the init bond for the `GameTypes.AGGREGATE_VERIFIER` enum value is set.
         assertEq(disputeGameFactory.initBonds(GameTypes.AGGREGATE_VERIFIER), 1 ether);
 
         vm.expectEmit(true, true, true, true, address(disputeGameFactory));
         emit InitBondUpdated(GameTypes.AGGREGATE_VERIFIER, 2 ether);
 
-        // Set the init bond for the `GameTypes.AGGREGATE_VERIFIER` enum value.
         disputeGameFactory.setInitBond(GameTypes.AGGREGATE_VERIFIER, 2 ether);
 
-        // Ensure that the init bond for the `GameTypes.AGGREGATE_VERIFIER` enum value is set.
         assertEq(disputeGameFactory.initBonds(GameTypes.AGGREGATE_VERIFIER), 2 ether);
     }
 
     /// @notice Tests that the `setInitBond` function reverts when called by a non-owner.
     function test_setInitBond_notOwner_reverts() public {
-        // Ensure that the `setInitBond` function reverts when called by a non-owner.
-        vm.prank(address(0));
-        vm.expectRevert("Ownable: caller is not the owner");
+        _expectNonOwnerRevert();
         disputeGameFactory.setInitBond(GameTypes.AGGREGATE_VERIFIER, 1 ether);
     }
 }
@@ -410,8 +365,6 @@ contract DisputeGameFactory_GetGameUUID_Test is DisputeGameFactory_TestInit {
     /// @notice Tests that the `getGameUUID` function returns the correct hash when comparing
     ///         against the keccak256 hash of the abi-encoded parameters.
     function testDiff_getGameUUID_succeeds(uint32 gameType, Claim rootClaim, bytes calldata extraData) public view {
-        // Ensure that the `gameType` is within the bounds of the `GameType` enum's possible
-        // values.
         GameType gt = GameType.wrap(uint8(bound(gameType, 0, 2)));
 
         assertEq(
@@ -424,33 +377,23 @@ contract DisputeGameFactory_GetGameUUID_Test is DisputeGameFactory_TestInit {
 /// @title DisputeGameFactory_FindLatestGames_Test
 /// @notice Tests the `findLatestGames` function of the `DisputeGameFactory` contract.
 contract DisputeGameFactory_FindLatestGames_Test is DisputeGameFactory_TestInit {
+    GameType internal constant FIND_LATEST_SEARCH_GAME_TYPE = GameType.wrap(type(uint32).max);
+    GameType internal constant FIND_LATEST_OTHER_GAME_TYPE = GameType.wrap(type(uint32).max - 1);
+
     function setUp() public override {
         super.setUp();
 
-        // Set three implementations to the same `FakeClone` contract.
         for (uint8 i; i < 3; i++) {
-            GameType lgt = GameType.wrap(i);
-            disputeGameFactory.setImplementation(lgt, IDisputeGame(address(fakeClone)));
-            disputeGameFactory.setInitBond(lgt, 0);
+            _setGame(address(fakeClone), GameType.wrap(i), 0);
         }
     }
 
     /// @notice Tests that `findLatestGames` returns an empty array when the passed starting index
     ///         is greater than or equal to the game count.
-    function testFuzz_findLatestGames_greaterThanLength_succeeds(uint256 _start) public {
-        // Creation count should be 32 for normal tests, 5 for upgrade tests.
-        uint256 creationCount = isForkTest() ? 5 : 32;
-
-        // Create some dispute games of varying game types.
-        for (uint256 i; i < creationCount; i++) {
-            disputeGameFactory.create(GameType.wrap(uint8(i % 2)), Claim.wrap(bytes32(i)), abi.encode(i));
-        }
-
-        // Bound the starting index to a number greater than the length of the game list.
+    function testFuzz_findLatestGames_greaterThanLength_succeeds(uint256 _start) public view {
         uint256 gameCount = disputeGameFactory.gameCount();
         _start = bound(_start, gameCount, type(uint256).max);
 
-        // The array's length should always be 0.
         IDisputeGameFactory.GameSearchResult[] memory games =
             disputeGameFactory.findLatestGames(GameTypes.AGGREGATE_VERIFIER, _start, 1);
         assertEq(games.length, 0);
@@ -458,84 +401,42 @@ contract DisputeGameFactory_FindLatestGames_Test is DisputeGameFactory_TestInit 
 
     /// @notice Tests that `findLatestGames` returns the correct games.
     function test_findLatestGames_static_succeeds() public {
-        // Creation count should be 32 for normal tests, 5 for upgrade tests.
-        uint256 creationCount = isForkTest() ? 5 : 32;
-
-        // Create some dispute games of varying game types, repeatedly iterating over the game
-        // types 0, 1, 2.
-        for (uint256 i; i < creationCount; i++) {
+        for (uint256 i; i < 5; i++) {
             disputeGameFactory.create(GameType.wrap(uint8(i % 3)), Claim.wrap(bytes32(i)), abi.encode(i));
         }
 
         uint256 gameCount = disputeGameFactory.gameCount();
 
-        IDisputeGameFactory.GameSearchResult[] memory games;
-
         uint256 start = gameCount - 1;
 
-        // Find type 1 games.
-        games = disputeGameFactory.findLatestGames(GameType.wrap(1), start, 1);
-        assertEq(games.length, 1);
-
-        // The type 1 game should be the last one added.
-        assertEq(games[0].index, start);
-        (GameType gameType, Timestamp createdAt, address game) = games[0].metadata.unpack();
-        assertEq(gameType.raw(), 1);
-        assertEq(createdAt.raw(), block.timestamp);
-
-        // Find type 0 games.
-        games = disputeGameFactory.findLatestGames(GameType.wrap(0), start, 1);
-        assertEq(games.length, 1);
-
-        // The type 0 game should be the second to last one added.
-        assertEq(games[0].index, start - 1);
-        (gameType, createdAt, game) = games[0].metadata.unpack();
-        assertEq(gameType.raw(), 0);
-        assertEq(createdAt.raw(), block.timestamp);
-
-        // Find type 2 games.
-        games = disputeGameFactory.findLatestGames(GameType.wrap(2), start, 1);
-        assertEq(games.length, 1);
-
-        // The type 2 game should be the third to last one added.
-        assertEq(games[0].index, start - 2);
-        (gameType, createdAt, game) = games[0].metadata.unpack();
-        assertEq(gameType.raw(), 2);
-        assertEq(createdAt.raw(), block.timestamp);
+        _assertLatestGameResult(GameType.wrap(1), start, start);
+        _assertLatestGameResult(GameType.wrap(0), start, start - 1);
+        _assertLatestGameResult(GameType.wrap(2), start, start - 2);
     }
 
     /// @notice Tests that `findLatestGames` returns the correct games, if there are less than `_n`
     ///         games of the given type available.
     function test_findLatestGames_lessThanNAvailable_succeeds() public {
-        // Need to clear out the length of the game list on forked list to avoid massive iteration.
-        if (isForkTest()) {
-            vm.store(
-                address(disputeGameFactory),
-                bytes32(ForgeArtifacts.getSlot("DisputeGameFactory", "_disputeGameList").slot),
-                bytes32(0)
-            );
-        }
+        _setGame(address(fakeClone), FIND_LATEST_SEARCH_GAME_TYPE, 0);
+        _setGame(address(fakeClone), FIND_LATEST_OTHER_GAME_TYPE, 0);
 
-        // Create some dispute games of varying game types.
-        disputeGameFactory.create(GameType.wrap(1), Claim.wrap(bytes32(0)), abi.encode(0));
-        disputeGameFactory.create(GameType.wrap(1), Claim.wrap(bytes32(uint256(1))), abi.encode(1));
+        uint256 firstSearchGameIndex = disputeGameFactory.gameCount();
+        disputeGameFactory.create(FIND_LATEST_SEARCH_GAME_TYPE, Claim.wrap(bytes32(0)), abi.encode(0));
+        disputeGameFactory.create(FIND_LATEST_SEARCH_GAME_TYPE, Claim.wrap(bytes32(uint256(1))), abi.encode(1));
         for (uint256 i; i < 1 << 3; i++) {
-            disputeGameFactory.create(GameType.wrap(0), Claim.wrap(bytes32(i)), abi.encode(i));
+            disputeGameFactory.create(FIND_LATEST_OTHER_GAME_TYPE, Claim.wrap(bytes32(i)), abi.encode(i));
         }
 
-        // Grab the existing game count.
         uint256 gameCount = disputeGameFactory.gameCount();
 
-        // Try to find 5 games of type 2, but there are none.
         IDisputeGameFactory.GameSearchResult[] memory games;
-        games = disputeGameFactory.findLatestGames(GameType.wrap(2), gameCount - 1, 5);
+        games = disputeGameFactory.findLatestGames(GameType.wrap(type(uint32).max - 2), gameCount - 1, 5);
         assertEq(games.length, 0);
 
-        // Try to find 2 games of type 1, but there are only 2.
-        games = disputeGameFactory.findLatestGames(GameType.wrap(1), gameCount - 1, 5);
+        games = disputeGameFactory.findLatestGames(FIND_LATEST_SEARCH_GAME_TYPE, gameCount - 1, 5);
         assertEq(games.length, 2);
-        assertEq(games[0].index, 1);
-        assertEq(games[1].index, 0);
+        assertEq(games[0].index, firstSearchGameIndex + 1);
+        assertEq(games[1].index, firstSearchGameIndex);
     }
 
     /// @notice Tests that the expected number of games are returned when `findLatestGames` is
@@ -547,21 +448,29 @@ contract DisputeGameFactory_FindLatestGames_Test is DisputeGameFactory_TestInit 
     )
         public
     {
-        _numGames = bound(_numGames, 0, isForkTest() ? 5 : 256);
+        _numGames = bound(_numGames, 0, isForkTest() ? 5 : 32);
         _numSearchedGames = bound(_numSearchedGames, 0, _numGames);
         _n = bound(_n, 0, _numSearchedGames);
 
-        // Create `_numGames` dispute games, with at least `_numSearchedGames` games.
         for (uint256 i; i < _numGames; i++) {
             uint32 gameType = i < _numSearchedGames ? 0 : 1;
             disputeGameFactory.create(GameType.wrap(gameType), Claim.wrap(bytes32(i)), abi.encode(i));
         }
 
-        // Ensure that the correct number of games are returned.
         uint256 start = _numGames == 0 ? 0 : _numGames - 1;
         IDisputeGameFactory.GameSearchResult[] memory games =
             disputeGameFactory.findLatestGames(GameType.wrap(0), start, _n);
         assertEq(games.length, _n);
+    }
+
+    function _assertLatestGameResult(GameType _gameType, uint256 _start, uint256 _expectedIndex) internal view {
+        IDisputeGameFactory.GameSearchResult[] memory games = disputeGameFactory.findLatestGames(_gameType, _start, 1);
+        assertEq(games.length, 1);
+
+        assertEq(games[0].index, _expectedIndex);
+        (GameType gameType, Timestamp createdAt,) = games[0].metadata.unpack();
+        assertEq(GameType.unwrap(gameType), GameType.unwrap(_gameType));
+        assertEq(Timestamp.unwrap(createdAt), block.timestamp);
     }
 }
 
@@ -582,8 +491,7 @@ contract DisputeGameFactory_Uncategorized_Test is DisputeGameFactory_TestInit {
 
     /// @notice Tests that the `transferOwnership` function reverts when called by a non-owner.
     function test_transferOwnership_notOwner_reverts() public {
-        vm.prank(address(0));
-        vm.expectRevert("Ownable: caller is not the owner");
+        _expectNonOwnerRevert();
         disputeGameFactory.transferOwnership(address(1));
     }
 }

--- a/test/L1/proofs/NitroEnclaveVerifier.t.sol
+++ b/test/L1/proofs/NitroEnclaveVerifier.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { Test } from "lib/forge-std/src/Test.sol";
+import { Ownable } from "lib/solady/src/auth/Ownable.sol";
 
 import {
     ZkCoProcessorType,
@@ -15,29 +16,35 @@ import {
 import { NitroEnclaveVerifier } from "src/L1/proofs/tee/NitroEnclaveVerifier.sol";
 
 contract NitroEnclaveVerifierTest is Test {
-    NitroEnclaveVerifier public verifier;
+    NitroEnclaveVerifier internal verifier;
 
-    address public owner;
-    address public submitter;
-    address public revokerAddr;
-    address public mockRiscZeroVerifier;
-    address public mockSP1Verifier;
+    address internal owner;
+    address internal submitter;
+    address internal revokerAddr;
+    address internal mockRiscZeroVerifier;
+    address internal mockSP1Verifier;
 
-    bytes32 public constant ROOT_CERT = keccak256("root-cert");
-    bytes32 public constant INTERMEDIATE_CERT_1 = keccak256("intermediate-cert-1");
-    bytes32 public constant INTERMEDIATE_CERT_2 = keccak256("intermediate-cert-2");
-    bytes32 public constant VERIFIER_ID = keccak256("verifier-id");
-    bytes32 public constant AGGREGATOR_ID = keccak256("aggregator-id");
-    bytes32 public constant VERIFIER_PROOF_ID = keccak256("verifier-proof-id");
+    bytes32 internal constant ROOT_CERT = keccak256("root-cert");
+    bytes32 internal constant INTERMEDIATE_CERT_1 = keccak256("intermediate-cert-1");
+    bytes32 internal constant INTERMEDIATE_CERT_2 = keccak256("intermediate-cert-2");
+    bytes32 internal constant VERIFIER_ID = keccak256("verifier-id");
+    bytes32 internal constant AGGREGATOR_ID = keccak256("aggregator-id");
+    bytes32 internal constant VERIFIER_PROOF_ID = keccak256("verifier-proof-id");
+    bytes4 internal constant DEFAULT_PROOF_SELECTOR = bytes4(0);
+    bytes4 internal constant NON_DEFAULT_PROOF_SELECTOR = 0x00000001;
+    bytes4 internal constant TEST_ROUTE_SELECTOR = bytes4(keccak256("test"));
+    bytes4 internal constant RISC_ZERO_VERIFY_SELECTOR = bytes4(keccak256("verify(bytes,bytes32,bytes32)"));
+    bytes4 internal constant SP1_VERIFY_PROOF_SELECTOR = bytes4(keccak256("verifyProof(bytes32,bytes,bytes)"));
+    address internal constant FROZEN_ROUTE_SENTINEL = address(0xdead);
 
-    uint64 public constant MAX_TIME_DIFF = 3600; // 1 hour
+    uint64 internal constant MAX_TIME_DIFF = 3600; // 1 hour
 
     // Realistic timestamp so timestamp validation tests work correctly
     uint256 internal constant REALISTIC_TIMESTAMP = 1_700_000_000;
 
     // Expiry timestamps for test certs (well after REALISTIC_TIMESTAMP)
     uint64 internal constant INTERMEDIATE_CERT_1_EXPIRY = 1_800_000_000; // ~2027
-    uint64 internal constant INTERMEDIATE_CERT_2_EXPIRY = 1_750_000_000; // ~2025
+    uint64 internal constant ROOT_CERT_EXPIRY = 1_900_000_000;
     uint64 internal constant NEW_LEAF_CERT_EXPIRY = 1_700_100_000; // ~28 hours after REALISTIC_TIMESTAMP
 
     function setUp() public {
@@ -55,8 +62,7 @@ contract NitroEnclaveVerifierTest is Test {
         uint64[] memory trustedCertExpiries = new uint64[](1);
         trustedCertExpiries[0] = INTERMEDIATE_CERT_1_EXPIRY;
 
-        ZkCoProcessorConfig memory zkCfg =
-            ZkCoProcessorConfig({ verifierId: VERIFIER_ID, aggregatorId: AGGREGATOR_ID, zkVerifier: mockSP1Verifier });
+        ZkCoProcessorConfig memory zkCfg = _zkConfig(mockSP1Verifier);
 
         verifier = new NitroEnclaveVerifier(
             owner,
@@ -101,7 +107,7 @@ contract NitroEnclaveVerifierTest is Test {
     function testConstructorRevertsIfCertExpiriesLengthMismatch() public {
         bytes32[] memory certs = new bytes32[](1);
         certs[0] = INTERMEDIATE_CERT_1;
-        uint64[] memory expiries = new uint64[](0); // mismatched length
+        uint64[] memory expiries = new uint64[](0);
         ZkCoProcessorConfig memory zkCfg =
             ZkCoProcessorConfig({ verifierId: bytes32(0), aggregatorId: bytes32(0), zkVerifier: address(0) });
         vm.expectRevert(abi.encodeWithSelector(NitroEnclaveVerifier.CertExpiriesLengthMismatch.selector, 1, 0));
@@ -128,8 +134,7 @@ contract NitroEnclaveVerifierTest is Test {
     }
 
     function testSetRootCertRevertsIfNotOwner() public {
-        vm.prank(submitter);
-        vm.expectRevert();
+        _expectNotOwnerRevert(submitter);
         verifier.setRootCert(keccak256("bad"));
     }
 
@@ -147,8 +152,7 @@ contract NitroEnclaveVerifierTest is Test {
     }
 
     function testSetMaxTimeDiffRevertsIfNotOwner() public {
-        vm.prank(submitter);
-        vm.expectRevert();
+        _expectNotOwnerRevert(submitter);
         verifier.setMaxTimeDiff(7200);
     }
 
@@ -166,17 +170,14 @@ contract NitroEnclaveVerifierTest is Test {
     }
 
     function testSetProofSubmitterRevertsIfNotOwner() public {
-        vm.prank(submitter);
-        vm.expectRevert();
+        _expectNotOwnerRevert(submitter);
         verifier.setProofSubmitter(makeAddr("anyone"));
     }
 
     // ============ setZkConfiguration Tests ============
 
     function testSetZkConfiguration() public {
-        ZkCoProcessorConfig memory config = ZkCoProcessorConfig({
-            verifierId: VERIFIER_ID, aggregatorId: AGGREGATOR_ID, zkVerifier: mockRiscZeroVerifier
-        });
+        ZkCoProcessorConfig memory config = _zkConfig(mockRiscZeroVerifier);
 
         verifier.setZkConfiguration(ZkCoProcessorType.RiscZero, config, VERIFIER_PROOF_ID);
 
@@ -189,12 +190,9 @@ contract NitroEnclaveVerifierTest is Test {
     }
 
     function testSetZkConfigurationRevertsIfNotOwner() public {
-        ZkCoProcessorConfig memory config = ZkCoProcessorConfig({
-            verifierId: VERIFIER_ID, aggregatorId: AGGREGATOR_ID, zkVerifier: mockRiscZeroVerifier
-        });
+        ZkCoProcessorConfig memory config = _zkConfig(mockRiscZeroVerifier);
 
-        vm.prank(submitter);
-        vm.expectRevert();
+        _expectNotOwnerRevert(submitter);
         verifier.setZkConfiguration(ZkCoProcessorType.RiscZero, config, VERIFIER_PROOF_ID);
     }
 
@@ -227,8 +225,7 @@ contract NitroEnclaveVerifierTest is Test {
     function testConstructorAcceptsZeroRevoker() public {
         bytes32[] memory certs = new bytes32[](0);
         uint64[] memory expiries = new uint64[](0);
-        ZkCoProcessorConfig memory zkCfg =
-            ZkCoProcessorConfig({ verifierId: VERIFIER_ID, aggregatorId: AGGREGATOR_ID, zkVerifier: mockSP1Verifier });
+        ZkCoProcessorConfig memory zkCfg = _zkConfig(mockSP1Verifier);
         NitroEnclaveVerifier v = new NitroEnclaveVerifier(
             owner,
             MAX_TIME_DIFF,
@@ -251,12 +248,6 @@ contract NitroEnclaveVerifierTest is Test {
         assertEq(verifier.trustedIntermediateCerts(INTERMEDIATE_CERT_1), 0);
     }
 
-    function testOwnerCanStillRevokeCert() public {
-        assertGt(verifier.trustedIntermediateCerts(INTERMEDIATE_CERT_1), 0);
-        verifier.revokeCert(INTERMEDIATE_CERT_1);
-        assertEq(verifier.trustedIntermediateCerts(INTERMEDIATE_CERT_1), 0);
-    }
-
     function testSetRevoker() public {
         address newRevoker = makeAddr("new-revoker");
         verifier.setRevoker(newRevoker);
@@ -267,7 +258,6 @@ contract NitroEnclaveVerifierTest is Test {
         verifier.setRevoker(address(0));
         assertEq(verifier.revoker(), address(0));
 
-        // Now revoker (zero address) can't call revokeCert
         vm.prank(revokerAddr);
         vm.expectRevert(NitroEnclaveVerifier.CallerNotOwnerOrRevoker.selector);
         verifier.revokeCert(INTERMEDIATE_CERT_1);
@@ -281,14 +271,12 @@ contract NitroEnclaveVerifierTest is Test {
     }
 
     function testSetRevokerRevertsIfNotOwner() public {
-        vm.prank(submitter);
-        vm.expectRevert();
+        _expectNotOwnerRevert(submitter);
         verifier.setRevoker(makeAddr("anyone"));
     }
 
     function testSetRevokerRevertsIfCalledByRevoker() public {
-        vm.prank(revokerAddr);
-        vm.expectRevert();
+        _expectNotOwnerRevert(revokerAddr);
         verifier.setRevoker(makeAddr("anyone"));
     }
 
@@ -324,8 +312,7 @@ contract NitroEnclaveVerifierTest is Test {
 
     function testUpdateVerifierIdRevertsIfNotOwner() public {
         _setUpRiscZeroConfig();
-        vm.prank(submitter);
-        vm.expectRevert();
+        _expectNotOwnerRevert(submitter);
         verifier.updateVerifierId(ZkCoProcessorType.RiscZero, keccak256("new"), keccak256("proof"));
     }
 
@@ -359,81 +346,65 @@ contract NitroEnclaveVerifierTest is Test {
 
     function testUpdateAggregatorIdRevertsIfNotOwner() public {
         _setUpRiscZeroConfig();
-        vm.prank(submitter);
-        vm.expectRevert();
+        _expectNotOwnerRevert(submitter);
         verifier.updateAggregatorId(ZkCoProcessorType.RiscZero, keccak256("new"));
     }
 
     // ============ addVerifyRoute / freezeVerifyRoute Tests ============
 
     function testAddVerifyRoute() public {
-        bytes4 selector = bytes4(keccak256("test"));
         address routeVerifier = makeAddr("route-verifier");
 
-        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, selector, routeVerifier);
-        assertEq(verifier.getZkVerifier(ZkCoProcessorType.RiscZero, selector), routeVerifier);
+        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR, routeVerifier);
+        assertEq(verifier.getZkVerifier(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR), routeVerifier);
     }
 
     function testAddVerifyRouteRevertsIfZeroAddress() public {
         vm.expectRevert(NitroEnclaveVerifier.ZeroVerifierAddress.selector);
-        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, bytes4(uint32(0x01)), address(0));
+        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, NON_DEFAULT_PROOF_SELECTOR, address(0));
     }
 
     function testAddVerifyRouteRevertsIfFrozenSentinel() public {
         vm.expectRevert(NitroEnclaveVerifier.InvalidVerifierAddress.selector);
-        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, bytes4(uint32(0x01)), address(0xdead));
+        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, NON_DEFAULT_PROOF_SELECTOR, FROZEN_ROUTE_SENTINEL);
     }
 
     function testAddVerifyRouteRevertsIfNotOwner() public {
-        vm.prank(submitter);
-        vm.expectRevert();
-        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, bytes4(keccak256("test")), makeAddr("v"));
+        _expectNotOwnerRevert(submitter);
+        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR, makeAddr("v"));
     }
 
     function testFreezeVerifyRoute() public {
-        bytes4 selector = bytes4(keccak256("test"));
         address routeVerifier = makeAddr("route-verifier");
 
-        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, selector, routeVerifier);
-        verifier.freezeVerifyRoute(ZkCoProcessorType.RiscZero, selector);
+        _addAndFreezeVerifyRoute(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR, routeVerifier);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(NitroEnclaveVerifier.ZkRouteFrozen.selector, ZkCoProcessorType.RiscZero, selector)
-        );
-        verifier.getZkVerifier(ZkCoProcessorType.RiscZero, selector);
+        _expectZkRouteFrozenRevert(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR);
+        verifier.getZkVerifier(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR);
     }
 
     function testAddVerifyRouteRevertsIfFrozen() public {
-        bytes4 selector = bytes4(keccak256("test"));
         address routeVerifier = makeAddr("route-verifier");
 
-        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, selector, routeVerifier);
-        verifier.freezeVerifyRoute(ZkCoProcessorType.RiscZero, selector);
+        _addAndFreezeVerifyRoute(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR, routeVerifier);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(NitroEnclaveVerifier.ZkRouteFrozen.selector, ZkCoProcessorType.RiscZero, selector)
-        );
-        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, selector, routeVerifier);
+        _expectZkRouteFrozenRevert(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR);
+        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR, routeVerifier);
     }
 
     function testFreezeVerifyRouteRevertsIfAlreadyFrozen() public {
-        bytes4 selector = bytes4(keccak256("test"));
-        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, selector, makeAddr("v"));
-        verifier.freezeVerifyRoute(ZkCoProcessorType.RiscZero, selector);
+        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR, makeAddr("v"));
+        verifier.freezeVerifyRoute(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(NitroEnclaveVerifier.ZkRouteFrozen.selector, ZkCoProcessorType.RiscZero, selector)
-        );
-        verifier.freezeVerifyRoute(ZkCoProcessorType.RiscZero, selector);
+        _expectZkRouteFrozenRevert(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR);
+        verifier.freezeVerifyRoute(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR);
     }
 
     function testFreezeVerifyRouteRevertsIfNotOwner() public {
-        bytes4 selector = bytes4(keccak256("test"));
-        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, selector, makeAddr("v"));
+        verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR, makeAddr("v"));
 
-        vm.prank(submitter);
-        vm.expectRevert();
-        verifier.freezeVerifyRoute(ZkCoProcessorType.RiscZero, selector);
+        _expectNotOwnerRevert(submitter);
+        verifier.freezeVerifyRoute(ZkCoProcessorType.RiscZero, TEST_ROUTE_SELECTOR);
     }
 
     // ============ getZkVerifier Tests ============
@@ -462,7 +433,7 @@ contract NitroEnclaveVerifierTest is Test {
         reportCerts[0] = new bytes32[](3);
         reportCerts[0][0] = ROOT_CERT;
         reportCerts[0][1] = INTERMEDIATE_CERT_1;
-        reportCerts[0][2] = INTERMEDIATE_CERT_2; // not trusted
+        reportCerts[0][2] = INTERMEDIATE_CERT_2;
 
         uint8[] memory results = verifier.checkTrustedIntermediateCerts(reportCerts);
         assertEq(results[0], 2); // root + 1 intermediate trusted
@@ -488,38 +459,29 @@ contract NitroEnclaveVerifierTest is Test {
     // ============ verify — ZkVerifierNotConfigured ============
 
     function testVerifyRevertsIfZkVerifierNotConfigured() public {
-        // Set up config WITHOUT a zkVerifier address (zero)
-        ZkCoProcessorConfig memory config =
-            ZkCoProcessorConfig({ verifierId: VERIFIER_ID, aggregatorId: AGGREGATOR_ID, zkVerifier: address(0) });
+        ZkCoProcessorConfig memory config = _zkConfig(address(0));
         verifier.setZkConfiguration(ZkCoProcessorType.RiscZero, config, VERIFIER_PROOF_ID);
 
-        VerifierJournal memory journal = _createSuccessJournal();
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        bytes memory proofBytes = _proofBytes();
 
         vm.prank(submitter);
         vm.expectRevert(
             abi.encodeWithSelector(NitroEnclaveVerifier.ZkVerifierNotConfigured.selector, ZkCoProcessorType.RiscZero)
         );
-        verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
+        verifier.verify("", ZkCoProcessorType.RiscZero, proofBytes);
     }
 
     // ============ verify — Unknown_Zk_Coprocessor ============
 
     function testVerifyRevertsForUnknownCoprocessor() public {
-        // Use ZkCoProcessorType.Unknown (0) — not RiscZero or Succinct
-        ZkCoProcessorConfig memory config = ZkCoProcessorConfig({
-            verifierId: VERIFIER_ID, aggregatorId: AGGREGATOR_ID, zkVerifier: mockRiscZeroVerifier
-        });
+        ZkCoProcessorConfig memory config = _zkConfig(mockRiscZeroVerifier);
         verifier.setZkConfiguration(ZkCoProcessorType.Unknown, config, VERIFIER_PROOF_ID);
 
-        VerifierJournal memory journal = _createSuccessJournal();
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        bytes memory proofBytes = _proofBytes();
 
         vm.prank(submitter);
         vm.expectRevert(NitroEnclaveVerifier.Unknown_Zk_Coprocessor.selector);
-        verifier.verify(output, ZkCoProcessorType.Unknown, proofBytes);
+        verifier.verify("", ZkCoProcessorType.Unknown, proofBytes);
     }
 
     // ============ verify — ZkRouteFrozen during verify() ============
@@ -527,19 +489,15 @@ contract NitroEnclaveVerifierTest is Test {
     function testVerifyRevertsIfRouteFrozen() public {
         _setUpRiscZeroConfig();
 
-        bytes4 selector = bytes4(0); // matches the selector in our proofBytes
+        bytes4 selector = DEFAULT_PROOF_SELECTOR;
         verifier.addVerifyRoute(ZkCoProcessorType.RiscZero, selector, makeAddr("route-v"));
         verifier.freezeVerifyRoute(ZkCoProcessorType.RiscZero, selector);
 
-        VerifierJournal memory journal = _createSuccessJournal();
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        bytes memory proofBytes = _proofBytes();
 
         vm.prank(submitter);
-        vm.expectRevert(
-            abi.encodeWithSelector(NitroEnclaveVerifier.ZkRouteFrozen.selector, ZkCoProcessorType.RiscZero, selector)
-        );
-        verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
+        _expectZkRouteFrozenRevert(ZkCoProcessorType.RiscZero, selector);
+        verifier.verify("", ZkCoProcessorType.RiscZero, proofBytes);
     }
 
     // ============ verify — RiscZero happy path ============
@@ -547,16 +505,9 @@ contract NitroEnclaveVerifierTest is Test {
     function testVerifySuccessfulJournal() public {
         _setUpRiscZeroConfig();
 
-        VerifierJournal memory journal = _createSuccessJournal();
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        VerifierJournal memory result = _verifyRiscZeroJournal(_createSuccessJournal());
 
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
-
-        assertEq(uint8(result.result), uint8(VerificationResult.Success));
+        _assertVerificationResult(result, VerificationResult.Success);
     }
 
     function testVerifyJournalRootCertNotTrusted() public {
@@ -564,15 +515,9 @@ contract NitroEnclaveVerifierTest is Test {
 
         VerifierJournal memory journal = _createSuccessJournal();
         journal.certs[0] = keccak256("wrong-root");
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        VerifierJournal memory result = _verifyRiscZeroJournal(journal);
 
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
-
-        assertEq(uint8(result.result), uint8(VerificationResult.RootCertNotTrusted));
+        _assertVerificationResult(result, VerificationResult.RootCertNotTrusted);
     }
 
     function testVerifyJournalRootCertNotTrustedZeroPrefixLen() public {
@@ -580,15 +525,9 @@ contract NitroEnclaveVerifierTest is Test {
 
         VerifierJournal memory journal = _createSuccessJournal();
         journal.trustedCertsPrefixLen = 0;
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        VerifierJournal memory result = _verifyRiscZeroJournal(journal);
 
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
-
-        assertEq(uint8(result.result), uint8(VerificationResult.RootCertNotTrusted));
+        _assertVerificationResult(result, VerificationResult.RootCertNotTrusted);
     }
 
     function testVerifyJournalIntermediateCertNotTrusted() public {
@@ -597,15 +536,9 @@ contract NitroEnclaveVerifierTest is Test {
         VerifierJournal memory journal = _createSuccessJournal();
         // Replace trusted intermediate with untrusted one, but keep trustedCertsPrefixLen = 2
         journal.certs[1] = keccak256("untrusted-intermediate");
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        VerifierJournal memory result = _verifyRiscZeroJournal(journal);
 
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
-
-        assertEq(uint8(result.result), uint8(VerificationResult.IntermediateCertsNotTrusted));
+        _assertVerificationResult(result, VerificationResult.IntermediateCertsNotTrusted);
     }
 
     function testVerifyJournalInvalidTimestampTooOld() public {
@@ -614,15 +547,9 @@ contract NitroEnclaveVerifierTest is Test {
         VerifierJournal memory journal = _createSuccessJournal();
         // Set timestamp far in the past — more than maxTimeDiff seconds ago (in ms)
         journal.timestamp = uint64(block.timestamp - MAX_TIME_DIFF - 1) * 1000;
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        VerifierJournal memory result = _verifyRiscZeroJournal(journal);
 
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
-
-        assertEq(uint8(result.result), uint8(VerificationResult.InvalidTimestamp));
+        _assertVerificationResult(result, VerificationResult.InvalidTimestamp);
     }
 
     function testVerifyJournalInvalidTimestampFuture() public {
@@ -631,15 +558,9 @@ contract NitroEnclaveVerifierTest is Test {
         VerifierJournal memory journal = _createSuccessJournal();
         // Set timestamp in the future (converted to ms)
         journal.timestamp = uint64(block.timestamp + 100) * 1000;
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        VerifierJournal memory result = _verifyRiscZeroJournal(journal);
 
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
-
-        assertEq(uint8(result.result), uint8(VerificationResult.InvalidTimestamp));
+        _assertVerificationResult(result, VerificationResult.InvalidTimestamp);
     }
 
     function testVerifyCachesNewCerts() public {
@@ -648,29 +569,8 @@ contract NitroEnclaveVerifierTest is Test {
         bytes32 newCert = keccak256("new-leaf-cert");
         assertEq(verifier.trustedIntermediateCerts(newCert), 0);
 
-        VerifierJournal memory journal = _createSuccessJournal();
-        // Add a new cert beyond the trusted prefix that will get cached
-        bytes32[] memory certs = new bytes32[](3);
-        certs[0] = ROOT_CERT;
-        certs[1] = INTERMEDIATE_CERT_1;
-        certs[2] = newCert;
-        journal.certs = certs;
-
-        uint64[] memory expiries = new uint64[](3);
-        expiries[0] = INTERMEDIATE_CERT_1_EXPIRY + 100_000_000; // root expiry (doesn't matter for caching)
-        expiries[1] = INTERMEDIATE_CERT_1_EXPIRY;
-        expiries[2] = NEW_LEAF_CERT_EXPIRY;
-        journal.certExpiries = expiries;
-
-        journal.trustedCertsPrefixLen = 2; // only root + 1 intermediate are pre-trusted
-
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
-
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
+        VerifierJournal memory journal = _createSuccessJournalWithLeaf(newCert, NEW_LEAF_CERT_EXPIRY);
+        _verifyRiscZeroJournal(journal);
 
         assertEq(verifier.trustedIntermediateCerts(newCert), NEW_LEAF_CERT_EXPIRY);
     }
@@ -680,51 +580,30 @@ contract NitroEnclaveVerifierTest is Test {
 
         VerifierJournal memory journal = _createSuccessJournal();
         journal.result = VerificationResult.IntermediateCertsNotTrusted;
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        VerifierJournal memory result = _verifyRiscZeroJournal(journal);
 
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
-
-        assertEq(uint8(result.result), uint8(VerificationResult.IntermediateCertsNotTrusted));
+        _assertVerificationResult(result, VerificationResult.IntermediateCertsNotTrusted);
     }
 
     // ============ verify — Succinct SP1 happy path ============
 
     function testVerifySuccessfulJournalSP1() public {
-        _setUpSP1Config();
+        VerifierJournal memory result = _verifySP1Journal(_createSuccessJournal());
 
-        VerifierJournal memory journal = _createSuccessJournal();
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
-
-        _mockSP1Verify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.Succinct, proofBytes);
-
-        assertEq(uint8(result.result), uint8(VerificationResult.Success));
-    }
-
-    function testVerifyRevertsIfNotProofSubmitterSP1() public {
-        vm.expectRevert(NitroEnclaveVerifier.CallerNotProofSubmitter.selector);
-        verifier.verify("", ZkCoProcessorType.Succinct, "");
+        _assertVerificationResult(result, VerificationResult.Success);
     }
 
     function testVerifyRevertsIfZkVerifierNotConfiguredSP1() public {
-        ZkCoProcessorConfig memory config =
-            ZkCoProcessorConfig({ verifierId: VERIFIER_ID, aggregatorId: AGGREGATOR_ID, zkVerifier: address(0) });
+        ZkCoProcessorConfig memory config = _zkConfig(address(0));
         verifier.setZkConfiguration(ZkCoProcessorType.Succinct, config, VERIFIER_PROOF_ID);
 
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        bytes memory proofBytes = _proofBytes();
 
         vm.prank(submitter);
         vm.expectRevert(
             abi.encodeWithSelector(NitroEnclaveVerifier.ZkVerifierNotConfigured.selector, ZkCoProcessorType.Succinct)
         );
-        verifier.verify(abi.encode(_createSuccessJournal()), ZkCoProcessorType.Succinct, proofBytes);
+        verifier.verify("", ZkCoProcessorType.Succinct, proofBytes);
     }
 
     // ============ batchVerify Tests ============
@@ -737,40 +616,19 @@ contract NitroEnclaveVerifierTest is Test {
     function testBatchVerifySuccess() public {
         _setUpRiscZeroConfig();
 
-        VerifierJournal memory journal = _createSuccessJournal();
-        VerifierJournal[] memory outputs = new VerifierJournal[](2);
-        outputs[0] = journal;
-        outputs[1] = journal;
-
-        BatchVerifierJournal memory batchJournal =
-            BatchVerifierJournal({ verifierVk: VERIFIER_PROOF_ID, outputs: outputs });
-
-        bytes memory output = abi.encode(batchJournal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
-
-        _mockRiscZeroVerify(AGGREGATOR_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal[] memory results = verifier.batchVerify(output, ZkCoProcessorType.RiscZero, proofBytes);
+        VerifierJournal[] memory results = _batchVerifyRiscZero(_createBatchJournal(VERIFIER_PROOF_ID, 2));
 
         assertEq(results.length, 2);
-        assertEq(uint8(results[0].result), uint8(VerificationResult.Success));
-        assertEq(uint8(results[1].result), uint8(VerificationResult.Success));
+        _assertVerificationResult(results[0], VerificationResult.Success);
+        _assertVerificationResult(results[1], VerificationResult.Success);
     }
 
     function testBatchVerifyRevertsIfVerifierVkMismatch() public {
         _setUpRiscZeroConfig();
 
         bytes32 wrongVk = keccak256("wrong-vk");
-        VerifierJournal[] memory outputs = new VerifierJournal[](1);
-        outputs[0] = _createSuccessJournal();
-
-        BatchVerifierJournal memory batchJournal = BatchVerifierJournal({ verifierVk: wrongVk, outputs: outputs });
-
-        bytes memory output = abi.encode(batchJournal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
-
-        _mockRiscZeroVerify(AGGREGATOR_ID, output, proofBytes);
+        BatchVerifierJournal memory batchJournal = _createBatchJournal(wrongVk, 1);
+        (bytes memory output, bytes memory proofBytes) = _mockRiscZeroBatchVerify(batchJournal);
 
         vm.prank(submitter);
         vm.expectRevert(
@@ -780,25 +638,10 @@ contract NitroEnclaveVerifierTest is Test {
     }
 
     function testBatchVerifySuccessSP1() public {
-        _setUpSP1Config();
-
-        VerifierJournal memory journal = _createSuccessJournal();
-        VerifierJournal[] memory outputs = new VerifierJournal[](1);
-        outputs[0] = journal;
-
-        BatchVerifierJournal memory batchJournal =
-            BatchVerifierJournal({ verifierVk: VERIFIER_PROOF_ID, outputs: outputs });
-
-        bytes memory output = abi.encode(batchJournal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
-
-        _mockSP1Verify(AGGREGATOR_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal[] memory results = verifier.batchVerify(output, ZkCoProcessorType.Succinct, proofBytes);
+        VerifierJournal[] memory results = _batchVerifySP1(_createBatchJournal(VERIFIER_PROOF_ID, 1));
 
         assertEq(results.length, 1);
-        assertEq(uint8(results[0].result), uint8(VerificationResult.Success));
+        _assertVerificationResult(results[0], VerificationResult.Success);
     }
 
     // ============ Revoked Cert Invalidates Journal ============
@@ -807,18 +650,12 @@ contract NitroEnclaveVerifierTest is Test {
         _setUpRiscZeroConfig();
 
         VerifierJournal memory journal = _createSuccessJournal();
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
 
-        // Revoke the intermediate cert before verification
         verifier.revokeCert(INTERMEDIATE_CERT_1);
 
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
+        VerifierJournal memory result = _verifyRiscZeroJournal(journal);
 
-        vm.prank(submitter);
-        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
-
-        assertEq(uint8(result.result), uint8(VerificationResult.IntermediateCertsNotTrusted));
+        _assertVerificationResult(result, VerificationResult.IntermediateCertsNotTrusted);
     }
 
     // ============ Expiry-Aware Caching Tests ============
@@ -826,40 +663,25 @@ contract NitroEnclaveVerifierTest is Test {
     function testExpiredCachedCertFailsVerification() public {
         _setUpRiscZeroConfig();
 
-        // Warp past the intermediate cert's expiry
         vm.warp(INTERMEDIATE_CERT_1_EXPIRY + 1);
 
         VerifierJournal memory journal = _createSuccessJournal();
-        // Update timestamp to be valid at the new block.timestamp
         journal.timestamp = uint64(block.timestamp - 1) * 1000;
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        VerifierJournal memory result = _verifyRiscZeroJournal(journal);
 
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
-
-        assertEq(uint8(result.result), uint8(VerificationResult.IntermediateCertsNotTrusted));
+        _assertVerificationResult(result, VerificationResult.IntermediateCertsNotTrusted);
     }
 
     function testNonExpiredCachedCertPassesVerification() public {
         _setUpRiscZeroConfig();
 
-        // Warp to just before the intermediate cert's expiry
         vm.warp(INTERMEDIATE_CERT_1_EXPIRY - 1);
 
         VerifierJournal memory journal = _createSuccessJournal();
         journal.timestamp = uint64(block.timestamp - 1) * 1000;
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        VerifierJournal memory result = _verifyRiscZeroJournal(journal);
 
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
-
-        assertEq(uint8(result.result), uint8(VerificationResult.Success));
+        _assertVerificationResult(result, VerificationResult.Success);
     }
 
     // Untrusted chain certs (past trustedCertsPrefixLen): expired journal notAfter => InvalidTimestamp
@@ -868,40 +690,20 @@ contract NitroEnclaveVerifierTest is Test {
 
         bytes32 expiredLeaf = keccak256("expired-untrusted-leaf");
 
-        VerifierJournal memory journal = _createSuccessJournal();
-        bytes32[] memory certs = new bytes32[](3);
-        certs[0] = ROOT_CERT;
-        certs[1] = INTERMEDIATE_CERT_1;
-        certs[2] = expiredLeaf;
-        journal.certs = certs;
+        VerifierJournal memory journal = _createSuccessJournalWithLeaf(expiredLeaf, uint64(block.timestamp - 1));
+        VerifierJournal memory result = _verifyRiscZeroJournal(journal);
 
-        uint64[] memory expiries = new uint64[](3);
-        expiries[0] = INTERMEDIATE_CERT_1_EXPIRY + 100_000_000;
-        expiries[1] = INTERMEDIATE_CERT_1_EXPIRY;
-        expiries[2] = uint64(block.timestamp - 1);
-        journal.certExpiries = expiries;
-        journal.trustedCertsPrefixLen = 2;
-
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
-
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
-
-        assertEq(uint8(result.result), uint8(VerificationResult.InvalidTimestamp));
+        _assertVerificationResult(result, VerificationResult.InvalidTimestamp);
         assertEq(verifier.trustedIntermediateCerts(expiredLeaf), 0);
     }
 
     function testCheckTrustedIntermediateCertsStopsAtExpiredCert() public {
-        // Warp past the intermediate cert's expiry
         vm.warp(INTERMEDIATE_CERT_1_EXPIRY + 1);
 
         bytes32[][] memory reportCerts = new bytes32[][](1);
         reportCerts[0] = new bytes32[](2);
         reportCerts[0][0] = ROOT_CERT;
-        reportCerts[0][1] = INTERMEDIATE_CERT_1; // expired
+        reportCerts[0][1] = INTERMEDIATE_CERT_1;
 
         uint8[] memory results = verifier.checkTrustedIntermediateCerts(reportCerts);
         assertEq(results[0], 1); // only root counted, expired intermediate skipped
@@ -913,51 +715,109 @@ contract NitroEnclaveVerifierTest is Test {
         bytes32 newCert = keccak256("brand-new-cert");
         uint64 newCertExpiry = uint64(REALISTIC_TIMESTAMP + 86_400); // 1 day from now
 
-        VerifierJournal memory journal = _createSuccessJournal();
-        bytes32[] memory certs = new bytes32[](3);
-        certs[0] = ROOT_CERT;
-        certs[1] = INTERMEDIATE_CERT_1;
-        certs[2] = newCert;
-        journal.certs = certs;
-
-        uint64[] memory expiries = new uint64[](3);
-        expiries[0] = INTERMEDIATE_CERT_1_EXPIRY + 100_000_000;
-        expiries[1] = INTERMEDIATE_CERT_1_EXPIRY;
-        expiries[2] = newCertExpiry;
-        journal.certExpiries = expiries;
-
-        journal.trustedCertsPrefixLen = 2;
-
-        bytes memory output = abi.encode(journal);
-        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
-
-        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
-
-        vm.prank(submitter);
-        verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
+        VerifierJournal memory journal = _createSuccessJournalWithLeaf(newCert, newCertExpiry);
+        _verifyRiscZeroJournal(journal);
 
         assertEq(verifier.trustedIntermediateCerts(newCert), newCertExpiry);
-    }
-
-    function testRevokeCertSetsExpiryToZero() public {
-        assertEq(verifier.trustedIntermediateCerts(INTERMEDIATE_CERT_1), INTERMEDIATE_CERT_1_EXPIRY);
-        verifier.revokeCert(INTERMEDIATE_CERT_1);
-        assertEq(verifier.trustedIntermediateCerts(INTERMEDIATE_CERT_1), 0);
     }
 
     // ============ Helpers ============
 
     function _setUpRiscZeroConfig() internal {
-        ZkCoProcessorConfig memory config = ZkCoProcessorConfig({
-            verifierId: VERIFIER_ID, aggregatorId: AGGREGATOR_ID, zkVerifier: mockRiscZeroVerifier
-        });
-        verifier.setZkConfiguration(ZkCoProcessorType.RiscZero, config, VERIFIER_PROOF_ID);
+        verifier.setZkConfiguration(ZkCoProcessorType.RiscZero, _zkConfig(mockRiscZeroVerifier), VERIFIER_PROOF_ID);
     }
 
-    function _setUpSP1Config() internal {
-        ZkCoProcessorConfig memory config =
-            ZkCoProcessorConfig({ verifierId: VERIFIER_ID, aggregatorId: AGGREGATOR_ID, zkVerifier: mockSP1Verifier });
-        verifier.setZkConfiguration(ZkCoProcessorType.Succinct, config, VERIFIER_PROOF_ID);
+    function _zkConfig(address zkVerifier) internal pure returns (ZkCoProcessorConfig memory) {
+        return ZkCoProcessorConfig({ verifierId: VERIFIER_ID, aggregatorId: AGGREGATOR_ID, zkVerifier: zkVerifier });
+    }
+
+    function _expectNotOwnerRevert(address caller) internal {
+        vm.prank(caller);
+        vm.expectRevert(Ownable.Unauthorized.selector);
+    }
+
+    function _expectZkRouteFrozenRevert(ZkCoProcessorType zkType, bytes4 selector) internal {
+        vm.expectRevert(abi.encodeWithSelector(NitroEnclaveVerifier.ZkRouteFrozen.selector, zkType, selector));
+    }
+
+    function _addAndFreezeVerifyRoute(ZkCoProcessorType zkType, bytes4 selector, address routeVerifier) internal {
+        verifier.addVerifyRoute(zkType, selector, routeVerifier);
+        verifier.freezeVerifyRoute(zkType, selector);
+    }
+
+    function _assertVerificationResult(VerifierJournal memory journal, VerificationResult expected) internal pure {
+        assertEq(uint8(journal.result), uint8(expected));
+    }
+
+    function _verifyRiscZeroJournal(VerifierJournal memory journal) internal returns (VerifierJournal memory) {
+        bytes memory output = abi.encode(journal);
+        bytes memory proofBytes = _proofBytes();
+
+        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
+
+        vm.prank(submitter);
+        return verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
+    }
+
+    function _verifySP1Journal(VerifierJournal memory journal) internal returns (VerifierJournal memory) {
+        bytes memory output = abi.encode(journal);
+        bytes memory proofBytes = _proofBytes();
+
+        _mockSP1Verify(VERIFIER_ID, output, proofBytes);
+
+        vm.prank(submitter);
+        return verifier.verify(output, ZkCoProcessorType.Succinct, proofBytes);
+    }
+
+    function _createBatchJournal(
+        bytes32 verifierVk,
+        uint256 outputCount
+    )
+        internal
+        view
+        returns (BatchVerifierJournal memory)
+    {
+        VerifierJournal[] memory outputs = new VerifierJournal[](outputCount);
+        VerifierJournal memory journal = _createSuccessJournal();
+        for (uint256 i; i < outputCount; ++i) {
+            outputs[i] = journal;
+        }
+
+        return BatchVerifierJournal({ verifierVk: verifierVk, outputs: outputs });
+    }
+
+    function _batchVerifyRiscZero(BatchVerifierJournal memory batchJournal)
+        internal
+        returns (VerifierJournal[] memory)
+    {
+        (bytes memory output, bytes memory proofBytes) = _mockRiscZeroBatchVerify(batchJournal);
+
+        vm.prank(submitter);
+        return verifier.batchVerify(output, ZkCoProcessorType.RiscZero, proofBytes);
+    }
+
+    function _batchVerifySP1(BatchVerifierJournal memory batchJournal) internal returns (VerifierJournal[] memory) {
+        bytes memory output = abi.encode(batchJournal);
+        bytes memory proofBytes = _proofBytes();
+
+        _mockSP1Verify(AGGREGATOR_ID, output, proofBytes);
+
+        vm.prank(submitter);
+        return verifier.batchVerify(output, ZkCoProcessorType.Succinct, proofBytes);
+    }
+
+    function _mockRiscZeroBatchVerify(BatchVerifierJournal memory batchJournal)
+        internal
+        returns (bytes memory output, bytes memory proofBytes)
+    {
+        output = abi.encode(batchJournal);
+        proofBytes = _proofBytes();
+
+        _mockRiscZeroVerify(AGGREGATOR_ID, output, proofBytes);
+    }
+
+    function _proofBytes() internal pure returns (bytes memory) {
+        return abi.encodePacked(DEFAULT_PROOF_SELECTOR, bytes32(0));
     }
 
     function _createSuccessJournal() internal view returns (VerifierJournal memory) {
@@ -966,9 +826,41 @@ contract NitroEnclaveVerifierTest is Test {
         certs[1] = INTERMEDIATE_CERT_1;
 
         uint64[] memory expiries = new uint64[](2);
-        expiries[0] = INTERMEDIATE_CERT_1_EXPIRY + 100_000_000; // root expiry (far future)
+        expiries[0] = ROOT_CERT_EXPIRY;
         expiries[1] = INTERMEDIATE_CERT_1_EXPIRY;
 
+        return _successJournal(certs, expiries);
+    }
+
+    function _createSuccessJournalWithLeaf(
+        bytes32 leafCert,
+        uint64 leafExpiry
+    )
+        internal
+        view
+        returns (VerifierJournal memory)
+    {
+        bytes32[] memory certs = new bytes32[](3);
+        certs[0] = ROOT_CERT;
+        certs[1] = INTERMEDIATE_CERT_1;
+        certs[2] = leafCert;
+
+        uint64[] memory expiries = new uint64[](3);
+        expiries[0] = ROOT_CERT_EXPIRY;
+        expiries[1] = INTERMEDIATE_CERT_1_EXPIRY;
+        expiries[2] = leafExpiry;
+
+        return _successJournal(certs, expiries);
+    }
+
+    function _successJournal(
+        bytes32[] memory certs,
+        uint64[] memory expiries
+    )
+        internal
+        view
+        returns (VerifierJournal memory)
+    {
         Pcr[] memory pcrs = new Pcr[](0);
 
         return VerifierJournal({
@@ -986,24 +878,16 @@ contract NitroEnclaveVerifierTest is Test {
     }
 
     function _mockRiscZeroVerify(bytes32 programId, bytes memory output, bytes memory proofBytes) internal {
-        // IRiscZeroVerifier.verify(proofBytes, programId, sha256(output))
         vm.mockCall(
             mockRiscZeroVerifier,
-            abi.encodeWithSelector(
-                bytes4(keccak256("verify(bytes,bytes32,bytes32)")), proofBytes, programId, sha256(output)
-            ),
+            abi.encodeWithSelector(RISC_ZERO_VERIFY_SELECTOR, proofBytes, programId, sha256(output)),
             ""
         );
     }
 
     function _mockSP1Verify(bytes32 programId, bytes memory output, bytes memory proofBytes) internal {
-        // ISP1Verifier.verifyProof(programVKey, publicValues, proofBytes)
         vm.mockCall(
-            mockSP1Verifier,
-            abi.encodeWithSelector(
-                bytes4(keccak256("verifyProof(bytes32,bytes,bytes)")), programId, output, proofBytes
-            ),
-            ""
+            mockSP1Verifier, abi.encodeWithSelector(SP1_VERIFY_PROOF_SELECTOR, programId, output, proofBytes), ""
         );
     }
 }

--- a/test/L1/proofs/NitroEnclaveVerifier.t.sol
+++ b/test/L1/proofs/NitroEnclaveVerifier.t.sol
@@ -44,6 +44,7 @@ contract NitroEnclaveVerifierTest is Test {
 
     // Expiry timestamps for test certs (well after REALISTIC_TIMESTAMP)
     uint64 internal constant INTERMEDIATE_CERT_1_EXPIRY = 1_800_000_000; // ~2027
+    uint64 internal constant INTERMEDIATE_CERT_2_EXPIRY = 1_750_000_000; // ~2025
     uint64 internal constant ROOT_CERT_EXPIRY = 1_900_000_000;
     uint64 internal constant NEW_LEAF_CERT_EXPIRY = 1_700_100_000; // ~28 hours after REALISTIC_TIMESTAMP
 

--- a/test/L1/proofs/Nullify.t.sol
+++ b/test/L1/proofs/Nullify.t.sol
@@ -103,7 +103,7 @@ contract NullifyTest is BaseTest {
 
     /// @notice With TEE + ZK, the fast window is 1 day. Another game nullifies the shared ZK verifier; the first
     ///         `resolve` persists the ZK refutation and returns `IN_PROGRESS`. After `SLOW_FINALIZATION_DELAY`
-    ///         (7 days) from that moment, a second `resolve` finalizes with only the TEE proof.
+    ///         from that moment, a second `resolve` finalizes with only the TEE proof.
     function testTwoProofsResolveDelayedAfterExternalVerifierNullify() public {
         AggregateVerifier gameA = _createGame(
             TEE_PROVER, "dual-a", "tee-dual-a", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry)

--- a/test/L1/proofs/Nullify.t.sol
+++ b/test/L1/proofs/Nullify.t.sol
@@ -10,285 +10,209 @@ import { AggregateVerifier } from "src/L1/proofs/AggregateVerifier.sol";
 import { BaseTest } from "./BaseTest.t.sol";
 
 contract NullifyTest is BaseTest {
+    uint256 private constant LAST_INTERMEDIATE_ROOT_INDEX = BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1;
+    uint256 private constant NO_PROOF_CREDIT_CLAIM_DELAY = 14 days;
+
     function testNullifyWithTEEProof() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee1")));
-        bytes memory teeProof1 = _generateProof("tee-proof-1", AggregateVerifier.ProofType.TEE);
-
-        AggregateVerifier game = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), teeProof1
+        AggregateVerifier game = _createGame(
+            TEE_PROVER, "tee1", "tee-proof-1", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry)
         );
 
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee2")));
-        bytes memory teeProof2 = _generateProof("tee-proof-2", AggregateVerifier.ProofType.TEE);
+        _nullify(game, "tee-proof-2", AggregateVerifier.ProofType.TEE, "tee2");
+        _assertNullifiedToNoProofs(game, TEE_PROVER);
 
-        game.nullify(teeProof2, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim2.raw());
-
-        assertEq(uint8(game.status()), uint8(GameStatus.IN_PROGRESS));
-        assertEq(game.bondRecipient(), TEE_PROVER);
-        assertEq(game.proofCount(), 0);
-        assertEq(game.expectedResolution().raw(), type(uint64).max);
-
-        // expectedResolution is uint64.max (no proofs left), so must wait 14 days from creation
-        vm.warp(block.timestamp + 14 days);
-
-        uint256 balanceBefore = game.gameCreator().balance;
-        game.claimCredit();
-        vm.warp(block.timestamp + DELAYED_WETH_DELAY);
-        game.claimCredit();
-        assertEq(game.gameCreator().balance, balanceBefore + INIT_BOND);
-        assertEq(delayedWETH.balanceOf(address(game)), 0);
+        vm.warp(block.timestamp + NO_PROOF_CREDIT_CLAIM_DELAY);
+        _claimCreditAfterDelay(game);
     }
 
     function testNullifyWithZKProof() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
+        AggregateVerifier game =
+            _createGame(ZK_PROVER, "zk1", "zk-proof-1", AggregateVerifier.ProofType.ZK, address(anchorStateRegistry));
 
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk1")));
-        bytes memory zkProof1 = _generateProof("zk-proof-1", AggregateVerifier.ProofType.ZK);
+        _nullify(game, "zk-proof-2", AggregateVerifier.ProofType.ZK, "zk2");
+        _assertNullifiedToNoProofs(game, ZK_PROVER);
 
-        AggregateVerifier game1 = _createAggregateVerifierGame(
-            ZK_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), zkProof1
-        );
-
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk2")));
-        bytes memory zkProof2 = _generateProof("zk-proof-2", AggregateVerifier.ProofType.ZK);
-
-        game1.nullify(zkProof2, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim2.raw());
-
-        assertEq(uint8(game1.status()), uint8(GameStatus.IN_PROGRESS));
-        assertEq(game1.bondRecipient(), ZK_PROVER);
-        assertEq(game1.proofCount(), 0);
-        assertEq(game1.expectedResolution().raw(), type(uint64).max);
-
-        // expectedResolution is uint64.max (no proofs left), so must wait 14 days from creation
-        vm.warp(block.timestamp + 14 days);
-
-        uint256 balanceBefore = game1.gameCreator().balance;
-        game1.claimCredit();
-        vm.warp(block.timestamp + DELAYED_WETH_DELAY);
-        game1.claimCredit();
-        assertEq(game1.gameCreator().balance, balanceBefore + INIT_BOND);
-        assertEq(delayedWETH.balanceOf(address(game1)), 0);
+        vm.warp(block.timestamp + NO_PROOF_CREDIT_CLAIM_DELAY);
+        _claimCreditAfterDelay(game);
     }
 
     function testNullifyWithTEEProofWhenTEEAndZKProofsAreProvided() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee1")));
-        bytes memory teeProof1 = _generateProof("tee-proof-1", AggregateVerifier.ProofType.TEE);
-
-        AggregateVerifier game = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), teeProof1
+        AggregateVerifier game = _createGame(
+            TEE_PROVER, "tee1", "tee-proof-1", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry)
         );
 
-        bytes memory zkProof = _generateProof("zk-proof-2", AggregateVerifier.ProofType.ZK);
-        game.verifyProposalProof(zkProof);
+        _provideProof(game, ZK_PROVER, _generateProof("zk-proof-2", AggregateVerifier.ProofType.ZK));
 
-        assertEq(game.expectedResolution().raw(), block.timestamp + FAST_FINALIZATION_DELAY);
+        assertEq(game.expectedResolution().raw(), block.timestamp + game.FAST_FINALIZATION_DELAY());
 
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee2")));
-        bytes memory teeProof2 = _generateProof("tee-proof-2", AggregateVerifier.ProofType.TEE);
-        game.nullify(teeProof2, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim2.raw());
+        _nullify(game, "tee-proof-2", AggregateVerifier.ProofType.TEE, "tee2");
 
-        assertEq(uint8(game.status()), uint8(GameStatus.IN_PROGRESS));
+        _assertStatus(game, GameStatus.IN_PROGRESS);
         assertEq(game.bondRecipient(), TEE_PROVER);
         assertEq(game.proofCount(), 1);
-        assertEq(game.expectedResolution().raw(), block.timestamp + SLOW_FINALIZATION_DELAY);
+        assertEq(game.expectedResolution().raw(), block.timestamp + game.SLOW_FINALIZATION_DELAY());
     }
 
     function testZKNullifyFailsIfNoZKProof() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee1")));
-        bytes memory teeProof = _generateProof("tee-proof", AggregateVerifier.ProofType.TEE);
-
-        AggregateVerifier game1 = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), teeProof
-        );
-
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee2")));
-        bytes memory zkProof = _generateProof("zk-proof", AggregateVerifier.ProofType.ZK);
+        AggregateVerifier game =
+            _createGame(TEE_PROVER, "tee1", "tee-proof", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry));
 
         vm.expectRevert(abi.encodeWithSelector(AggregateVerifier.MissingProof.selector, AggregateVerifier.ProofType.ZK));
-        game1.nullify(zkProof, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim2.raw());
+        _nullify(game, "zk-proof", AggregateVerifier.ProofType.ZK, "tee2");
     }
 
     function testNullifyFailsIfGameAlreadyResolved() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee1")));
-        bytes memory teeProof1 = _generateProof("tee-proof-1", AggregateVerifier.ProofType.TEE);
-
-        AggregateVerifier game1 = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), teeProof1
+        AggregateVerifier game = _createGame(
+            TEE_PROVER, "tee1", "tee-proof-1", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry)
         );
 
-        // Resolve game1
-        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
-        game1.resolve();
-
-        // Try to nullify game1
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk")));
-        bytes memory teeProof2 = _generateProof("tee-proof-2", AggregateVerifier.ProofType.TEE);
+        vm.warp(block.timestamp + game.SLOW_FINALIZATION_DELAY());
+        game.resolve();
 
         vm.expectRevert(ClaimAlreadyResolved.selector);
-        game1.nullify(teeProof2, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim2.raw());
+        _nullify(game, "tee-proof-2", AggregateVerifier.ProofType.TEE, "zk");
     }
 
     function testNullifyCanOverrideChallenge() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaim1 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee1")));
-        bytes memory teeProof1 = _generateProof("tee-proof-1", AggregateVerifier.ProofType.TEE);
-
-        AggregateVerifier game1 = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaim1, currentL2BlockNumber, address(anchorStateRegistry), teeProof1
+        AggregateVerifier game = _createGame(
+            TEE_PROVER, "tee1", "tee-proof-1", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry)
         );
 
-        // Challenge game1 with ZK proof
-        Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk")));
-        bytes memory zkProof = _generateProof("zk-proof", AggregateVerifier.ProofType.ZK);
-
         vm.prank(ZK_PROVER);
-        game1.challenge(zkProof, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim2.raw());
+        game.challenge(
+            _generateProof("zk-proof", AggregateVerifier.ProofType.ZK), LAST_INTERMEDIATE_ROOT_INDEX, _claim("zk").raw()
+        );
 
-        // Nullify can override challenge
-        bytes memory zkProof2 = _generateProof("zk-proof-2", AggregateVerifier.ProofType.ZK);
-        game1.nullify(zkProof2, BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1, rootClaim1.raw());
+        _nullify(game, "zk-proof-2", AggregateVerifier.ProofType.ZK, "tee1");
 
-        assertEq(game1.bondRecipient(), TEE_PROVER);
+        assertEq(game.bondRecipient(), TEE_PROVER);
+        assertEq(game.expectedResolution().raw(), block.timestamp + game.SLOW_FINALIZATION_DELAY());
 
-        // After nullify, only TEE proof remains; expectedResolution = now + SLOW_FINALIZATION_DELAY
-        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
-        game1.resolve();
-
-        uint256 balanceBefore = game1.gameCreator().balance;
-        game1.claimCredit();
-        vm.warp(block.timestamp + DELAYED_WETH_DELAY);
-        game1.claimCredit();
-        assertEq(game1.gameCreator().balance, balanceBefore + INIT_BOND);
-        assertEq(delayedWETH.balanceOf(address(game1)), 0);
+        vm.warp(block.timestamp + game.SLOW_FINALIZATION_DELAY());
+        game.resolve();
+        _claimCreditAfterDelay(game);
     }
 
-    /// @notice `resolve` runs `_updateProofCount`; when the shared TEE verifier was nullified by another game,
-    ///         refutation persists and `resolve` returns early `IN_PROGRESS` (no `Resolved` event) instead of
-    /// reverting. @dev All clones share the same `MockVerifier` TEE instance; `Verifier.nullify` requires a proper
-    /// factory game.
     function testResolveEarlyReturnWhenSharedTeeVerifierNullifiedByAnotherGame() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaimA = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "game-a")));
-        bytes memory teeProofA = _generateProof("tee-proof-a", AggregateVerifier.ProofType.TEE);
-        AggregateVerifier gameA = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaimA, currentL2BlockNumber, address(anchorStateRegistry), teeProofA
-        );
-
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaimB = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "game-b")));
-        bytes memory teeProofB = _generateProof("tee-proof-b", AggregateVerifier.ProofType.TEE);
-        AggregateVerifier gameB =
-            _createAggregateVerifierGame(TEE_PROVER, rootClaimB, currentL2BlockNumber, address(gameA), teeProofB);
-
-        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
-        assertTrue(gameA.gameOver());
-        assertEq(gameA.proofCount(), 1);
-
-        Claim rootClaimNullify = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "nullify-b")));
-        bytes memory teeProofNullify = _generateProof("tee-nullify-b", AggregateVerifier.ProofType.TEE);
-        uint256 lastIntermediateIdx = BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1;
-        gameB.nullify(teeProofNullify, lastIntermediateIdx, rootClaimNullify.raw());
-
-        assertTrue(teeVerifier.nullified());
-        assertEq(gameA.proofCount(), 1);
-
-        assertEq(uint8(gameA.resolve()), uint8(GameStatus.IN_PROGRESS));
-        assertEq(gameA.proofCount(), 0);
-        assertEq(gameA.expectedResolution().raw(), type(uint64).max);
-
-        vm.expectRevert(AggregateVerifier.GameNotOver.selector);
-        gameA.resolve();
+        _assertResolveEarlyReturnWhenSharedVerifierNullifiedByAnotherGame(TEE_PROVER, AggregateVerifier.ProofType.TEE);
     }
 
-    /// @notice Same as `testResolveEarlyReturnWhenSharedTeeVerifierNullifiedByAnotherGame` but for the shared ZK
-    /// verifier.
     function testResolveEarlyReturnWhenSharedZkVerifierNullifiedByAnotherGame() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaimA = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk-game-a")));
-        bytes memory zkProofA = _generateProof("zk-proof-a", AggregateVerifier.ProofType.ZK);
-        AggregateVerifier gameA = _createAggregateVerifierGame(
-            ZK_PROVER, rootClaimA, currentL2BlockNumber, address(anchorStateRegistry), zkProofA
-        );
-
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaimB = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk-game-b")));
-        bytes memory zkProofB = _generateProof("zk-proof-b", AggregateVerifier.ProofType.ZK);
-        AggregateVerifier gameB =
-            _createAggregateVerifierGame(ZK_PROVER, rootClaimB, currentL2BlockNumber, address(gameA), zkProofB);
-
-        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
-        assertTrue(gameA.gameOver());
-        assertEq(gameA.proofCount(), 1);
-
-        Claim rootClaimNullify = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "zk-nullify-b")));
-        bytes memory zkProofNullify = _generateProof("zk-nullify-b", AggregateVerifier.ProofType.ZK);
-        uint256 lastIntermediateIdx = BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1;
-        gameB.nullify(zkProofNullify, lastIntermediateIdx, rootClaimNullify.raw());
-
-        assertTrue(zkVerifier.nullified());
-        assertEq(gameA.proofCount(), 1);
-
-        assertEq(uint8(gameA.resolve()), uint8(GameStatus.IN_PROGRESS));
-        assertEq(gameA.proofCount(), 0);
-        assertEq(gameA.expectedResolution().raw(), type(uint64).max);
-
-        vm.expectRevert(AggregateVerifier.GameNotOver.selector);
-        gameA.resolve();
+        _assertResolveEarlyReturnWhenSharedVerifierNullifiedByAnotherGame(ZK_PROVER, AggregateVerifier.ProofType.ZK);
     }
 
-    /// @notice With TEE + ZK, the fast window is `FAST_FINALIZATION_DELAY`. Another game nullifies the shared ZK
-    ///         verifier; the first `resolve` persists the ZK refutation and returns `IN_PROGRESS`. After
-    ///         `SLOW_FINALIZATION_DELAY` from that moment, a second `resolve` finalizes with only the TEE proof.
+    /// @notice With TEE + ZK, the fast window is 1 day. Another game nullifies the shared ZK verifier; the first
+    ///         `resolve` persists the ZK refutation and returns `IN_PROGRESS`. After `SLOW_FINALIZATION_DELAY`
+    ///         (7 days) from that moment, a second `resolve` finalizes with only the TEE proof.
     function testTwoProofsResolveDelayedAfterExternalVerifierNullify() public {
-        currentL2BlockNumber += BLOCK_INTERVAL;
-
-        Claim rootClaimA = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "dual-a")));
-        bytes memory teeProofA = _generateProof("tee-dual-a", AggregateVerifier.ProofType.TEE);
-        AggregateVerifier gameA = _createAggregateVerifierGame(
-            TEE_PROVER, rootClaimA, currentL2BlockNumber, address(anchorStateRegistry), teeProofA
+        AggregateVerifier gameA = _createGame(
+            TEE_PROVER, "dual-a", "tee-dual-a", AggregateVerifier.ProofType.TEE, address(anchorStateRegistry)
         );
 
-        bytes memory zkProofA = _generateProof("zk-dual-a", AggregateVerifier.ProofType.ZK);
-        vm.prank(ZK_PROVER);
-        gameA.verifyProposalProof(zkProofA);
+        _provideProof(gameA, ZK_PROVER, _generateProof("zk-dual-a", AggregateVerifier.ProofType.ZK));
 
         assertEq(gameA.proofCount(), 2);
-        assertEq(gameA.expectedResolution().raw(), block.timestamp + FAST_FINALIZATION_DELAY);
+        assertEq(gameA.expectedResolution().raw(), block.timestamp + gameA.FAST_FINALIZATION_DELAY());
 
-        vm.warp(block.timestamp + FAST_FINALIZATION_DELAY);
+        vm.warp(block.timestamp + gameA.FAST_FINALIZATION_DELAY());
         assertTrue(gameA.gameOver());
 
-        currentL2BlockNumber += BLOCK_INTERVAL;
-        Claim rootClaimB = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "dual-b")));
-        bytes memory zkProofB = _generateProof("zk-dual-b", AggregateVerifier.ProofType.ZK);
         AggregateVerifier gameB =
-            _createAggregateVerifierGame(ZK_PROVER, rootClaimB, currentL2BlockNumber, address(gameA), zkProofB);
+            _createGame(ZK_PROVER, "dual-b", "zk-dual-b", AggregateVerifier.ProofType.ZK, address(gameA));
 
-        Claim rootClaimNullify = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "dual-nullify-b")));
-        bytes memory zkProofNullify = _generateProof("zk-nullify-dual", AggregateVerifier.ProofType.ZK);
-        uint256 lastIntermediateIdx = BLOCK_INTERVAL / INTERMEDIATE_BLOCK_INTERVAL - 1;
-        gameB.nullify(zkProofNullify, lastIntermediateIdx, rootClaimNullify.raw());
+        _nullify(gameB, "zk-nullify-dual", AggregateVerifier.ProofType.ZK, "dual-nullify-b");
         assertTrue(zkVerifier.nullified());
 
         assertEq(uint8(gameA.resolve()), uint8(GameStatus.IN_PROGRESS));
         assertEq(gameA.proofCount(), 1);
-        assertEq(gameA.expectedResolution().raw(), block.timestamp + SLOW_FINALIZATION_DELAY);
+        assertEq(gameA.expectedResolution().raw(), block.timestamp + gameA.SLOW_FINALIZATION_DELAY());
 
-        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
+        vm.warp(block.timestamp + gameA.SLOW_FINALIZATION_DELAY());
         assertEq(uint8(gameA.resolve()), uint8(GameStatus.DEFENDER_WINS));
-        assertEq(uint8(gameA.status()), uint8(GameStatus.DEFENDER_WINS));
+        _assertStatus(gameA, GameStatus.DEFENDER_WINS);
+    }
+
+    function _createGame(
+        address prover,
+        bytes memory claimSalt,
+        bytes memory proofSalt,
+        AggregateVerifier.ProofType proofType,
+        address parent
+    )
+        private
+        returns (AggregateVerifier)
+    {
+        currentL2BlockNumber += BLOCK_INTERVAL;
+        return _createAggregateVerifierGame(
+            prover, _claim(claimSalt), currentL2BlockNumber, parent, _generateProof(proofSalt, proofType)
+        );
+    }
+
+    function _claim(bytes memory salt) private view returns (Claim) {
+        return Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, salt)));
+    }
+
+    function _nullify(
+        AggregateVerifier game,
+        bytes memory proofSalt,
+        AggregateVerifier.ProofType proofType,
+        bytes memory claimSalt
+    )
+        private
+    {
+        game.nullify(_generateProof(proofSalt, proofType), LAST_INTERMEDIATE_ROOT_INDEX, _claim(claimSalt).raw());
+    }
+
+    function _assertNullifiedToNoProofs(AggregateVerifier game, address expectedBondRecipient) private view {
+        _assertStatus(game, GameStatus.IN_PROGRESS);
+        assertEq(game.bondRecipient(), expectedBondRecipient);
+        assertEq(game.proofCount(), 0);
+        assertEq(game.expectedResolution().raw(), type(uint64).max);
+    }
+
+    function _assertStatus(AggregateVerifier game, GameStatus expectedStatus) private view {
+        assertEq(uint8(game.status()), uint8(expectedStatus));
+    }
+
+    /// @notice When a shared verifier is nullified by another game, `resolve` persists the refutation and returns
+    ///         early `IN_PROGRESS` instead of reverting.
+    function _assertResolveEarlyReturnWhenSharedVerifierNullifiedByAnotherGame(
+        address prover,
+        AggregateVerifier.ProofType proofType
+    )
+        private
+    {
+        AggregateVerifier gameA = _createGame(prover, "game-a", "proof-a", proofType, address(anchorStateRegistry));
+        AggregateVerifier gameB = _createGame(prover, "game-b", "proof-b", proofType, address(gameA));
+
+        vm.warp(block.timestamp + gameA.SLOW_FINALIZATION_DELAY());
+        assertTrue(gameA.gameOver());
+        assertEq(gameA.proofCount(), 1);
+
+        _nullify(gameB, "nullify-proof", proofType, "nullify-claim");
+
+        if (proofType == AggregateVerifier.ProofType.TEE) {
+            assertTrue(teeVerifier.nullified());
+        } else {
+            assertTrue(zkVerifier.nullified());
+        }
+        assertEq(gameA.proofCount(), 1);
+
+        assertEq(uint8(gameA.resolve()), uint8(GameStatus.IN_PROGRESS));
+        assertEq(gameA.proofCount(), 0);
+        assertEq(gameA.expectedResolution().raw(), type(uint64).max);
+
+        vm.expectRevert(AggregateVerifier.GameNotOver.selector);
+        gameA.resolve();
+    }
+
+    function _claimCreditAfterDelay(AggregateVerifier game) private {
+        address recipient = game.gameCreator();
+        uint256 balanceBefore = recipient.balance;
+        game.claimCredit();
+        vm.warp(block.timestamp + DELAYED_WETH_DELAY);
+        game.claimCredit();
+        assertEq(recipient.balance, balanceBefore + INIT_BOND);
+        assertEq(delayedWETH.balanceOf(address(game)), 0);
     }
 }

--- a/test/L1/proofs/TEEProverRegistry.t.sol
+++ b/test/L1/proofs/TEEProverRegistry.t.sol
@@ -6,7 +6,6 @@ import { Test } from "lib/forge-std/src/Test.sol";
 import {
     TransparentUpgradeableProxy
 } from "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
 
 import { INitroEnclaveVerifier } from "interfaces/L1/proofs/tee/INitroEnclaveVerifier.sol";
 import { IDisputeGameFactory } from "interfaces/L1/proofs/IDisputeGameFactory.sol";
@@ -17,48 +16,38 @@ import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
 import { DevTEEProverRegistry } from "test/mocks/MockDevTEEProverRegistry.sol";
 import { TEEProverRegistry } from "src/L1/proofs/tee/TEEProverRegistry.sol";
 
-/// @notice Mock AggregateVerifier that returns a configurable TEE_IMAGE_HASH.
 contract MockAggregateVerifierForRegistry {
-    bytes32 public TEE_IMAGE_HASH;
+    bytes32 public immutable TEE_IMAGE_HASH;
 
     constructor(bytes32 imageHash) {
         TEE_IMAGE_HASH = imageHash;
     }
 }
 
-/// @notice Mock DisputeGameFactory that returns a fixed game implementation.
 contract MockDisputeGameFactoryForRegistry {
-    mapping(uint32 => address) internal _impls;
+    IDisputeGame internal immutable _impl;
 
-    function setImpl(uint32 gameType, address impl) external {
-        _impls[gameType] = impl;
+    constructor(address impl) {
+        _impl = IDisputeGame(impl);
     }
 
-    function gameImpls(GameType gameType) external view returns (IDisputeGame) {
-        return IDisputeGame(_impls[GameType.unwrap(gameType)]);
+    function gameImpls(GameType) external view returns (IDisputeGame) {
+        return _impl;
     }
 }
 
-/// @notice Tests for TEEProverRegistry and DevTEEProverRegistry contracts.
-/// @dev IMPORTANT: This test file uses DevTEEProverRegistry as the implementation because
-/// registering signers on the production TEEProverRegistry requires a ZK proof of a valid
-/// AWS Nitro attestation, which cannot be generated in a test environment. DevTEEProverRegistry extends
-/// TEEProverRegistry with an `addDevSigner` function that bypasses attestation verification,
-/// allowing us to test all signer-related functionality. All tests for base TEEProverRegistry
-/// functionality (ownership, proposer, etc.) are equally valid since
-/// DevTEEProverRegistry inherits from TEEProverRegistry without modifying those functions.
+/// @dev Uses DevTEEProverRegistry because production signer registration requires a Nitro attestation proof.
 contract TEEProverRegistryTest is Test {
     DevTEEProverRegistry public teeProverRegistry;
-    ProxyAdmin public proxyAdmin;
-    MockDisputeGameFactoryForRegistry public mockFactory;
-    MockAggregateVerifierForRegistry public mockVerifier;
 
     address public owner;
     address public manager;
     address public unauthorized;
 
     bytes32 public constant TEST_IMAGE_HASH = keccak256("test-image-hash");
-    uint32 public constant TEST_GAME_TYPE = 621;
+    GameType public constant TEST_GAME_TYPE = GameType.wrap(621);
+    string internal constant NOT_OWNER = "OwnableManaged: caller is not the owner";
+    string internal constant NOT_OWNER_OR_MANAGER = "OwnableManaged: caller is not the owner or the manager";
 
     // Events must be redeclared here because Solidity 0.8.15 doesn't support
     // referencing events from other contracts via qualified names (requires 0.8.21+)
@@ -71,31 +60,55 @@ contract TEEProverRegistryTest is Test {
         manager = makeAddr("manager");
         unauthorized = makeAddr("unauthorized");
 
-        // Deploy mock factory and verifier
-        mockVerifier = new MockAggregateVerifierForRegistry(TEST_IMAGE_HASH);
-        mockFactory = new MockDisputeGameFactoryForRegistry();
-        mockFactory.setImpl(TEST_GAME_TYPE, address(mockVerifier));
-
-        // Deploy implementation (using DevTEEProverRegistry for test flexibility)
-        DevTEEProverRegistry impl =
-            new DevTEEProverRegistry(INitroEnclaveVerifier(address(0)), IDisputeGameFactory(address(mockFactory)));
-
-        // Deploy proxy admin
-        proxyAdmin = new ProxyAdmin(address(this));
-
-        // Deploy proxy
-        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
-            address(impl),
-            address(proxyAdmin),
-            abi.encodeCall(
-                TEEProverRegistry.initialize, (owner, manager, new address[](0), GameType.wrap(TEST_GAME_TYPE))
-            )
-        );
-
-        teeProverRegistry = DevTEEProverRegistry(address(proxy));
+        teeProverRegistry = _deployRegistry(new address[](0), TEST_GAME_TYPE);
     }
 
-    // ============ Initialization Tests ============
+    function _deployRegistry(address[] memory proposers, GameType gameType) internal returns (DevTEEProverRegistry) {
+        MockAggregateVerifierForRegistry verifier = new MockAggregateVerifierForRegistry(TEST_IMAGE_HASH);
+        MockDisputeGameFactoryForRegistry factory = new MockDisputeGameFactoryForRegistry(address(verifier));
+
+        DevTEEProverRegistry impl =
+            new DevTEEProverRegistry(INitroEnclaveVerifier(address(0)), IDisputeGameFactory(address(factory)));
+
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(impl),
+            makeAddr("proxy-admin"),
+            abi.encodeCall(TEEProverRegistry.initialize, (owner, manager, proposers, gameType))
+        );
+
+        return DevTEEProverRegistry(address(proxy));
+    }
+
+    function _addDevSigner(address signer) internal {
+        vm.prank(owner);
+        teeProverRegistry.addDevSigner(signer, TEST_IMAGE_HASH);
+    }
+
+    function _addDevSigners(address signer1, address signer2, address signer3) internal {
+        vm.startPrank(owner);
+        teeProverRegistry.addDevSigner(signer1, TEST_IMAGE_HASH);
+        teeProverRegistry.addDevSigner(signer2, TEST_IMAGE_HASH);
+        teeProverRegistry.addDevSigner(signer3, TEST_IMAGE_HASH);
+        vm.stopPrank();
+    }
+
+    function _expectNotOwnerRevert(address caller) internal {
+        vm.prank(caller);
+        vm.expectRevert(bytes(NOT_OWNER));
+    }
+
+    function _expectNotOwnerOrManagerRevert(address caller) internal {
+        vm.prank(caller);
+        vm.expectRevert(bytes(NOT_OWNER_OR_MANAGER));
+    }
+
+    function _assertContains(address[] memory values, address expected) internal {
+        for (uint256 i = 0; i < values.length; i++) {
+            if (values[i] == expected) return;
+        }
+
+        fail();
+    }
 
     function testInitialization() public view {
         assertEq(teeProverRegistry.owner(), owner);
@@ -107,43 +120,27 @@ contract TEEProverRegistryTest is Test {
         address proposer1 = makeAddr("proposer1");
         address proposer2 = makeAddr("proposer2");
         address proposer3 = makeAddr("proposer3");
-        DevTEEProverRegistry impl2 =
-            new DevTEEProverRegistry(INitroEnclaveVerifier(address(0)), IDisputeGameFactory(address(1)));
-        ProxyAdmin proxyAdmin2 = new ProxyAdmin(address(this));
         address[] memory proposers = new address[](3);
         proposers[0] = proposer1;
         proposers[1] = proposer2;
         proposers[2] = proposer3;
-        TransparentUpgradeableProxy proxy2 = new TransparentUpgradeableProxy(
-            address(impl2),
-            address(proxyAdmin2),
-            abi.encodeCall(TEEProverRegistry.initialize, (owner, manager, proposers, GameType.wrap(0)))
-        );
-        DevTEEProverRegistry registry2 = DevTEEProverRegistry(address(proxy2));
+
+        DevTEEProverRegistry registry2 = _deployRegistry(proposers, TEST_GAME_TYPE);
         assertTrue(registry2.isValidProposer(proposer1));
         assertTrue(registry2.isValidProposer(proposer2));
         assertTrue(registry2.isValidProposer(proposer3));
     }
 
     function testInitializationWithEmptyProposers() public view {
-        // Default setUp uses an empty proposer array — no proposer should be set
         assertFalse(teeProverRegistry.isValidProposer(address(0)));
     }
-
-    // ============ Signer Deregistration Tests ============
 
     function testDeregisterSignerAsOwner() public {
         address signer = makeAddr("signer");
 
-        // Add signer via DevTEEProverRegistry
-        vm.prank(owner);
-        teeProverRegistry.addDevSigner(signer, TEST_IMAGE_HASH);
+        _addDevSigner(signer);
 
-        // Verify signer is registered
-        assertTrue(teeProverRegistry.isValidSigner(signer));
-
-        // Deregister as owner
-        vm.expectEmit(true, false, false, false);
+        vm.expectEmit(true, false, false, false, address(teeProverRegistry));
         emit SignerDeregistered(signer);
 
         vm.prank(owner);
@@ -155,11 +152,7 @@ contract TEEProverRegistryTest is Test {
     function testDeregisterSignerAsManager() public {
         address signer = makeAddr("signer");
 
-        // Add signer via DevTEEProverRegistry
-        vm.prank(owner);
-        teeProverRegistry.addDevSigner(signer, TEST_IMAGE_HASH);
-
-        assertTrue(teeProverRegistry.isValidSigner(signer));
+        _addDevSigner(signer);
 
         vm.prank(manager);
         teeProverRegistry.deregisterSigner(signer);
@@ -170,17 +163,14 @@ contract TEEProverRegistryTest is Test {
     function testDeregisterSignerFailsIfUnauthorized() public {
         address signer = makeAddr("signer");
 
-        vm.prank(unauthorized);
-        vm.expectRevert("OwnableManaged: caller is not the owner or the manager");
+        _expectNotOwnerOrManagerRevert(unauthorized);
         teeProverRegistry.deregisterSigner(signer);
     }
-
-    // ============ Proposer Tests ============
 
     function testSetProposer() public {
         address newProposer = makeAddr("proposer");
 
-        vm.expectEmit(true, false, false, false);
+        vm.expectEmit(true, false, false, false, address(teeProverRegistry));
         emit ProposerSet(newProposer, true);
 
         vm.prank(owner);
@@ -192,16 +182,12 @@ contract TEEProverRegistryTest is Test {
     function testSetProposerFailsIfNotOwner() public {
         address newProposer = makeAddr("proposer");
 
-        vm.prank(manager);
-        vm.expectRevert("OwnableManaged: caller is not the owner");
+        _expectNotOwnerRevert(manager);
         teeProverRegistry.setProposer(newProposer, true);
 
-        vm.prank(unauthorized);
-        vm.expectRevert("OwnableManaged: caller is not the owner");
+        _expectNotOwnerRevert(unauthorized);
         teeProverRegistry.setProposer(newProposer, true);
     }
-
-    // ============ isValidSigner Tests ============
 
     function testIsValidSignerReturnsFalseForUnregistered() public {
         address unregistered = makeAddr("unregistered");
@@ -211,19 +197,14 @@ contract TEEProverRegistryTest is Test {
     function testIsValidSignerReturnsTrueForRegistered() public {
         address signer = makeAddr("signer");
 
-        vm.prank(owner);
-        teeProverRegistry.addDevSigner(signer, TEST_IMAGE_HASH);
+        _addDevSigner(signer);
 
         assertTrue(teeProverRegistry.isValidSigner(signer));
     }
 
-    // ============ MAX_AGE Tests ============
-
     function testMaxAgeConstant() public view {
         assertEq(teeProverRegistry.MAX_AGE(), 60 minutes);
     }
-
-    // ============ Ownership Transfer Tests ============
 
     function testTransferOwnership() public {
         address newOwner = makeAddr("newOwner");
@@ -237,12 +218,10 @@ contract TEEProverRegistryTest is Test {
     function testTransferOwnershipFailsIfNotOwner() public {
         address newOwner = makeAddr("newOwner");
 
-        vm.prank(manager);
-        vm.expectRevert("OwnableManaged: caller is not the owner");
+        _expectNotOwnerRevert(manager);
         teeProverRegistry.transferOwnership(newOwner);
 
-        vm.prank(unauthorized);
-        vm.expectRevert("OwnableManaged: caller is not the owner");
+        _expectNotOwnerRevert(unauthorized);
         teeProverRegistry.transferOwnership(newOwner);
     }
 
@@ -251,8 +230,6 @@ contract TEEProverRegistryTest is Test {
         vm.expectRevert("OwnableManaged: new owner is the zero address");
         teeProverRegistry.transferOwnership(address(0));
     }
-
-    // ============ Management Transfer Tests ============
 
     function testTransferManagementAsOwner() public {
         address newManager = makeAddr("newManager");
@@ -275,8 +252,7 @@ contract TEEProverRegistryTest is Test {
     function testTransferManagementFailsIfUnauthorized() public {
         address newManager = makeAddr("newManager");
 
-        vm.prank(unauthorized);
-        vm.expectRevert("OwnableManaged: caller is not the owner or the manager");
+        _expectNotOwnerOrManagerRevert(unauthorized);
         teeProverRegistry.transferManagement(newManager);
     }
 
@@ -285,8 +261,6 @@ contract TEEProverRegistryTest is Test {
         vm.expectRevert("OwnableManaged: new manager is the zero address");
         teeProverRegistry.transferManagement(address(0));
     }
-
-    // ============ Renounce Tests ============
 
     function testRenounceOwnership() public {
         vm.prank(owner);
@@ -309,12 +283,10 @@ contract TEEProverRegistryTest is Test {
         assertEq(teeProverRegistry.manager(), address(0));
     }
 
-    // ============ DevTEEProverRegistry: addDevSigner Tests ============
-
     function testAddDevSigner() public {
         address signer = makeAddr("dev-signer");
 
-        vm.expectEmit(true, false, false, false);
+        vm.expectEmit(true, false, false, false, address(teeProverRegistry));
         emit SignerRegistered(signer);
 
         vm.prank(owner);
@@ -326,25 +298,19 @@ contract TEEProverRegistryTest is Test {
     function testAddDevSignerFailsIfNotOwner() public {
         address signer = makeAddr("dev-signer");
 
-        vm.prank(manager);
-        vm.expectRevert("OwnableManaged: caller is not the owner");
+        _expectNotOwnerRevert(manager);
         teeProverRegistry.addDevSigner(signer, TEST_IMAGE_HASH);
 
-        vm.prank(unauthorized);
-        vm.expectRevert("OwnableManaged: caller is not the owner");
+        _expectNotOwnerRevert(unauthorized);
         teeProverRegistry.addDevSigner(signer, TEST_IMAGE_HASH);
     }
 
     function testAddDevSignerIdempotent() public {
         address signer = makeAddr("dev-signer");
 
-        vm.prank(owner);
-        teeProverRegistry.addDevSigner(signer, TEST_IMAGE_HASH);
-        assertTrue(teeProverRegistry.isValidSigner(signer));
+        _addDevSigner(signer);
+        _addDevSigner(signer);
 
-        // Adding again should not revert
-        vm.prank(owner);
-        teeProverRegistry.addDevSigner(signer, TEST_IMAGE_HASH);
         assertTrue(teeProverRegistry.isValidSigner(signer));
     }
 
@@ -353,29 +319,21 @@ contract TEEProverRegistryTest is Test {
         address signer2 = makeAddr("dev-signer-2");
         address signer3 = makeAddr("dev-signer-3");
 
-        vm.startPrank(owner);
-        teeProverRegistry.addDevSigner(signer1, TEST_IMAGE_HASH);
-        teeProverRegistry.addDevSigner(signer2, TEST_IMAGE_HASH);
-        teeProverRegistry.addDevSigner(signer3, TEST_IMAGE_HASH);
-        vm.stopPrank();
+        _addDevSigners(signer1, signer2, signer3);
 
         assertTrue(teeProverRegistry.isValidSigner(signer1));
         assertTrue(teeProverRegistry.isValidSigner(signer2));
         assertTrue(teeProverRegistry.isValidSigner(signer3));
     }
 
-    // ============ getRegisteredSigners Tests ============
-
     function testGetRegisteredSignersEmpty() public view {
-        address[] memory signers = teeProverRegistry.getRegisteredSigners();
-        assertEq(signers.length, 0);
+        assertEq(teeProverRegistry.getRegisteredSigners().length, 0);
     }
 
     function testGetRegisteredSignersAfterRegister() public {
         address signer = makeAddr("signer");
 
-        vm.prank(owner);
-        teeProverRegistry.addDevSigner(signer, TEST_IMAGE_HASH);
+        _addDevSigner(signer);
 
         address[] memory signers = teeProverRegistry.getRegisteredSigners();
         assertEq(signers.length, 1);
@@ -385,16 +343,12 @@ contract TEEProverRegistryTest is Test {
     function testGetRegisteredSignersAfterDeregister() public {
         address signer = makeAddr("signer");
 
-        vm.prank(owner);
-        teeProverRegistry.addDevSigner(signer, TEST_IMAGE_HASH);
-
-        assertEq(teeProverRegistry.getRegisteredSigners().length, 1);
+        _addDevSigner(signer);
 
         vm.prank(owner);
         teeProverRegistry.deregisterSigner(signer);
 
-        address[] memory signers = teeProverRegistry.getRegisteredSigners();
-        assertEq(signers.length, 0);
+        assertEq(teeProverRegistry.getRegisteredSigners().length, 0);
     }
 
     function testGetRegisteredSignersMultiple() public {
@@ -402,27 +356,14 @@ contract TEEProverRegistryTest is Test {
         address signer2 = makeAddr("signer-2");
         address signer3 = makeAddr("signer-3");
 
-        vm.startPrank(owner);
-        teeProverRegistry.addDevSigner(signer1, TEST_IMAGE_HASH);
-        teeProverRegistry.addDevSigner(signer2, TEST_IMAGE_HASH);
-        teeProverRegistry.addDevSigner(signer3, TEST_IMAGE_HASH);
-        vm.stopPrank();
+        _addDevSigners(signer1, signer2, signer3);
 
         address[] memory signers = teeProverRegistry.getRegisteredSigners();
         assertEq(signers.length, 3);
 
-        // Verify all three are present (order not guaranteed)
-        bool foundSigner1;
-        bool foundSigner2;
-        bool foundSigner3;
-        for (uint256 i = 0; i < signers.length; i++) {
-            if (signers[i] == signer1) foundSigner1 = true;
-            if (signers[i] == signer2) foundSigner2 = true;
-            if (signers[i] == signer3) foundSigner3 = true;
-        }
-        assertTrue(foundSigner1);
-        assertTrue(foundSigner2);
-        assertTrue(foundSigner3);
+        _assertContains(signers, signer1);
+        _assertContains(signers, signer2);
+        _assertContains(signers, signer3);
     }
 
     function testGetRegisteredSignersConsistencyAfterMixedOperations() public {
@@ -430,42 +371,26 @@ contract TEEProverRegistryTest is Test {
         address signer2 = makeAddr("signer-2");
         address signer3 = makeAddr("signer-3");
 
-        // Register three signers
-        vm.startPrank(owner);
-        teeProverRegistry.addDevSigner(signer1, TEST_IMAGE_HASH);
-        teeProverRegistry.addDevSigner(signer2, TEST_IMAGE_HASH);
-        teeProverRegistry.addDevSigner(signer3, TEST_IMAGE_HASH);
-        vm.stopPrank();
+        _addDevSigners(signer1, signer2, signer3);
 
-        assertEq(teeProverRegistry.getRegisteredSigners().length, 3);
-
-        // Deregister the middle one
         vm.prank(manager);
         teeProverRegistry.deregisterSigner(signer2);
 
         address[] memory signers = teeProverRegistry.getRegisteredSigners();
         assertEq(signers.length, 2);
-
-        // Mapping and set stay consistent
-        for (uint256 i = 0; i < signers.length; i++) {
-            assertTrue(teeProverRegistry.isValidSigner(signers[i]));
-            assertNotEq(signers[i], signer2);
-        }
-
-        // Deregistered signer not in mapping either
+        _assertContains(signers, signer1);
+        _assertContains(signers, signer3);
         assertFalse(teeProverRegistry.isValidSigner(signer2));
     }
 
     function testGetRegisteredSignersDeregisterIdempotent() public {
         address signer = makeAddr("signer");
 
-        vm.prank(owner);
-        teeProverRegistry.addDevSigner(signer, TEST_IMAGE_HASH);
+        _addDevSigner(signer);
 
         vm.prank(owner);
         teeProverRegistry.deregisterSigner(signer);
 
-        // Deregistering again should not revert and set should still be empty
         vm.prank(owner);
         teeProverRegistry.deregisterSigner(signer);
 

--- a/test/L1/proofs/TEEProverRegistry.t.sol
+++ b/test/L1/proofs/TEEProverRegistry.t.sol
@@ -3,9 +3,7 @@ pragma solidity 0.8.15;
 
 import { Test } from "lib/forge-std/src/Test.sol";
 
-import {
-    TransparentUpgradeableProxy
-} from "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { Proxy } from "src/universal/Proxy.sol";
 
 import { INitroEnclaveVerifier } from "interfaces/L1/proofs/tee/INitroEnclaveVerifier.sol";
 import { IDisputeGameFactory } from "interfaces/L1/proofs/IDisputeGameFactory.sol";
@@ -70,10 +68,11 @@ contract TEEProverRegistryTest is Test {
         DevTEEProverRegistry impl =
             new DevTEEProverRegistry(INitroEnclaveVerifier(address(0)), IDisputeGameFactory(address(factory)));
 
-        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
-            address(impl),
-            makeAddr("proxy-admin"),
-            abi.encodeCall(TEEProverRegistry.initialize, (owner, manager, proposers, gameType))
+        address proxyAdmin = makeAddr("proxy-admin");
+        Proxy proxy = new Proxy(proxyAdmin);
+        vm.prank(proxyAdmin);
+        proxy.upgradeToAndCall(
+            address(impl), abi.encodeCall(TEEProverRegistry.initialize, (owner, manager, proposers, gameType))
         );
 
         return DevTEEProverRegistry(address(proxy));

--- a/test/L1/proofs/TEEVerifier.t.sol
+++ b/test/L1/proofs/TEEVerifier.t.sol
@@ -6,7 +6,6 @@ import { Test } from "lib/forge-std/src/Test.sol";
 import {
     TransparentUpgradeableProxy
 } from "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
 
 import { INitroEnclaveVerifier } from "interfaces/L1/proofs/tee/INitroEnclaveVerifier.sol";
 import { IAnchorStateRegistry } from "interfaces/L1/proofs/IAnchorStateRegistry.sol";
@@ -19,171 +18,108 @@ import { DevTEEProverRegistry } from "test/mocks/MockDevTEEProverRegistry.sol";
 import { TEEProverRegistry } from "src/L1/proofs/tee/TEEProverRegistry.sol";
 import { TEEVerifier } from "src/L1/proofs/tee/TEEVerifier.sol";
 
-/// @notice Mock AggregateVerifier that returns a configurable TEE_IMAGE_HASH.
 contract MockAggregateVerifierForVerifier {
-    bytes32 public TEE_IMAGE_HASH;
+    bytes32 public immutable TEE_IMAGE_HASH;
 
     constructor(bytes32 imageHash) {
         TEE_IMAGE_HASH = imageHash;
     }
 }
 
-/// @notice Mock DisputeGameFactory that returns a fixed game implementation.
 contract MockDisputeGameFactoryForVerifier {
-    mapping(uint32 => address) internal _impls;
+    IDisputeGame internal immutable _impl;
 
-    function setImpl(uint32 gameType_, address impl) external {
-        _impls[gameType_] = impl;
+    constructor(address impl) {
+        _impl = IDisputeGame(impl);
     }
 
-    function gameImpls(GameType gameType_) external view returns (IDisputeGame) {
-        return IDisputeGame(_impls[GameType.unwrap(gameType_)]);
+    function gameImpls(GameType) external view returns (IDisputeGame) {
+        return _impl;
     }
 }
 
 contract TEEVerifierTest is Test {
     TEEVerifier public verifier;
     DevTEEProverRegistry public teeProverRegistry;
-    ProxyAdmin public proxyAdmin;
-    MockAnchorStateRegistry public anchorStateRegistry;
 
-    // Test signer - we'll derive address from private key
     uint256 internal constant SIGNER_PRIVATE_KEY = 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef;
-    address internal signerAddress;
-
     bytes32 internal constant IMAGE_ID = keccak256("test-image-id");
-    uint32 internal constant TEST_GAME_TYPE = 621;
+    bytes32 internal constant TEST_JOURNAL = keccak256("test-journal");
+    GameType internal constant TEST_GAME_TYPE = GameType.wrap(621);
     address internal immutable PROPOSER = makeAddr("proposer");
 
-    address internal owner;
-
     function setUp() public {
-        owner = address(this);
-
-        // Derive signer address from private key
-        signerAddress = vm.addr(SIGNER_PRIVATE_KEY);
-
-        // Deploy mock factory and verifier
+        address signerAddress = vm.addr(SIGNER_PRIVATE_KEY);
         MockAggregateVerifierForVerifier mockVerifier = new MockAggregateVerifierForVerifier(IMAGE_ID);
-        MockDisputeGameFactoryForVerifier mockFactory = new MockDisputeGameFactoryForVerifier();
-        mockFactory.setImpl(TEST_GAME_TYPE, address(mockVerifier));
+        MockDisputeGameFactoryForVerifier mockFactory = new MockDisputeGameFactoryForVerifier(address(mockVerifier));
 
-        // Deploy implementation (NitroEnclaveVerifier not needed for dev signer tests)
+        // DevTEEProverRegistry keeps these tests focused on verifier behavior without Nitro attestation setup.
         DevTEEProverRegistry impl =
             new DevTEEProverRegistry(INitroEnclaveVerifier(address(0)), IDisputeGameFactory(address(mockFactory)));
 
-        // Deploy proxy admin
-        proxyAdmin = new ProxyAdmin(address(this));
-
-        // Deploy proxy
         TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
             address(impl),
-            address(proxyAdmin),
+            makeAddr("proxy-admin"),
             abi.encodeCall(
-                TEEProverRegistry.initialize, (owner, owner, new address[](0), GameType.wrap(TEST_GAME_TYPE))
+                TEEProverRegistry.initialize, (address(this), address(this), new address[](0), TEST_GAME_TYPE)
             )
         );
 
         teeProverRegistry = DevTEEProverRegistry(address(proxy));
-
-        // Register the signer with the correct image hash
         teeProverRegistry.addDevSigner(signerAddress, IMAGE_ID);
-
-        // Set the proposer as valid
         teeProverRegistry.setProposer(PROPOSER, true);
 
-        // Deploy TEEVerifier
-        anchorStateRegistry = new MockAnchorStateRegistry();
+        MockAnchorStateRegistry anchorStateRegistry = new MockAnchorStateRegistry();
         verifier = new TEEVerifier(
             TEEProverRegistry(address(teeProverRegistry)), IAnchorStateRegistry(address(anchorStateRegistry))
         );
     }
 
     function testVerifyValidSignature() public view {
-        // Create a journal hash
-        bytes32 journal = keccak256("test-journal");
-
-        // Sign the journal with the signer's private key
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PRIVATE_KEY, journal);
-        bytes memory signature = abi.encodePacked(r, s, v);
-
-        // Construct proof: proposer(20) + signature(65) = 85 bytes
-        bytes memory proofBytes = abi.encodePacked(PROPOSER, signature);
-
-        // Verify should return true regardless of imageId (enforced via journal hash, not registry)
-        bool result = verifier.verify(proofBytes, IMAGE_ID, journal);
-        assertTrue(result);
+        assertTrue(verifier.verify(_proofFor(PROPOSER, SIGNER_PRIVATE_KEY, TEST_JOURNAL), IMAGE_ID, TEST_JOURNAL));
     }
 
     function testVerifyFailsWithInvalidSignature() public {
-        bytes32 journal = keccak256("test-journal");
-
-        // Create an invalid signature (all zeros except v)
-        bytes memory invalidSignature = new bytes(65);
-        invalidSignature[64] = bytes1(uint8(27)); // Set v to 27
-
-        bytes memory proofBytes = abi.encodePacked(PROPOSER, invalidSignature);
+        bytes memory proofBytes = abi.encodePacked(PROPOSER, bytes32(0), bytes32(0), uint8(27));
 
         vm.expectRevert(TEEVerifier.InvalidSignature.selector);
-        verifier.verify(proofBytes, IMAGE_ID, journal);
+        verifier.verify(proofBytes, IMAGE_ID, TEST_JOURNAL);
     }
 
     function testVerifyFailsWithInvalidProposer() public {
-        // Create a journal hash
-        bytes32 journal = keccak256("test-journal");
-
-        // Sign the journal with the signer's private key
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PRIVATE_KEY, journal);
-        bytes memory signature = abi.encodePacked(r, s, v);
-
-        // Construct proof: proposer(20) + signature(65) = 85 bytes
-        bytes memory proofBytes = abi.encodePacked(address(0), signature);
+        bytes memory proofBytes = _proofFor(address(0), SIGNER_PRIVATE_KEY, TEST_JOURNAL);
 
         vm.expectRevert(abi.encodeWithSelector(TEEVerifier.InvalidProposer.selector, address(0)));
-        verifier.verify(proofBytes, IMAGE_ID, journal);
+        verifier.verify(proofBytes, IMAGE_ID, TEST_JOURNAL);
     }
 
     function testVerifyFailsWithUnregisteredSigner() public {
-        // Use a different private key that's not registered
         uint256 unregisteredKey = 0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef;
         address unregisteredSigner = vm.addr(unregisteredKey);
 
-        bytes32 journal = keccak256("test-journal");
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(unregisteredKey, journal);
-        bytes memory signature = abi.encodePacked(r, s, v);
-
-        bytes memory proofBytes = abi.encodePacked(PROPOSER, signature);
-
         vm.expectRevert(abi.encodeWithSelector(TEEVerifier.InvalidSigner.selector, unregisteredSigner));
-        verifier.verify(proofBytes, IMAGE_ID, journal);
+        verifier.verify(_proofFor(PROPOSER, unregisteredKey, TEST_JOURNAL), IMAGE_ID, TEST_JOURNAL);
     }
 
     function testVerifyFailsWithImageIdMismatch() public {
-        bytes32 journal = keccak256("test-journal");
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PRIVATE_KEY, journal);
-        bytes memory signature = abi.encodePacked(r, s, v);
-
-        bytes memory proofBytes = abi.encodePacked(PROPOSER, signature);
-
-        // Different imageId should fail — signer was registered with IMAGE_ID
         bytes32 wrongImageId = keccak256("different-image");
         vm.expectRevert(abi.encodeWithSelector(TEEVerifier.ImageIdMismatch.selector, IMAGE_ID, wrongImageId));
-        verifier.verify(proofBytes, wrongImageId, journal);
+        verifier.verify(_proofFor(PROPOSER, SIGNER_PRIVATE_KEY, TEST_JOURNAL), wrongImageId, TEST_JOURNAL);
     }
 
     function testVerifyFailsWithInvalidProofFormat() public {
-        bytes32 journal = keccak256("test-journal");
-
-        // Proof too short (less than 85 bytes)
         bytes memory shortProof = new bytes(50);
 
         vm.expectRevert(TEEVerifier.InvalidProofFormat.selector);
-        verifier.verify(shortProof, IMAGE_ID, journal);
+        verifier.verify(shortProof, IMAGE_ID, TEST_JOURNAL);
     }
 
     function testConstants() public view {
         assertEq(address(verifier.TEE_PROVER_REGISTRY()), address(teeProverRegistry));
+    }
+
+    function _proofFor(address proposer, uint256 privateKey, bytes32 journal) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, journal);
+        return abi.encodePacked(proposer, r, s, v);
     }
 }

--- a/test/L1/proofs/TEEVerifier.t.sol
+++ b/test/L1/proofs/TEEVerifier.t.sol
@@ -3,9 +3,7 @@ pragma solidity 0.8.15;
 
 import { Test } from "lib/forge-std/src/Test.sol";
 
-import {
-    TransparentUpgradeableProxy
-} from "lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { Proxy } from "src/universal/Proxy.sol";
 
 import { INitroEnclaveVerifier } from "interfaces/L1/proofs/tee/INitroEnclaveVerifier.sol";
 import { IAnchorStateRegistry } from "interfaces/L1/proofs/IAnchorStateRegistry.sol";
@@ -57,9 +55,11 @@ contract TEEVerifierTest is Test {
         DevTEEProverRegistry impl =
             new DevTEEProverRegistry(INitroEnclaveVerifier(address(0)), IDisputeGameFactory(address(mockFactory)));
 
-        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+        address proxyAdmin = makeAddr("proxy-admin");
+        Proxy proxy = new Proxy(proxyAdmin);
+        vm.prank(proxyAdmin);
+        proxy.upgradeToAndCall(
             address(impl),
-            makeAddr("proxy-admin"),
             abi.encodeCall(
                 TEEProverRegistry.initialize, (address(this), address(this), new address[](0), TEST_GAME_TYPE)
             )


### PR DESCRIPTION
Simplifies and consolidates the L1 proof test suite.

## Changes

- Reduces test file sizes significantly (~1000 lines removed)
- Standardizes visibility modifiers (`public` → `internal`) for test fixtures
- Removes unused imports and dead code
- Bumps pragma to `^0.8.15` for consistency
- Tightens up test setup and helpers across all proof test files