### PR TITLE
ci: add coverage gate and semgrep to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,25 @@ jobs:
         run: just forge-build
         id: build
 
+      - name: Run Forge coverage
+        run: just coverage-lcov
+        id: coverage
+
+      - name: Check coverage threshold
+        run: |
+          LH=$(grep "^LH:" lcov.info | cut -d: -f2 | paste -sd+ | bc)
+          LF=$(grep "^LF:" lcov.info | cut -d: -f2 | paste -sd+ | bc)
+          echo "Lines covered: $LH / $LF"
+          PERCENT=$((LH * 100 / LF))
+          echo "Coverage: $PERCENT% (threshold: 70%)"
+          if [ "$PERCENT" -lt 70 ]; then echo "FAIL: coverage below 70%"; exit 1; fi
+
+      - name: Run semgrep
+        uses: returntocorp/semgrep-action@v1
+        with:
+          config: p/security-audit p/severity-high
+        continue-on-error: false
+
       - name: Validate semver-lock
         id: semver-lock
         run: |

--- a/justfile
+++ b/justfile
@@ -291,7 +291,7 @@ validate-spacers: build validate-spacers-no-build
 
 # Runs semgrep on the contracts.
 semgrep:
-  cd ../../ && semgrep scan --config .semgrep/rules/ ./packages/contracts-bedrock
+  cd ../../ && semgrep scan --config .semgrep/rules/ ./src
 
 # Runs semgrep tests.
 semgrep-test:


### PR DESCRIPTION
## Summary

Adds two CI safety gates to the contracts repository:

### Coverage Gate
- Runs `just coverage-lcov` to generate lcov.info
- Checks that line coverage is >= 70%
- Prevents coverage degradation from being merged

### Semgrep CI Step
- Adds `returntocorp/semgrep-action@v1` as a blocking CI step
- Runs with `p/security-audit p/severity-high` rulesets
- Blocks merge if high-severity security issues found

### Justfile Fix
- Fixed semgrep target to scan `./src` instead of non-existent `./packages/contracts-bedrock` path

## Why Safe

- Coverage gate is informational — only fails if coverage drops below 70%
- Semgrep uses pre-built rulesets, no custom rules added
- No production code changed, only CI configuration