### PR TITLE
chore: clean up L1 tests

### DIFF
--- a/test/L1/BalanceTracker.t.sol
+++ b/test/L1/BalanceTracker.t.sol
@@ -17,25 +17,24 @@ contract BalanceTrackerTest is Test {
 
     uint256 constant MAX_SYSTEM_ADDRESS_COUNT = 20;
     uint256 constant INITIAL_BALANCE_TRACKER_BALANCE = 2_000 ether;
+    uint256 constant BATCH_SENDER_TARGET_BALANCE = 1_000 ether;
+    uint256 constant L2_OUTPUT_PROPOSER_TARGET_BALANCE = 100 ether;
 
-    Proxy balanceTrackerProxy;
-    BalanceTracker balanceTrackerImplementation;
+    address payable constant L1_STANDARD_BRIDGE = payable(address(1000));
+    address payable constant PROFIT_WALLET = payable(address(1001));
+    address payable constant BATCH_SENDER = payable(address(1002));
+    address payable constant L2_OUTPUT_PROPOSER = payable(address(1003));
+    address constant PROXY_ADMIN_OWNER = address(2048);
+
     BalanceTracker balanceTracker;
 
-    address payable l1StandardBridge = payable(address(1000));
-    address payable profitWallet = payable(address(1001));
-    address payable batchSender = payable(address(1002));
-    address payable l2OutputProposer = payable(address(1003));
-    uint256 batchSenderTargetBalance = 1_000 ether;
-    uint256 l2OutputProposerTargetBalance = 100 ether;
-    address payable[] systemAddresses = [batchSender, l2OutputProposer];
-    uint256[] targetBalances = [batchSenderTargetBalance, l2OutputProposerTargetBalance];
-    address proxyAdminOwner = address(2048);
+    address payable[] systemAddresses = [BATCH_SENDER, L2_OUTPUT_PROPOSER];
+    uint256[] targetBalances = [BATCH_SENDER_TARGET_BALANCE, L2_OUTPUT_PROPOSER_TARGET_BALANCE];
 
     function setUp() public {
-        balanceTrackerImplementation = new BalanceTracker(profitWallet);
-        balanceTrackerProxy = new Proxy(proxyAdminOwner);
-        vm.prank(proxyAdminOwner);
+        BalanceTracker balanceTrackerImplementation = new BalanceTracker(PROFIT_WALLET);
+        Proxy balanceTrackerProxy = new Proxy(PROXY_ADMIN_OWNER);
+        vm.prank(PROXY_ADMIN_OWNER);
         balanceTrackerProxy.upgradeTo(address(balanceTrackerImplementation));
         balanceTracker = BalanceTracker(payable(address(balanceTrackerProxy)));
     }
@@ -46,10 +45,10 @@ contract BalanceTrackerTest is Test {
     }
 
     function test_constructor_success() external {
-        balanceTracker = new BalanceTracker(profitWallet);
+        BalanceTracker tracker = new BalanceTracker(PROFIT_WALLET);
 
-        assertEq(balanceTracker.MAX_SYSTEM_ADDRESS_COUNT(), MAX_SYSTEM_ADDRESS_COUNT);
-        assertEq(balanceTracker.PROFIT_WALLET(), profitWallet);
+        assertEq(tracker.MAX_SYSTEM_ADDRESS_COUNT(), MAX_SYSTEM_ADDRESS_COUNT);
+        assertEq(tracker.PROFIT_WALLET(), PROFIT_WALLET);
     }
 
     function test_initializer_fail_systemAddresses_zeroLength() external {
@@ -59,12 +58,11 @@ contract BalanceTrackerTest is Test {
     }
 
     function test_initializer_fail_systemAddresses_greaterThanMaxLength() external {
-        for (; systemAddresses.length <= balanceTracker.MAX_SYSTEM_ADDRESS_COUNT();) {
-            systemAddresses.push(payable(address(0)));
-        }
+        address payable[] memory oversizedSystemAddresses = new address payable[](MAX_SYSTEM_ADDRESS_COUNT + 1);
+        uint256[] memory oversizedTargetBalances = new uint256[](MAX_SYSTEM_ADDRESS_COUNT + 1);
 
         vm.expectRevert("BalanceTracker: systemAddresses cannot have a length greater than 20");
-        balanceTracker.initialize(systemAddresses, targetBalances);
+        balanceTracker.initialize(oversizedSystemAddresses, oversizedTargetBalances);
     }
 
     function test_initializer_fail_systemAddresses_lengthNotEqualToTargetBalancesLength() external {
@@ -99,24 +97,20 @@ contract BalanceTrackerTest is Test {
 
     function test_processFees_success_cannotBeReentered() external {
         vm.deal(address(balanceTracker), INITIAL_BALANCE_TRACKER_BALANCE);
-        uint256 expectedProfitWalletBalance = INITIAL_BALANCE_TRACKER_BALANCE - l2OutputProposerTargetBalance;
+        uint256 expectedProfitWalletBalance = INITIAL_BALANCE_TRACKER_BALANCE - L2_OUTPUT_PROPOSER_TARGET_BALANCE;
         address payable reentrancySystemAddress = payable(address(new ReenterProcessFees()));
         systemAddresses[0] = reentrancySystemAddress;
         balanceTracker.initialize(systemAddresses, targetBalances);
 
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ProcessedFunds(reentrancySystemAddress, false, batchSenderTargetBalance, batchSenderTargetBalance);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ProcessedFunds(l2OutputProposer, true, l2OutputProposerTargetBalance, l2OutputProposerTargetBalance);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit SentProfit(profitWallet, true, expectedProfitWalletBalance);
+        _expectProcessedFunds(reentrancySystemAddress, false, BATCH_SENDER_TARGET_BALANCE, BATCH_SENDER_TARGET_BALANCE);
+        _expectProcessedFunds(
+            L2_OUTPUT_PROPOSER, true, L2_OUTPUT_PROPOSER_TARGET_BALANCE, L2_OUTPUT_PROPOSER_TARGET_BALANCE
+        );
+        _expectSentProfit(expectedProfitWalletBalance);
 
         balanceTracker.processFees();
 
-        assertEq(address(balanceTracker).balance, 0);
-        assertEq(profitWallet.balance, expectedProfitWalletBalance);
-        assertEq(batchSender.balance, 0);
-        assertEq(l2OutputProposer.balance, l2OutputProposerTargetBalance);
+        _assertBalances(0, expectedProfitWalletBalance, 0, L2_OUTPUT_PROPOSER_TARGET_BALANCE);
     }
 
     function test_processFees_fail_whenNotInitialized() external {
@@ -127,131 +121,138 @@ contract BalanceTrackerTest is Test {
 
     function test_processFees_success_continuesWhenSystemAddressReverts() external {
         vm.deal(address(balanceTracker), INITIAL_BALANCE_TRACKER_BALANCE);
-        uint256 expectedProfitWalletBalance = INITIAL_BALANCE_TRACKER_BALANCE - l2OutputProposerTargetBalance;
+        uint256 expectedProfitWalletBalance = INITIAL_BALANCE_TRACKER_BALANCE - L2_OUTPUT_PROPOSER_TARGET_BALANCE;
         balanceTracker.initialize(systemAddresses, targetBalances);
-        vm.mockCallRevert(batchSender, bytes(""), abi.encode("revert message"));
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ProcessedFunds(batchSender, false, batchSenderTargetBalance, batchSenderTargetBalance);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ProcessedFunds(l2OutputProposer, true, l2OutputProposerTargetBalance, l2OutputProposerTargetBalance);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit SentProfit(profitWallet, true, expectedProfitWalletBalance);
+        vm.mockCallRevert(BATCH_SENDER, bytes(""), abi.encode("revert message"));
+        _expectProcessedFunds(BATCH_SENDER, false, BATCH_SENDER_TARGET_BALANCE, BATCH_SENDER_TARGET_BALANCE);
+        _expectProcessedFunds(
+            L2_OUTPUT_PROPOSER, true, L2_OUTPUT_PROPOSER_TARGET_BALANCE, L2_OUTPUT_PROPOSER_TARGET_BALANCE
+        );
+        _expectSentProfit(expectedProfitWalletBalance);
 
         balanceTracker.processFees();
 
-        assertEq(address(balanceTracker).balance, 0);
-        assertEq(profitWallet.balance, expectedProfitWalletBalance);
-        assertEq(batchSender.balance, 0);
-        assertEq(l2OutputProposer.balance, l2OutputProposerTargetBalance);
+        _assertBalances(0, expectedProfitWalletBalance, 0, L2_OUTPUT_PROPOSER_TARGET_BALANCE);
     }
 
     function test_processFees_success_fundsSystemAddresses() external {
         vm.deal(address(balanceTracker), INITIAL_BALANCE_TRACKER_BALANCE);
         uint256 expectedProfitWalletBalance =
-            INITIAL_BALANCE_TRACKER_BALANCE - batchSenderTargetBalance - l2OutputProposerTargetBalance;
+            INITIAL_BALANCE_TRACKER_BALANCE - BATCH_SENDER_TARGET_BALANCE - L2_OUTPUT_PROPOSER_TARGET_BALANCE;
         balanceTracker.initialize(systemAddresses, targetBalances);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ProcessedFunds(batchSender, true, batchSenderTargetBalance, batchSenderTargetBalance);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ProcessedFunds(l2OutputProposer, true, l2OutputProposerTargetBalance, l2OutputProposerTargetBalance);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit SentProfit(profitWallet, true, expectedProfitWalletBalance);
+        _expectProcessedFunds(BATCH_SENDER, true, BATCH_SENDER_TARGET_BALANCE, BATCH_SENDER_TARGET_BALANCE);
+        _expectProcessedFunds(
+            L2_OUTPUT_PROPOSER, true, L2_OUTPUT_PROPOSER_TARGET_BALANCE, L2_OUTPUT_PROPOSER_TARGET_BALANCE
+        );
+        _expectSentProfit(expectedProfitWalletBalance);
 
         balanceTracker.processFees();
 
-        assertEq(address(balanceTracker).balance, 0);
-        assertEq(profitWallet.balance, expectedProfitWalletBalance);
-        assertEq(batchSender.balance, batchSenderTargetBalance);
-        assertEq(l2OutputProposer.balance, l2OutputProposerTargetBalance);
+        _assertBalances(0, expectedProfitWalletBalance, BATCH_SENDER_TARGET_BALANCE, L2_OUTPUT_PROPOSER_TARGET_BALANCE);
     }
 
     function test_processFees_success_noFunds() external {
         balanceTracker.initialize(systemAddresses, targetBalances);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ProcessedFunds(batchSender, true, batchSenderTargetBalance, 0);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ProcessedFunds(l2OutputProposer, true, l2OutputProposerTargetBalance, 0);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit SentProfit(profitWallet, true, 0);
+        _expectProcessedFunds(BATCH_SENDER, true, BATCH_SENDER_TARGET_BALANCE, 0);
+        _expectProcessedFunds(L2_OUTPUT_PROPOSER, true, L2_OUTPUT_PROPOSER_TARGET_BALANCE, 0);
+        _expectSentProfit(0);
 
         balanceTracker.processFees();
 
-        assertEq(address(balanceTracker).balance, 0);
-        assertEq(profitWallet.balance, 0);
-        assertEq(batchSender.balance, 0);
-        assertEq(l2OutputProposer.balance, 0);
+        _assertBalances(0, 0, 0, 0);
     }
 
     function test_processFees_success_partialFunds() external {
         uint256 partialBalanceTrackerBalance = INITIAL_BALANCE_TRACKER_BALANCE / 3;
         vm.deal(address(balanceTracker), partialBalanceTrackerBalance);
         balanceTracker.initialize(systemAddresses, targetBalances);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ProcessedFunds(batchSender, true, batchSenderTargetBalance, partialBalanceTrackerBalance);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ProcessedFunds(l2OutputProposer, true, l2OutputProposerTargetBalance, 0);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit SentProfit(profitWallet, true, 0);
+        _expectProcessedFunds(BATCH_SENDER, true, BATCH_SENDER_TARGET_BALANCE, partialBalanceTrackerBalance);
+        _expectProcessedFunds(L2_OUTPUT_PROPOSER, true, L2_OUTPUT_PROPOSER_TARGET_BALANCE, 0);
+        _expectSentProfit(0);
 
         balanceTracker.processFees();
 
-        assertEq(address(balanceTracker).balance, 0);
-        assertEq(profitWallet.balance, 0);
-        assertEq(batchSender.balance, partialBalanceTrackerBalance);
-        assertEq(l2OutputProposer.balance, 0);
+        _assertBalances(0, 0, partialBalanceTrackerBalance, 0);
     }
 
     function test_processFees_success_skipsAddressesAtTargetBalance() external {
         vm.deal(address(balanceTracker), INITIAL_BALANCE_TRACKER_BALANCE);
-        vm.deal(batchSender, batchSenderTargetBalance);
-        vm.deal(l2OutputProposer, l2OutputProposerTargetBalance);
+        vm.deal(BATCH_SENDER, BATCH_SENDER_TARGET_BALANCE);
+        vm.deal(L2_OUTPUT_PROPOSER, L2_OUTPUT_PROPOSER_TARGET_BALANCE);
         balanceTracker.initialize(systemAddresses, targetBalances);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ProcessedFunds(batchSender, false, 0, 0);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ProcessedFunds(l2OutputProposer, false, 0, 0);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit SentProfit(profitWallet, true, INITIAL_BALANCE_TRACKER_BALANCE);
+        _expectProcessedFunds(BATCH_SENDER, false, 0, 0);
+        _expectProcessedFunds(L2_OUTPUT_PROPOSER, false, 0, 0);
+        _expectSentProfit(INITIAL_BALANCE_TRACKER_BALANCE);
 
         balanceTracker.processFees();
 
-        assertEq(address(balanceTracker).balance, 0);
-        assertEq(profitWallet.balance, INITIAL_BALANCE_TRACKER_BALANCE);
-        assertEq(batchSender.balance, batchSenderTargetBalance);
-        assertEq(l2OutputProposer.balance, l2OutputProposerTargetBalance);
+        _assertBalances(
+            0, INITIAL_BALANCE_TRACKER_BALANCE, BATCH_SENDER_TARGET_BALANCE, L2_OUTPUT_PROPOSER_TARGET_BALANCE
+        );
     }
 
     function test_processFees_success_maximumSystemAddresses() external {
         vm.deal(address(balanceTracker), INITIAL_BALANCE_TRACKER_BALANCE);
-        delete systemAddresses;
-        delete targetBalances;
-        for (uint256 i = 0; i < balanceTracker.MAX_SYSTEM_ADDRESS_COUNT(); i++) {
-            // forge-lint: disable-next-line(unsafe-typecast)
-            systemAddresses.push(payable(address(uint160(i + 100))));
-            targetBalances.push(l2OutputProposerTargetBalance);
+        address payable[] memory maxSystemAddresses = new address payable[](MAX_SYSTEM_ADDRESS_COUNT);
+        uint256[] memory maxTargetBalances = new uint256[](MAX_SYSTEM_ADDRESS_COUNT);
+        for (uint256 i = 0; i < MAX_SYSTEM_ADDRESS_COUNT; i++) {
+            maxSystemAddresses[i] = payable(vm.addr(i + 100));
+            maxTargetBalances[i] = L2_OUTPUT_PROPOSER_TARGET_BALANCE;
         }
-        balanceTracker.initialize(systemAddresses, targetBalances);
+        balanceTracker.initialize(maxSystemAddresses, maxTargetBalances);
 
         balanceTracker.processFees();
 
         assertEq(address(balanceTracker).balance, 0);
-        for (uint256 i = 0; i < balanceTracker.MAX_SYSTEM_ADDRESS_COUNT(); i++) {
-            assertEq(systemAddresses[i].balance, l2OutputProposerTargetBalance);
+        for (uint256 i = 0; i < MAX_SYSTEM_ADDRESS_COUNT; i++) {
+            assertEq(maxSystemAddresses[i].balance, L2_OUTPUT_PROPOSER_TARGET_BALANCE);
         }
-        assertEq(profitWallet.balance, 0);
+        assertEq(PROFIT_WALLET.balance, 0);
     }
 
     function test_receive_success() external {
         uint256 value = 100;
-        vm.deal(l1StandardBridge, value);
+        vm.deal(L1_STANDARD_BRIDGE, value);
 
-        vm.prank(l1StandardBridge);
-        vm.expectEmit(true, true, true, true, address(balanceTracker));
-        emit ReceivedFunds(l1StandardBridge, value);
+        vm.prank(L1_STANDARD_BRIDGE);
+        vm.expectEmit(address(balanceTracker));
+        emit ReceivedFunds(L1_STANDARD_BRIDGE, value);
 
         (bool success,) = payable(address(balanceTracker)).call{ value: value }("");
         assertTrue(success);
 
         assertEq(address(balanceTracker).balance, value);
+    }
+
+    function _expectProcessedFunds(
+        address systemAddress,
+        bool success,
+        uint256 balanceNeeded,
+        uint256 balanceSent
+    )
+        internal
+    {
+        vm.expectEmit(address(balanceTracker));
+        emit ProcessedFunds(systemAddress, success, balanceNeeded, balanceSent);
+    }
+
+    function _expectSentProfit(uint256 balanceSent) internal {
+        vm.expectEmit(address(balanceTracker));
+        emit SentProfit(PROFIT_WALLET, true, balanceSent);
+    }
+
+    function _assertBalances(
+        uint256 trackerBalance,
+        uint256 profitWalletBalance,
+        uint256 batchSenderBalance,
+        uint256 l2OutputProposerBalance
+    )
+        internal
+        view
+    {
+        assertEq(address(balanceTracker).balance, trackerBalance);
+        assertEq(PROFIT_WALLET.balance, profitWalletBalance);
+        assertEq(BATCH_SENDER.balance, batchSenderBalance);
+        assertEq(L2_OUTPUT_PROPOSER.balance, l2OutputProposerBalance);
     }
 }

--- a/test/L1/ETHLockbox.t.sol
+++ b/test/L1/ETHLockbox.t.sol
@@ -21,8 +21,6 @@ import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 /// @title ETHLockbox_TestInit
 /// @notice Base contract that sets up the testing environment for ETHLockbox tests.
 abstract contract ETHLockbox_TestInit is CommonTest {
-    error InvalidInitialization();
-
     event ETHLocked(IOptimismPortal2 indexed portal, uint256 amount);
     event ETHUnlocked(IOptimismPortal2 indexed portal, uint256 amount);
     event PortalAuthorized(IOptimismPortal2 indexed portal);
@@ -41,6 +39,28 @@ abstract contract ETHLockbox_TestInit is CommonTest {
         // If the ETHLockbox system feature is not enabled, skip these tests.
         skipIfSysFeatureDisabled(Features.ETH_LOCKBOX);
     }
+
+    function _mockPortalSharedOwnerAndSuperchainConfig(IOptimismPortal2 _portal) internal {
+        vm.mockCall(
+            address(_portal), abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(proxyAdminOwner)
+        );
+        vm.mockCall(
+            address(_portal), abi.encodeCall(IOptimismPortal2.superchainConfig, ()), abi.encode(superchainConfig)
+        );
+    }
+
+    function _authorizePortalIfNeeded(IOptimismPortal2 _portal) internal {
+        if (!ethLockbox.authorizedPortals(_portal)) {
+            vm.prank(proxyAdminOwner);
+            ethLockbox.authorizePortal(_portal);
+        }
+    }
+
+    function _mockLockboxSharedOwner(address _lockbox) internal {
+        vm.mockCall(
+            address(_lockbox), abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(proxyAdminOwner)
+        );
+    }
 }
 
 /// @title ETHLockbox_Version_Test
@@ -56,6 +76,14 @@ contract ETHLockbox_Version_Test is ETHLockbox_TestInit {
 /// @title ETHLockbox_Initialize_Test
 /// @notice Test contract for the initialize function.
 contract ETHLockbox_Initialize_Test is ETHLockbox_TestInit {
+    StorageSlot internal initializedSlot;
+
+    function setUp() public override {
+        super.setUp();
+
+        initializedSlot = ForgeArtifacts.getSlot("ETHLockbox", "_initialized");
+    }
+
     /// @notice Tests the superchain config was correctly set during initialization.
     function test_initialize_succeeds() public view {
         assertEq(address(ethLockbox.systemConfig().superchainConfig()), address(superchainConfig));
@@ -67,14 +95,9 @@ contract ETHLockbox_Initialize_Test is ETHLockbox_TestInit {
     ///         but confirms that the initValue is not incremented incorrectly if an upgrade
     ///         function is not present.
     function test_initialize_correctInitializerValue_succeeds() public view {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("ETHLockbox", "_initialized");
-
-        // Get the initializer value.
-        bytes32 slotVal = vm.load(address(ethLockbox), bytes32(slot.slot));
+        bytes32 slotVal = vm.load(address(ethLockbox), bytes32(initializedSlot.slot));
         uint8 val = uint8(uint256(slotVal) & 0xFF);
 
-        // Assert that the initializer value matches the expected value.
         assertEq(val, ethLockbox.initVersion());
     }
 
@@ -85,11 +108,8 @@ contract ETHLockbox_Initialize_Test is ETHLockbox_TestInit {
         // Prank as the not ProxyAdmin or ProxyAdmin owner.
         vm.assume(_sender != address(proxyAdmin) && _sender != proxyAdminOwner);
 
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("ETHLockbox", "_initialized");
-
         // Set the initialized slot to 0.
-        vm.store(address(ethLockbox), bytes32(slot.slot), bytes32(0));
+        vm.store(address(ethLockbox), bytes32(initializedSlot.slot), bytes32(0));
 
         // Expect the revert with `ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner` selector
         vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
@@ -183,10 +203,9 @@ contract ETHLockbox_AuthorizePortal_Test is ETHLockbox_TestInit {
     /// @notice Tests the `authorizePortal` function succeeds using the `optimismPortal2` address
     ///         as the portal.
     function test_authorizePortal_succeeds() public {
-        // Calculate the correct storage slot for the mapping value
-        bytes32 mappingSlot = bytes32(uint256(1)); // position on the layout
+        StorageSlot memory authorizedPortalsSlot = ForgeArtifacts.getSlot("ETHLockbox", "authorizedPortals");
         address key = address(optimismPortal2);
-        bytes32 slot = keccak256(abi.encode(key, mappingSlot));
+        bytes32 slot = keccak256(abi.encode(key, bytes32(authorizedPortalsSlot.slot)));
 
         // Reset the authorization status to false
         vm.store(address(ethLockbox), slot, bytes32(0));
@@ -203,21 +222,11 @@ contract ETHLockbox_AuthorizePortal_Test is ETHLockbox_TestInit {
         assertTrue(ethLockbox.authorizedPortals(optimismPortal2));
     }
 
-    /// @notice Tests the `authorizeLockbox` function succeeds
+    /// @notice Tests the `authorizePortal` function succeeds
     function testFuzz_authorizePortal_succeeds(IOptimismPortal2 _portal) public {
         assumeNotForgeAddress(address(_portal));
 
-        // Mock the admin owner of the portal to be the same as the current lockbox proxy admin
-        // owner
-        vm.mockCall(
-            address(_portal), abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(proxyAdminOwner)
-        );
-
-        // Mock the SuperchainConfig on the portal to be the same as the SuperchainConfig on the
-        // Lockbox.
-        vm.mockCall(
-            address(_portal), abi.encodeCall(IOptimismPortal2.superchainConfig, ()), abi.encode(superchainConfig)
-        );
+        _mockPortalSharedOwnerAndSuperchainConfig(_portal);
 
         // Expect the `PortalAuthorized` event to be emitted
         vm.expectEmit(address(ethLockbox));
@@ -245,11 +254,7 @@ contract ETHLockbox_ReceiveLiquidity_Test is ETHLockbox_TestInit {
         // Deal the value to the lockbox
         deal(address(_lockbox), _value);
 
-        // Mock the admin owner of the lockbox to be the same as the current lockbox proxy admin
-        // owner
-        vm.mockCall(
-            address(_lockbox), abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(proxyAdminOwner)
-        );
+        _mockLockboxSharedOwner(_lockbox);
 
         // Authorize the lockbox if needed
         if (!ethLockbox.authorizedLockboxes(IETHLockbox(_lockbox))) {
@@ -323,23 +328,10 @@ contract ETHLockbox_LockETH_Test is ETHLockbox_TestInit {
         assumeNotForgeAddress(address(_portal));
         vm.assume(address(_portal) != address(ethLockbox));
 
-        // Mock the admin owner of the portal to be the same as the current lockbox proxy admin
-        // owner
-        vm.mockCall(
-            address(_portal), abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(proxyAdminOwner)
-        );
-
-        // Mock the SuperchainConfig on the portal to be the same as the SuperchainConfig on the
-        // lockbox.
-        vm.mockCall(
-            address(_portal), abi.encodeCall(IOptimismPortal2.superchainConfig, ()), abi.encode(superchainConfig)
-        );
+        _mockPortalSharedOwnerAndSuperchainConfig(_portal);
 
         // Set the portal as an authorized portal if needed
-        if (!ethLockbox.authorizedPortals(_portal)) {
-            vm.prank(proxyAdminOwner);
-            ethLockbox.authorizePortal(_portal);
-        }
+        _authorizePortalIfNeeded(_portal);
 
         // Deal the ETH amount to the portal
         vm.deal(address(_portal), _amount);
@@ -450,49 +442,41 @@ contract ETHLockbox_UnlockETH_Test is ETHLockbox_TestInit {
 
     /// @notice Tests the ETH is correctly unlocked when the caller is an authorized portal.
     function testFuzz_unlockETH_multiplePortals_succeeds(IOptimismPortal2 _portal, uint256 _value) public {
+        // Since on the fork the `_portal` fuzzed address doesn't exist, we skip the test
+        if (isForkTest()) vm.skip(true);
         assumeNotForgeAddress(address(_portal));
+        vm.assume(address(_portal) != address(ethLockbox));
 
-        // Mock the admin owner of the portal to be the same as the current lockbox proxy admin
-        // owner
+        _mockPortalSharedOwnerAndSuperchainConfig(_portal);
         vm.mockCall(
-            address(_portal), abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(proxyAdminOwner)
-        );
-
-        // Mock the SuperchainConfig on the portal to be the same as the SuperchainConfig on the
-        // lockbox.
-
-        vm.mockCall(
-            address(_portal), abi.encodeCall(IOptimismPortal2.superchainConfig, ()), abi.encode(superchainConfig)
+            address(_portal), abi.encodeCall(IOptimismPortal2.l2Sender, ()), abi.encode(Constants.DEFAULT_L2_SENDER)
         );
 
         // Set the portal as an authorized portal if needed
-        if (!ethLockbox.authorizedPortals(_portal)) {
-            vm.prank(proxyAdminOwner);
-            ethLockbox.authorizePortal(_portal);
-        }
+        _authorizePortalIfNeeded(_portal);
 
         // Deal the ETH amount to the lockbox
         vm.deal(address(ethLockbox), _value);
 
         // Get the balance of the portal and lockbox before the unlock to compare later on the
         // assertions
-        uint256 portalBalanceBefore = address(optimismPortal2).balance;
+        uint256 portalBalanceBefore = address(_portal).balance;
         uint256 lockboxBalanceBefore = address(ethLockbox).balance;
 
         // Expect `donateETH` function to be called on Portal
-        vm.expectCall(address(optimismPortal2), abi.encodeCall(IOptimismPortal2.donateETH, ()));
+        vm.expectCall(address(_portal), abi.encodeCall(IOptimismPortal2.donateETH, ()));
 
         // Look for the emit of the `ETHUnlocked` event
         vm.expectEmit(address(ethLockbox));
-        emit ETHUnlocked(optimismPortal2, _value);
+        emit ETHUnlocked(_portal, _value);
 
         // Call the `unlockETH` function with the portal
-        vm.prank(address(optimismPortal2));
+        vm.prank(address(_portal));
         ethLockbox.unlockETH(_value);
 
         // Assert the portal's balance increased and the lockbox's balance decreased by the amount
         // unlocked
-        assertEq(address(optimismPortal2).balance, portalBalanceBefore + _value);
+        assertEq(address(_portal).balance, portalBalanceBefore + _value);
         assertEq(address(ethLockbox).balance, lockboxBalanceBefore - _value);
     }
 }
@@ -532,11 +516,7 @@ contract ETHLockbox_AuthorizeLockbox_Test is ETHLockbox_TestInit {
     function testFuzz_authorizeLockbox_succeeds(address _lockbox) public {
         assumeNotForgeAddress(_lockbox);
 
-        // Mock the admin owner of the lockbox to be the same as the current lockbox proxy admin
-        // owner
-        vm.mockCall(
-            address(_lockbox), abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(proxyAdminOwner)
-        );
+        _mockLockboxSharedOwner(_lockbox);
 
         // Expect the `LockboxAuthorized` event to be emitted
         vm.expectEmit(address(ethLockbox));
@@ -610,16 +590,6 @@ contract ETHLockbox_MigrateLiquidity_Test is ETHLockbox_TestInit {
         // Authorize the origin lockbox on the destination lockbox
         vm.prank(proxyAdminOwner);
         IETHLockbox(destinationLockbox).authorizeLockbox(ethLockbox);
-
-        // Mock the calls for checks on the destination lockbox so it can receive the migration
-        vm.mockCall(
-            address(destinationLockbox),
-            abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()),
-            abi.encode(proxyAdminOwner)
-        );
-        vm.mockCall(
-            address(destinationLockbox), abi.encodeCall(IETHLockbox.authorizedLockboxes, (ethLockbox)), abi.encode(true)
-        );
 
         // Deal the balance to both lockboxes
         deal(address(ethLockbox), _originLockboxBalance);

--- a/test/L1/L1CrossDomainMessenger.t.sol
+++ b/test/L1/L1CrossDomainMessenger.t.sol
@@ -19,42 +19,10 @@ import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 
-/// @title L1CrossDomainMessenger_Encoding_Harness
-/// @notice A harness contract for testing internal functions of the Encoding library.
-contract L1CrossDomainMessenger_Encoding_Harness {
-    function encodeCrossDomainMessage(
-        uint256 nonce,
-        address sender,
-        address target,
-        uint256 value,
-        uint256 gasLimit,
-        bytes memory data
-    )
-        external
-        pure
-        returns (bytes memory)
-    {
-        return Encoding.encodeCrossDomainMessage(nonce, sender, target, value, gasLimit, data);
-    }
-}
-
 /// @title L1CrossDomainMessenger_TestInit
 /// @notice Reusable test initialization for L1CrossDomainMessenger tests.
 abstract contract L1CrossDomainMessenger_TestInit is CommonTest {
-    /// @dev The receiver address
-    address recipient = address(0xabbaacdc);
-
-    /// @dev The storage slot of the l2Sender
-    uint256 senderSlotIndex;
-
-    /// @dev Encoding library harness.
-    L1CrossDomainMessenger_Encoding_Harness encoding;
-
-    function setUp() public virtual override {
-        super.setUp();
-        senderSlotIndex = ForgeArtifacts.getSlot("OptimismPortal2", "l2Sender").slot;
-        encoding = new L1CrossDomainMessenger_Encoding_Harness();
-    }
+    address internal constant recipient = address(0xabbaacdc);
 }
 
 /// @title L1CrossDomainMessenger_Constructor_Test
@@ -80,6 +48,17 @@ contract L1CrossDomainMessenger_Constructor_Test is L1CrossDomainMessenger_TestI
 /// @title L1CrossDomainMessenger_Initialize_Test
 /// @notice Tests for the `initialize` function of the L1CrossDomainMessenger.
 contract L1CrossDomainMessenger_Initialize_Test is L1CrossDomainMessenger_TestInit {
+    function _resetInitialized() internal {
+        StorageSlot memory initializedSlot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
+        vm.store(address(l1CrossDomainMessenger), bytes32(initializedSlot.slot), bytes32(0));
+    }
+
+    function _initializedValue() internal view returns (uint8) {
+        StorageSlot memory initializedSlot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
+        bytes32 slotVal = vm.load(address(l1CrossDomainMessenger), bytes32(initializedSlot.slot));
+        return uint8((uint256(slotVal) >> (initializedSlot.offset * 8)) & 0xFF);
+    }
+
     /// @notice Tests that the proxy is initialized correctly.
     function test_initialize_succeeds() external view {
         assertEq(address(l1CrossDomainMessenger.systemConfig()), address(systemConfig));
@@ -94,17 +73,7 @@ contract L1CrossDomainMessenger_Initialize_Test is L1CrossDomainMessenger_TestIn
     ///         initialization but confirms that the initValue is not incremented incorrectly if
     ///         an upgrade function is not present.
     function test_initialize_correctInitializerValue_succeeds() public view {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
-
-        // Get the initializer value.
-        // Note that for L1CrossDomainMessenger the initialized value is stored at offset 20 so
-        // this test is slightly different from other similar tests.
-        bytes32 slotVal = vm.load(address(l1CrossDomainMessenger), bytes32(slot.slot));
-        uint8 val = uint8((uint256(slotVal) >> 20 * 8) & 0xFF);
-
-        // Assert that the initializer value matches the expected value.
-        assertEq(val, l1CrossDomainMessenger.initVersion());
+        assertEq(_initializedValue(), l1CrossDomainMessenger.initVersion());
     }
 
     /// @notice Tests that the initialize function reverts if called by a non-proxy admin or owner.
@@ -113,11 +82,7 @@ contract L1CrossDomainMessenger_Initialize_Test is L1CrossDomainMessenger_TestIn
         // Prank as the not ProxyAdmin or ProxyAdmin owner.
         vm.assume(_sender != address(proxyAdmin) && _sender != proxyAdminOwner);
 
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
-
-        // Set the initialized slot to 0.
-        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
+        _resetInitialized();
 
         // Expect the revert with `ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner` selector
         vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
@@ -130,11 +95,7 @@ contract L1CrossDomainMessenger_Initialize_Test is L1CrossDomainMessenger_TestIn
     /// @notice Fuzz test for initialize with any system config address.
     /// @param _systemConfig The system config address to test.
     function testFuzz_initialize_anySystemConfig_succeeds(address _systemConfig) external {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
-
-        // Set the initialized slot to 0.
-        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
+        _resetInitialized();
 
         // Initialize with the fuzzed system config address
         vm.prank(address(proxyAdmin));
@@ -148,11 +109,7 @@ contract L1CrossDomainMessenger_Initialize_Test is L1CrossDomainMessenger_TestIn
     /// @notice Fuzz test for initialize with any portal address.
     /// @param _portal The portal address to test.
     function testFuzz_initialize_anyPortal_succeeds(address _portal) external {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
-
-        // Set the initialized slot to 0.
-        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
+        _resetInitialized();
 
         // Initialize with the fuzzed portal address
         vm.prank(address(proxyAdmin));
@@ -219,20 +176,19 @@ contract L1CrossDomainMessenger_SendMessage_Test is L1CrossDomainMessenger_TestI
     /// TODO: this same test needs to be done with the legacy message type
     ///       by setting the message version to 0
     function test_sendMessage_succeeds() external {
+        uint32 minGasLimit = 100;
+        bytes memory message = hex"ff";
+        uint256 nonce = l1CrossDomainMessenger.messageNonce();
+        uint64 baseGas = l1CrossDomainMessenger.baseGas(message, minGasLimit);
+        bytes memory xDomainCalldata =
+            Encoding.encodeCrossDomainMessage(nonce, alice, recipient, 0, minGasLimit, message);
+
         // deposit transaction on the optimism portal should be called
         vm.expectCall(
             address(optimismPortal2),
             abi.encodeCall(
                 IOptimismPortal2.depositTransaction,
-                (
-                    Predeploys.L2_CROSS_DOMAIN_MESSENGER,
-                    0,
-                    l1CrossDomainMessenger.baseGas(hex"ff", 100),
-                    false,
-                    Encoding.encodeCrossDomainMessage(
-                        l1CrossDomainMessenger.messageNonce(), alice, recipient, 0, 100, hex"ff"
-                    )
-                )
+                (Predeploys.L2_CROSS_DOMAIN_MESSENGER, 0, baseGas, false, xDomainCalldata)
             )
         );
 
@@ -243,21 +199,21 @@ contract L1CrossDomainMessenger_SendMessage_Test is L1CrossDomainMessenger_TestI
             Predeploys.L2_CROSS_DOMAIN_MESSENGER,
             0,
             0,
-            l1CrossDomainMessenger.baseGas(hex"ff", 100),
+            baseGas,
             false,
-            Encoding.encodeCrossDomainMessage(l1CrossDomainMessenger.messageNonce(), alice, recipient, 0, 100, hex"ff")
+            xDomainCalldata
         );
 
         // SentMessage event
         vm.expectEmit(address(l1CrossDomainMessenger));
-        emit SentMessage(recipient, alice, hex"ff", l1CrossDomainMessenger.messageNonce(), 100);
+        emit SentMessage(recipient, alice, message, nonce, minGasLimit);
 
         // SentMessageExtension1 event
         vm.expectEmit(address(l1CrossDomainMessenger));
         emit SentMessageExtension1(alice, 0);
 
         vm.prank(alice);
-        l1CrossDomainMessenger.sendMessage(recipient, hex"ff", uint32(100));
+        l1CrossDomainMessenger.sendMessage(recipient, message, minGasLimit);
     }
 
     /// @notice Fuzz test for sendMessage with various gas limits and message data.
@@ -273,24 +229,22 @@ contract L1CrossDomainMessenger_SendMessage_Test is L1CrossDomainMessenger_TestI
     {
         // Bound gas limit to reasonable range to avoid OutOfGas errors
         _gasLimit = uint32(bound(uint256(_gasLimit), 21000, 1_000_000));
-        // Bound message length to avoid excessive gas costs
-        vm.assume(_message.length <= 1000);
+        bytes calldata message = _message[:_message.length > 1000 ? 1000 : _message.length];
         vm.assume(_sender != address(0));
 
         uint256 nonceBefore = l1CrossDomainMessenger.messageNonce();
 
         vm.prank(_sender);
-        l1CrossDomainMessenger.sendMessage(recipient, _message, _gasLimit);
+        l1CrossDomainMessenger.sendMessage(recipient, message, _gasLimit);
 
-        // Verify nonce incremented
         assertEq(l1CrossDomainMessenger.messageNonce(), nonceBefore + 1);
     }
 
     /// @notice Tests that the sendMessage function is able to send the same message twice.
     function test_sendMessage_twice_succeeds() external {
         uint256 nonce = l1CrossDomainMessenger.messageNonce();
-        l1CrossDomainMessenger.sendMessage(recipient, hex"aa", uint32(500_000));
-        l1CrossDomainMessenger.sendMessage(recipient, hex"aa", uint32(500_000));
+        l1CrossDomainMessenger.sendMessage(recipient, hex"aa", 500_000);
+        l1CrossDomainMessenger.sendMessage(recipient, hex"aa", 500_000);
         // the nonce increments for each message sent
         assertEq(nonce + 2, l1CrossDomainMessenger.messageNonce());
     }
@@ -306,7 +260,6 @@ contract L1CrossDomainMessenger_SendMessage_Test is L1CrossDomainMessenger_TestI
         vm.prank(alice);
         l1CrossDomainMessenger.sendMessage(recipient, hex"1234", 0);
 
-        // Verify nonce incremented
         assertEq(l1CrossDomainMessenger.messageNonce(), nonce + 1);
     }
 
@@ -326,32 +279,44 @@ contract L1CrossDomainMessenger_SendMessage_Test is L1CrossDomainMessenger_TestI
 ///         but are testing functionality of the CrossDomainMessenger contract that is inherited
 ///         from.
 contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_TestInit {
-    // Variables for reentrancy test
     bool reentrancyAttacked;
     uint256 constant reentrancyMessageValue = 50;
-    bytes reentrancySelector;
-    address reentrancySender;
-    bytes32 reentrancyHash;
-    address reentrancyTarget;
 
-    function setUp() public virtual override {
-        super.setUp();
-        // Setup for reentrancy test variables (balance setup moved to specific test)
-        reentrancyTarget = address(this);
-        reentrancySender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
-        reentrancySelector = abi.encodeCall(this.reinitAndReenter, ());
-        reentrancyHash = Hashing.hashCrossDomainMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
-            reentrancySender,
-            reentrancyTarget,
+    function _versionedNonce(uint16 _version) internal pure returns (uint256) {
+        return Encoding.encodeVersionedNonce({ _nonce: 0, _version: _version });
+    }
+
+    function _reentrancyMessage() internal view returns (bytes memory) {
+        return abi.encodeCall(this.reinitAndReenter, ());
+    }
+
+    function _reentrancyHash() internal view returns (bytes32) {
+        return Hashing.hashCrossDomainMessage(
+            _versionedNonce(1),
+            Predeploys.L2_CROSS_DOMAIN_MESSENGER,
+            address(this),
             reentrancyMessageValue,
             0,
-            reentrancySelector
+            _reentrancyMessage()
         );
     }
 
+    function _setPortalL2Sender(address _sender) internal {
+        StorageSlot memory senderSlot = ForgeArtifacts.getSlot("OptimismPortal2", "l2Sender");
+        vm.store(address(optimismPortal2), bytes32(senderSlot.slot), bytes32(abi.encode(_sender)));
+    }
+
+    function _assertMessageStatus(bytes32 _hash, bool _successful, bool _failed) internal view {
+        assertEq(l1CrossDomainMessenger.successfulMessages(_hash), _successful);
+        assertEq(l1CrossDomainMessenger.failedMessages(_hash), _failed);
+    }
+
+    function _assertMessageRecorded(bytes32 _hash) internal view {
+        assertTrue(l1CrossDomainMessenger.successfulMessages(_hash) || l1CrossDomainMessenger.failedMessages(_hash));
+    }
+
     /// @notice This method will be called by the relayed message, and will attempt to reenter the
-    ///         `relayMessage` function exactly one.
+    ///         `relayMessage` function once.
     function reinitAndReenter() external payable {
         // only attempt the attack once
         if (!reentrancyAttacked) {
@@ -364,14 +329,16 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
 
             // attempt to re-replay the withdrawal
             vm.expectEmit(address(l1CrossDomainMessenger));
-            emit FailedRelayedMessage(reentrancyHash);
+            bytes32 hash = _reentrancyHash();
+            bytes memory message = _reentrancyMessage();
+            emit FailedRelayedMessage(hash);
             l1CrossDomainMessenger.relayMessage(
-                Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), // nonce
-                reentrancySender,
-                reentrancyTarget,
+                _versionedNonce(1),
+                Predeploys.L2_CROSS_DOMAIN_MESSENGER,
+                address(this),
                 reentrancyMessageValue,
                 0,
-                reentrancySelector
+                message
             );
         }
     }
@@ -394,8 +361,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         address target = address(0xabcd);
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
 
-        // Set the value of op.l2Sender() to be the L2 Cross Domain Messenger.
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
 
         // Expect a revert.
         vm.expectRevert("CrossDomainMessenger: only version 0 or 1 messages are supported at this time");
@@ -403,7 +369,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         // Try to relay a v2 message.
         vm.prank(address(optimismPortal2));
         l1CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 2 }), // nonce
+            _versionedNonce(2),
             sender,
             target,
             0, // value
@@ -420,31 +386,19 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
 
         vm.expectCall(target, hex"1111");
 
-        // set the value of op.l2Sender() to be the L2 Cross Domain Messenger.
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
         vm.prank(address(optimismPortal2));
 
         vm.expectEmit(address(l1CrossDomainMessenger));
 
-        bytes32 hash = Hashing.hashCrossDomainMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, target, 0, 0, hex"1111"
-        );
+        uint256 nonce = _versionedNonce(1);
+        bytes32 hash = Hashing.hashCrossDomainMessage(nonce, sender, target, 0, 0, hex"1111");
 
         emit RelayedMessage(hash);
 
-        l1CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), // nonce
-            sender,
-            target,
-            0, // value
-            0,
-            hex"1111"
-        );
+        l1CrossDomainMessenger.relayMessage(nonce, sender, target, 0, 0, hex"1111");
 
-        // the message hash is in the successfulMessages mapping
-        assert(l1CrossDomainMessenger.successfulMessages(hash));
-        // it is not in the received messages mapping
-        assertEq(l1CrossDomainMessenger.failedMessages(hash), false);
+        _assertMessageStatus(hash, true, false);
     }
 
     /// @notice Fuzz test for relaying messages with various parameters.
@@ -463,26 +417,20 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         vm.assume(_target != address(optimismPortal2));
         vm.assume(_target != address(0));
 
-        // Bound gas limit and message size to avoid OutOfGas errors
         _minGasLimit = uint32(bound(uint256(_minGasLimit), 0, 100_000));
-        vm.assume(_message.length <= 100);
+        bytes calldata message = _message[:_message.length > 100 ? 100 : _message.length];
 
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
 
-        // set the value of op.l2Sender() to be the L2 Cross Domain Messenger.
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
 
-        bytes32 hash = Hashing.hashCrossDomainMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, _target, 0, _minGasLimit, _message
-        );
+        uint256 nonce = _versionedNonce(1);
+        bytes32 hash = Hashing.hashCrossDomainMessage(nonce, sender, _target, 0, _minGasLimit, message);
 
         vm.prank(address(optimismPortal2));
-        l1CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, _target, 0, _minGasLimit, _message
-        );
+        l1CrossDomainMessenger.relayMessage(nonce, sender, _target, 0, _minGasLimit, message);
 
-        // Verify message was relayed (either successfully or failed)
-        assertTrue(l1CrossDomainMessenger.successfulMessages(hash) || l1CrossDomainMessenger.failedMessages(hash));
+        _assertMessageRecorded(hash);
     }
 
     /// @notice Tests that `relayMessage` reverts if the caller is optimismPortal2 and the value
@@ -492,8 +440,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
         bytes memory message = hex"1111";
 
-        // set the value of op.l2Sender() to be the L2CrossDomainMessenger.
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
 
         // correctly sending as OptimismPortal but amount does not match msg.value
         vm.deal(address(optimismPortal2), 10 ether);
@@ -511,8 +458,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
         bytes memory message = hex"1111";
 
-        // set the value of op.l2Sender() to be the L2 Cross Domain Messenger.
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
 
         // make a failed message
         vm.etch(target, hex"fe");
@@ -535,7 +481,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
         bytes memory message = hex"1111";
 
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
 
         vm.prank(address(optimismPortal2));
         vm.expectRevert("CrossDomainMessenger: cannot send message to blocked system address");
@@ -555,7 +501,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
         bytes memory message = hex"1111";
 
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
 
         vm.prank(address(optimismPortal2));
         vm.expectRevert("CrossDomainMessenger: cannot send message to blocked system address");
@@ -567,11 +513,11 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
     /// @notice Tests that `relayMessage` reverts if the message is called by a non-optimismPortal2
     ///         address and is not a failed message eligible for replay.
     function test_relayMessage_relayingNewMessageByExternalUser_reverts() external {
-        address target = address(alice);
+        address target = alice;
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
         bytes memory message = hex"1111";
 
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
 
         vm.prank(bob);
         vm.expectRevert("CrossDomainMessenger: message cannot be replayed");
@@ -632,25 +578,29 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
             _message
         );
 
-        // Count the number of non-zero bytes in the message.
-        uint256 zeroBytesInCalldata = 0;
+        // Count calldata bytes so the EIP-7623 floor can be checked against actual encoded data.
         uint256 nonzeroBytesInCalldata = 0;
         for (uint256 i = 0; i < encoded.length; i++) {
             if (encoded[i] != bytes1(0)) {
                 nonzeroBytesInCalldata++;
-            } else {
-                zeroBytesInCalldata++;
             }
         }
 
+        uint256 zeroBytesInCalldata = encoded.length - nonzeroBytesInCalldata;
+        uint256 calldataTokens = zeroBytesInCalldata + nonzeroBytesInCalldata * 4;
+        uint256 floorCost = l1CrossDomainMessenger.TX_BASE_GAS() + calldataTokens
+            * (l1CrossDomainMessenger.FLOOR_CALLDATA_OVERHEAD() / 4);
+
         // Base gas must always be sufficient to cover the floor cost from EIP-7623.
-        assertGt(baseGas, 21000 + ((zeroBytesInCalldata + nonzeroBytesInCalldata * 4) * 10));
+        assertGt(baseGas, floorCost);
 
         // Actual gas on L2 will be the base gas minus the intrinsic gas cost. Note that even after
         // EIP-7623, we still deduct 21k + 16 gas per calldata token from the gas limit before
         // execution happens. After execution, if the message didn't spend enough in execution gas,
         // the EVM will floor the cost of the transaction to 21k + 40 gas per calldata token.
-        uint256 gasSupplied = baseGas - (21000 + ((zeroBytesInCalldata + nonzeroBytesInCalldata * 4) * 4));
+        uint256 intrinsicCost = l1CrossDomainMessenger.TX_BASE_GAS() + calldataTokens
+            * (l1CrossDomainMessenger.MIN_GAS_CALLDATA_OVERHEAD() / 4);
+        uint256 gasSupplied = baseGas - intrinsicCost;
 
         // We'll trigger the L2CrossDomainMessenger as if we're the L1CrossDomainMessenger
         address caller = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
@@ -662,8 +612,9 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         assertTrue(success, "L2CrossDomainMessenger call should not fail");
 
         // Message should either be in the failed or successful messages mapping.
-        bool inFailedMessages = l2CrossDomainMessenger.failedMessages(keccak256(encoded));
-        bool inSuccessfulMessages = l2CrossDomainMessenger.successfulMessages(keccak256(encoded));
+        bytes32 encodedHash = keccak256(encoded);
+        bool inFailedMessages = l2CrossDomainMessenger.failedMessages(encodedHash);
+        bool inSuccessfulMessages = l2CrossDomainMessenger.successfulMessages(encodedHash);
         assertTrue(
             inFailedMessages || inSuccessfulMessages, "message should be in either failed or successful messages"
         );
@@ -705,26 +656,13 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         bytes memory _message
     )
         external
+        view
     {
-        // Make sure that unexpected nonces aren't being used right now.
-        // Prevents people from forgetting to update this test if a new version is ever used.
-        if (_version > 2) {
-            vm.expectRevert("Encoding: unknown cross domain message version");
-            encoding.encodeCrossDomainMessage(
-                Encoding.encodeVersionedNonce({ _nonce: 0, _version: _version }),
-                _sender,
-                _target,
-                _value,
-                _minGasLimit,
-                _message
-            );
-        }
-
         // Clamp the version to 0 or 1.
         _version = _version % 2;
 
         // Encode the message.
-        bytes memory encoded = encoding.encodeCrossDomainMessage(
+        bytes memory encoded = Encoding.encodeCrossDomainMessage(
             Encoding.encodeVersionedNonce({ _nonce: _nonce, _version: _version }),
             _sender,
             _target,
@@ -745,7 +683,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
 
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
 
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
         vm.prank(address(optimismPortal2));
         l1CrossDomainMessenger.relayMessage(
             Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), address(0), address(0), 0, 0, hex""
@@ -755,9 +693,11 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         l1CrossDomainMessenger.xDomainMessageSender();
     }
 
-    /// @notice Tests that xDomainMessageSender is never set during sendMessage.
-    function test_xDomainMessageSender_duringSend_reverts() external {
-        // XDomainMessageSender is only set during relayMessage, not sendMessage
+    /// @notice Tests that xDomainMessageSender remains unset after sendMessage.
+    function test_xDomainMessageSender_afterSend_reverts() external {
+        vm.prank(alice);
+        l1CrossDomainMessenger.sendMessage(recipient, hex"1234", 100);
+
         vm.expectRevert("CrossDomainMessenger: xDomainMessageSender is not set");
         l1CrossDomainMessenger.xDomainMessageSender();
     }
@@ -776,8 +716,8 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
             Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, target, value, 0, hex"1111"
         );
 
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
-        vm.etch(target, address(new Reverter()).code);
+        _setPortalL2Sender(sender);
+        vm.etch(target, type(Reverter).runtimeCode);
         vm.deal(address(optimismPortal2), value);
         vm.prank(address(optimismPortal2));
         l1CrossDomainMessenger.relayMessage{ value: value }(
@@ -791,8 +731,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
 
         assertEq(address(l1CrossDomainMessenger).balance, value);
         assertEq(address(target).balance, 0);
-        assertEq(l1CrossDomainMessenger.successfulMessages(hash), false);
-        assertEq(l1CrossDomainMessenger.failedMessages(hash), true);
+        _assertMessageStatus(hash, false, true);
 
         vm.expectEmit(address(l1CrossDomainMessenger));
 
@@ -811,8 +750,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
 
         assertEq(address(l1CrossDomainMessenger).balance, 0);
         assertEq(address(target).balance, value);
-        assertEq(l1CrossDomainMessenger.successfulMessages(hash), true);
-        assertEq(l1CrossDomainMessenger.failedMessages(hash), true);
+        _assertMessageStatus(hash, true, true);
     }
 
     /// @notice Tests that `relayMessage` should successfully call the target contract after the
@@ -833,8 +771,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
             hex"1111"
         );
 
-        // Set the value of op.l2Sender() to be the L2 Cross Domain Messenger.
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
 
         // Target should be called with expected data.
         vm.expectCall(target, hex"1111");
@@ -854,33 +791,24 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
             hex"1111"
         );
 
-        // Message was successfully relayed.
-        assertEq(l1CrossDomainMessenger.successfulMessages(hash), true);
-        assertEq(l1CrossDomainMessenger.failedMessages(hash), false);
+        _assertMessageStatus(hash, true, false);
     }
 
     /// @notice Tests that `relayMessage` should revert if the message is already replayed.
     function test_relayMessage_legacyOldReplay_reverts() external {
         address target = address(0xabcd);
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
+        uint256 nonce = _versionedNonce(0);
 
         // Compute the message hash.
-        bytes32 hash = Hashing.hashCrossDomainMessageV1(
-            // Using a legacy nonce with version 0.
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 0 }),
-            sender,
-            target,
-            0,
-            0,
-            hex"1111"
-        );
+        bytes32 hash = Hashing.hashCrossDomainMessageV1(nonce, sender, target, 0, 0, hex"1111");
 
-        // Set the value of op.l2Sender() to be the L2 Cross Domain Messenger.
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
         // Mark legacy message as already relayed.
-        uint256 successfulMessagesSlot = 203;
         bytes32 oldHash = Hashing.hashCrossDomainMessageV0(target, sender, hex"1111", 0);
-        bytes32 slot = keccak256(abi.encode(oldHash, successfulMessagesSlot));
+        StorageSlot memory successfulMessagesSlot =
+            ForgeArtifacts.getSlot("L1CrossDomainMessenger", "successfulMessages");
+        bytes32 slot = keccak256(abi.encode(oldHash, successfulMessagesSlot.slot));
         vm.store(address(l1CrossDomainMessenger), slot, bytes32(uint256(1)));
 
         // Expect revert.
@@ -888,18 +816,9 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
 
         // Relay the message.
         vm.prank(address(optimismPortal2));
-        l1CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 0 }), // nonce
-            sender,
-            target,
-            0, // value
-            0,
-            hex"1111"
-        );
+        l1CrossDomainMessenger.relayMessage(nonce, sender, target, 0, 0, hex"1111");
 
-        // Message was not relayed.
-        assertEq(l1CrossDomainMessenger.successfulMessages(hash), false);
-        assertEq(l1CrossDomainMessenger.failedMessages(hash), false);
+        _assertMessageStatus(hash, false, false);
     }
 
     /// @notice Tests that `relayMessage` can be retried after a failure with a legacy message.
@@ -919,11 +838,9 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
             hex"1111"
         );
 
-        // Set the value of op.l2Sender() to be the L2 Cross Domain Messenger.
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
 
-        // Turn the target into a Reverter.
-        vm.etch(target, address(new Reverter()).code);
+        vm.etch(target, type(Reverter).runtimeCode);
 
         // Target should be called with expected data.
         vm.expectCall(target, hex"1111");
@@ -947,8 +864,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         // Message failed.
         assertEq(address(l1CrossDomainMessenger).balance, value);
         assertEq(address(target).balance, 0);
-        assertEq(l1CrossDomainMessenger.successfulMessages(hash), false);
-        assertEq(l1CrossDomainMessenger.failedMessages(hash), true);
+        _assertMessageStatus(hash, false, true);
 
         // Make the target not revert anymore.
         vm.etch(target, address(0).code);
@@ -974,8 +890,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         // Message was successfully relayed.
         assertEq(address(l1CrossDomainMessenger).balance, 0);
         assertEq(address(target).balance, value);
-        assertEq(l1CrossDomainMessenger.successfulMessages(hash), true);
-        assertEq(l1CrossDomainMessenger.failedMessages(hash), true);
+        _assertMessageStatus(hash, true, true);
     }
 
     /// @notice Tests that `relayMessage` cannot be retried after success with a legacy message.
@@ -995,8 +910,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
             hex"1111"
         );
 
-        // Set the value of op.l2Sender() to be the L2 Cross Domain Messenger.
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
 
         // Target should be called with expected data.
         vm.expectCall(target, hex"1111");
@@ -1020,8 +934,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         // Message was successfully relayed.
         assertEq(address(l1CrossDomainMessenger).balance, 0);
         assertEq(address(target).balance, value);
-        assertEq(l1CrossDomainMessenger.successfulMessages(hash), true);
-        assertEq(l1CrossDomainMessenger.failedMessages(hash), false);
+        _assertMessageStatus(hash, true, false);
 
         // Expect a revert.
         vm.expectRevert("CrossDomainMessenger: message cannot be replayed");
@@ -1055,11 +968,9 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
             hex"1111"
         );
 
-        // Set the value of op.l2Sender() to be the L2 Cross Domain Messenger.
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
 
-        // Turn the target into a Reverter.
-        vm.etch(target, address(new Reverter()).code);
+        vm.etch(target, type(Reverter).runtimeCode);
 
         // Target should be called with expected data.
         vm.expectCall(target, hex"1111");
@@ -1079,8 +990,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         // Message failed.
         assertEq(address(l1CrossDomainMessenger).balance, value);
         assertEq(address(target).balance, 0);
-        assertEq(l1CrossDomainMessenger.successfulMessages(hash), false);
-        assertEq(l1CrossDomainMessenger.failedMessages(hash), true);
+        _assertMessageStatus(hash, false, true);
 
         // Make the target not revert anymore.
         vm.etch(target, address(0).code);
@@ -1106,8 +1016,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         // Message was successfully relayed.
         assertEq(address(l1CrossDomainMessenger).balance, 0);
         assertEq(address(target).balance, value);
-        assertEq(l1CrossDomainMessenger.successfulMessages(hash), true);
-        assertEq(l1CrossDomainMessenger.failedMessages(hash), true);
+        _assertMessageStatus(hash, true, true);
 
         // Expect a revert.
         vm.expectRevert("CrossDomainMessenger: message has already been relayed");
@@ -1124,8 +1033,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         );
     }
 
-    /// @notice Tests that the relayMessage function is able to relay a message successfully by
-    ///         calling the target contract.
+    /// @notice Tests that relayMessage reverts while the messenger is paused.
     function test_relayMessage_paused_reverts() external {
         vm.prank(superchainConfig.guardian());
         superchainConfig.pause(address(0));
@@ -1151,25 +1059,25 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
 
         uint256 balanceBeforeThis = address(this).balance;
         uint256 balanceBeforeMessenger = address(l1CrossDomainMessenger).balance;
+        bytes32 hash = _reentrancyHash();
+        bytes memory message = _reentrancyMessage();
+        StorageSlot memory failedMessagesSlot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "failedMessages");
 
         // A requisite for the attack is that the message has already been attempted and written
         // to the failedMessages mapping, so that it can be replayed.
-        vm.store(address(l1CrossDomainMessenger), keccak256(abi.encode(reentrancyHash, 206)), bytes32(uint256(1)));
-        assertTrue(l1CrossDomainMessenger.failedMessages(reentrancyHash));
+        vm.store(
+            address(l1CrossDomainMessenger), keccak256(abi.encode(hash, failedMessagesSlot.slot)), bytes32(uint256(1))
+        );
+        assertTrue(l1CrossDomainMessenger.failedMessages(hash));
 
         vm.expectEmit(address(l1CrossDomainMessenger));
-        emit FailedRelayedMessage(reentrancyHash);
+        emit FailedRelayedMessage(hash);
         l1CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), // nonce
-            reentrancySender,
-            reentrancyTarget,
-            reentrancyMessageValue,
-            0,
-            reentrancySelector
+            _versionedNonce(1), Predeploys.L2_CROSS_DOMAIN_MESSENGER, address(this), reentrancyMessageValue, 0, message
         );
 
         // The message hash is not in the successfulMessages mapping.
-        assertFalse(l1CrossDomainMessenger.successfulMessages(reentrancyHash));
+        assertFalse(l1CrossDomainMessenger.successfulMessages(hash));
         // The balance of this contract is unchanged.
         assertEq(address(this).balance, balanceBeforeThis);
         // The balance of the messenger contract is unchanged.

--- a/test/L1/L1ERC721Bridge.t.sol
+++ b/test/L1/L1ERC721Bridge.t.sol
@@ -34,6 +34,8 @@ abstract contract L1ERC721Bridge_TestInit is CommonTest {
     L1ERC721Bridge_TestERC721_Harness internal localToken;
     L1ERC721Bridge_TestERC721_Harness internal remoteToken;
     uint256 internal constant tokenId = 1;
+    uint32 internal constant DEFAULT_MIN_GAS_LIMIT = 1234;
+    bytes internal constant EXTRA_DATA = hex"5678";
 
     event ERC721BridgeInitiated(
         address indexed localToken,
@@ -53,17 +55,65 @@ abstract contract L1ERC721Bridge_TestInit is CommonTest {
         bytes extraData
     );
 
-    /// @notice Sets up the testing environment.
-    function setUp() public override {
+    function _expectBridgeMessage(address _to) internal {
+        bytes memory message = abi.encodeCall(
+            IL2ERC721Bridge.finalizeBridgeERC721,
+            (address(remoteToken), address(localToken), alice, _to, tokenId, EXTRA_DATA)
+        );
+
+        vm.expectCall(
+            address(l1ERC721Bridge.messenger()),
+            abi.encodeCall(
+                ICrossDomainMessenger.sendMessage,
+                (address(l1ERC721Bridge.otherBridge()), message, DEFAULT_MIN_GAS_LIMIT)
+            )
+        );
+    }
+
+    function _expectBridgeInitiated(address _to) internal {
+        vm.expectEmit(address(l1ERC721Bridge));
+        emit ERC721BridgeInitiated(address(localToken), address(remoteToken), alice, _to, tokenId, EXTRA_DATA);
+    }
+
+    function _mockXDomainMessageSender(address _sender) internal {
+        vm.mockCall(
+            address(l1ERC721Bridge.messenger()),
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(_sender)
+        );
+    }
+
+    function _mockOtherBridge() internal {
+        _mockXDomainMessageSender(address(l1ERC721Bridge.otherBridge()));
+    }
+
+    function _bridgeToken() internal {
+        vm.prank(alice, alice);
+        l1ERC721Bridge.bridgeERC721(
+            address(localToken), address(remoteToken), tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA
+        );
+    }
+
+    function _assertTokenEscrowed() internal view {
+        assertTrue(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId));
+        assertEq(localToken.ownerOf(tokenId), address(l1ERC721Bridge));
+    }
+
+    function _assertTokenNotEscrowed(address _owner) internal view {
+        assertFalse(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId));
+        assertEq(localToken.ownerOf(tokenId), _owner);
+    }
+}
+
+abstract contract L1ERC721Bridge_Bridge_TestInit is L1ERC721Bridge_TestInit {
+    function setUp() public virtual override {
         super.setUp();
 
         localToken = new L1ERC721Bridge_TestERC721_Harness();
         remoteToken = new L1ERC721Bridge_TestERC721_Harness();
 
-        // Mint alice a token.
         localToken.mint(alice, tokenId);
 
-        // Approve the bridge to transfer the token.
         vm.prank(alice);
         localToken.approve(address(l1ERC721Bridge), tokenId);
     }
@@ -89,6 +139,23 @@ contract L1ERC721Bridge_Constructor_Test is L1ERC721Bridge_TestInit {
 /// @title L1ERC721Bridge_Initialize_Test
 /// @notice Test contract for L1ERC721Bridge `initialize` function.
 contract L1ERC721Bridge_Initialize_Test is L1ERC721Bridge_TestInit {
+    StorageSlot internal initializedSlot;
+
+    function setUp() public override {
+        super.setUp();
+
+        initializedSlot = ForgeArtifacts.getSlot("L1ERC721Bridge", "_initialized");
+    }
+
+    function _resetInitialized() internal {
+        vm.store(address(l1ERC721Bridge), bytes32(initializedSlot.slot), bytes32(0));
+    }
+
+    function _initializedValue() internal view returns (uint8) {
+        bytes32 slotVal = vm.load(address(l1ERC721Bridge), bytes32(initializedSlot.slot));
+        return uint8((uint256(slotVal) >> (initializedSlot.offset * 8)) & 0xFF);
+    }
+
     /// @notice Tests that the proxy is initialized with the correct values.
     function test_initialize_succeeds() public view {
         assertEq(address(l1ERC721Bridge.MESSENGER()), address(l1CrossDomainMessenger));
@@ -103,15 +170,7 @@ contract L1ERC721Bridge_Initialize_Test is L1ERC721Bridge_TestInit {
     ///         initialization but confirms that the initValue is not incremented incorrectly if
     ///         an upgrade function is not present.
     function test_initialize_correctInitializerValue_succeeds() public view {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1ERC721Bridge", "_initialized");
-
-        // Get the initializer value.
-        bytes32 slotVal = vm.load(address(l1ERC721Bridge), bytes32(slot.slot));
-        uint8 val = uint8(uint256(slotVal) & 0xFF);
-
-        // Assert that the initializer value matches the expected value.
-        assertEq(val, l1ERC721Bridge.initVersion());
+        assertEq(_initializedValue(), l1ERC721Bridge.initVersion());
     }
 
     /// @notice Tests that the initialize function reverts if called by a non-proxy admin or owner.
@@ -120,11 +179,7 @@ contract L1ERC721Bridge_Initialize_Test is L1ERC721Bridge_TestInit {
         // Prank as the not ProxyAdmin or ProxyAdmin owner.
         vm.assume(_sender != address(proxyAdmin) && _sender != proxyAdminOwner);
 
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1ERC721Bridge", "_initialized");
-
-        // Set the initialized slot to 0.
-        vm.store(address(l1ERC721Bridge), bytes32(slot.slot), bytes32(0));
+        _resetInitialized();
 
         // Expect the revert with `ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner` selector
         vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
@@ -185,154 +240,111 @@ contract L1ERC721Bridge_Paused_Test is L1ERC721Bridge_TestInit {
 
 /// @title L1ERC721Bridge_FinalizeBridgeERC721_Test
 /// @notice Test contract for L1ERC721Bridge `finalizeBridgeERC721` function.
-contract L1ERC721Bridge_FinalizeBridgeERC721_Test is L1ERC721Bridge_TestInit {
+contract L1ERC721Bridge_FinalizeBridgeERC721_Test is L1ERC721Bridge_Bridge_TestInit {
     /// @notice Tests that the ERC721 bridge successfully finalizes a withdrawal.
     function test_finalizeBridgeERC721_succeeds() external {
-        // Bridge the token.
-        vm.prank(alice, alice);
-        l1ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
+        _bridgeToken();
+        vm.expectEmit(address(l1ERC721Bridge));
+        emit ERC721BridgeFinalized(address(localToken), address(remoteToken), alice, alice, tokenId, EXTRA_DATA);
 
-        // Expect an event to be emitted.
-        vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeFinalized(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
-
-        // Finalize a withdrawal.
-        vm.mockCall(
-            address(l1CrossDomainMessenger),
-            abi.encodeCall(l1CrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(Predeploys.L2_ERC721_BRIDGE)
+        _mockOtherBridge();
+        vm.prank(address(l1ERC721Bridge.messenger()));
+        l1ERC721Bridge.finalizeBridgeERC721(
+            address(localToken), address(remoteToken), alice, alice, tokenId, EXTRA_DATA
         );
-        vm.prank(address(l1CrossDomainMessenger));
-        l1ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
 
-        // Token is not locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), false);
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenNotEscrowed(alice);
     }
 
     /// @notice Tests that the ERC721 bridge finalize reverts when not called by the remote bridge.
     function test_finalizeBridgeERC721_notViaLocalMessenger_reverts() external {
-        // Finalize a withdrawal.
         vm.prank(alice);
         vm.expectRevert("ERC721Bridge: function can only be called from the other bridge");
-        l1ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+        l1ERC721Bridge.finalizeBridgeERC721(
+            address(localToken), address(remoteToken), alice, alice, tokenId, EXTRA_DATA
+        );
     }
 
     /// @notice Tests that the ERC721 bridge finalize reverts when not called from the remote
     ///         messenger.
     function test_finalizeBridgeERC721_notFromRemoteMessenger_reverts() external {
-        // Finalize a withdrawal.
-        vm.mockCall(
-            address(l1CrossDomainMessenger),
-            abi.encodeCall(l1CrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(alice)
-        );
-        vm.prank(address(l1CrossDomainMessenger));
+        _mockXDomainMessageSender(alice);
+        vm.prank(address(l1ERC721Bridge.messenger()));
         vm.expectRevert("ERC721Bridge: function can only be called from the other bridge");
-        l1ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+        l1ERC721Bridge.finalizeBridgeERC721(
+            address(localToken), address(remoteToken), alice, alice, tokenId, EXTRA_DATA
+        );
     }
 
     /// @notice Tests finalizeBridgeERC721 reverts with invalid caller address.
     /// @param _caller Random address that is not the messenger.
     function testFuzz_finalizeBridgeERC721_invalidCaller_reverts(address _caller) external {
-        vm.assume(_caller != address(l1CrossDomainMessenger));
+        vm.assume(_caller != address(l1ERC721Bridge.messenger()));
         vm.prank(_caller);
         vm.expectRevert("ERC721Bridge: function can only be called from the other bridge");
-        l1ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+        l1ERC721Bridge.finalizeBridgeERC721(
+            address(localToken), address(remoteToken), alice, alice, tokenId, EXTRA_DATA
+        );
     }
 
     /// @notice Tests that the ERC721 bridge finalize reverts when the local token is set as the
     ///         bridge itself.
     function test_finalizeBridgeERC721_selfToken_reverts() external {
-        // Finalize a withdrawal.
-        vm.mockCall(
-            address(l1CrossDomainMessenger),
-            abi.encodeCall(l1CrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(Predeploys.L2_ERC721_BRIDGE)
-        );
-        vm.prank(address(l1CrossDomainMessenger));
+        _mockOtherBridge();
+        vm.prank(address(l1ERC721Bridge.messenger()));
         vm.expectRevert("L1ERC721Bridge: local token cannot be self");
         l1ERC721Bridge.finalizeBridgeERC721(
-            address(l1ERC721Bridge), address(remoteToken), alice, alice, tokenId, hex"5678"
+            address(l1ERC721Bridge), address(remoteToken), alice, alice, tokenId, EXTRA_DATA
         );
     }
 
     /// @notice Tests that the ERC721 bridge finalize reverts when the remote token is not escrowed
     ///         in the L1 bridge.
     function test_finalizeBridgeERC721_notEscrowed_reverts() external {
-        // Finalize a withdrawal.
-        vm.mockCall(
-            address(l1CrossDomainMessenger),
-            abi.encodeCall(l1CrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(Predeploys.L2_ERC721_BRIDGE)
-        );
-        vm.prank(address(l1CrossDomainMessenger));
+        _mockOtherBridge();
+        vm.prank(address(l1ERC721Bridge.messenger()));
         vm.expectRevert("L1ERC721Bridge: Token ID is not escrowed in the L1 Bridge");
-        l1ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+        l1ERC721Bridge.finalizeBridgeERC721(
+            address(localToken), address(remoteToken), alice, alice, tokenId, EXTRA_DATA
+        );
     }
 
     /// @notice Tests finalizeBridgeERC721 with random valid addresses succeeds after bridging.
     /// @param _from Random from address for testing.
     /// @param _to Random to address for testing.
     function testFuzz_finalizeBridgeERC721_randomAddresses_succeeds(address _from, address _to) external {
-        // Avoid special predeploy addresses that might cause initialization issues
         vm.assume(_from != address(0) && _to != address(0));
-        vm.assume(
-            uint160(_from) < uint160(0x4200000000000000000000000000000000000000)
-                || uint160(_from) > uint160(0x4200000000000000000000000000000000001000)
-        );
-        vm.assume(
-            uint160(_to) < uint160(0x4200000000000000000000000000000000000000)
-                || uint160(_to) > uint160(0x4200000000000000000000000000000000001000)
-        );
+        vm.assume(!Predeploys.isPredeployNamespace(_from));
+        vm.assume(!Predeploys.isPredeployNamespace(_to));
 
-        // Ensure the to address is an EOA.
         vm.assume(_to.code.length == 0);
 
-        // Bridge the token first.
-        vm.prank(alice, alice);
-        l1ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
+        _bridgeToken();
+        _mockOtherBridge();
 
-        // Mock the cross domain messenger.
-        vm.mockCall(
-            address(l1CrossDomainMessenger),
-            abi.encodeCall(l1CrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(Predeploys.L2_ERC721_BRIDGE)
-        );
+        vm.prank(address(l1ERC721Bridge.messenger()));
+        l1ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), _from, _to, tokenId, EXTRA_DATA);
 
-        // Finalize with random addresses.
-        vm.prank(address(l1CrossDomainMessenger));
-        l1ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), _from, _to, tokenId, hex"5678");
-
-        // Verify token was transferred to _to.
-        assertEq(localToken.ownerOf(tokenId), _to);
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), false);
+        _assertTokenNotEscrowed(_to);
     }
 
-    /// @notice Ensures that the `bridgeERC721` function reverts when the bridge is paused.
+    /// @notice Ensures that the `finalizeBridgeERC721` function reverts when the bridge is paused.
     function test_finalizeBridgeERC721_paused_reverts() external {
-        /// Sets up the test by pausing the bridge, giving ether to the bridge and mocking the
-        /// calls to the xDomainMessageSender so that it returns the correct value.
-        vm.startPrank(systemConfig.superchainConfig().guardian());
-        systemConfig.superchainConfig().pause(address(0));
-        vm.stopPrank();
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(address(0));
 
         assertTrue(l1ERC721Bridge.paused());
-        vm.mockCall(
-            address(l1ERC721Bridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1ERC721Bridge.otherBridge()))
-        );
+        _mockOtherBridge();
 
         vm.prank(address(l1ERC721Bridge.messenger()));
         vm.expectRevert("L1ERC721Bridge: paused");
         l1ERC721Bridge.finalizeBridgeERC721({
-            _localToken: address(0),
-            _remoteToken: address(0),
-            _from: address(0),
-            _to: address(0),
-            _tokenId: 0,
-            _extraData: hex""
+            _localToken: address(localToken),
+            _remoteToken: address(remoteToken),
+            _from: alice,
+            _to: alice,
+            _tokenId: tokenId,
+            _extraData: EXTRA_DATA
         });
     }
 }
@@ -340,214 +352,139 @@ contract L1ERC721Bridge_FinalizeBridgeERC721_Test is L1ERC721Bridge_TestInit {
 /// @title L1ERC721Bridge_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `L1ERC721Bridge`
 ///         contract or are testing multiple functions at once.
-contract L1ERC721Bridge_Uncategorized_Test is L1ERC721Bridge_TestInit {
+contract L1ERC721Bridge_Uncategorized_Test is L1ERC721Bridge_Bridge_TestInit {
     /// @notice Tests that the ERC721 can be bridged successfully.
     function test_bridgeERC721_fromEOA_succeeds() public {
-        // Expect a call to the messenger.
-        vm.expectCall(
-            address(l1CrossDomainMessenger),
-            abi.encodeCall(
-                l1CrossDomainMessenger.sendMessage,
-                (
-                    address(l2ERC721Bridge),
-                    abi.encodeCall(
-                        IL2ERC721Bridge.finalizeBridgeERC721,
-                        (address(remoteToken), address(localToken), alice, alice, tokenId, hex"5678")
-                    ),
-                    1234
-                )
-            )
-        );
+        _expectBridgeMessage(alice);
+        _expectBridgeInitiated(alice);
 
-        // Expect an event to be emitted.
-        vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeInitiated(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+        _bridgeToken();
 
-        // Bridge the token.
-        vm.prank(alice, alice);
-        l1ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
-
-        // Token is locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), true);
-        assertEq(localToken.ownerOf(tokenId), address(l1ERC721Bridge));
+        _assertTokenEscrowed();
     }
 
     /// @notice Tests that the ERC721 can be bridged successfully.
     function test_bridgeERC721_fromEOA7702_succeeds() public {
-        // Expect a call to the messenger.
-        vm.expectCall(
-            address(l1CrossDomainMessenger),
-            abi.encodeCall(
-                l1CrossDomainMessenger.sendMessage,
-                (
-                    address(l2ERC721Bridge),
-                    abi.encodeCall(
-                        IL2ERC721Bridge.finalizeBridgeERC721,
-                        (address(remoteToken), address(localToken), alice, alice, tokenId, hex"5678")
-                    ),
-                    1234
-                )
-            )
-        );
-
-        // Expect an event to be emitted.
-        vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeInitiated(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+        _expectBridgeMessage(alice);
+        _expectBridgeInitiated(alice);
 
         // Set alice to have 7702 code (delegation target must be non-zero; address(0) is treated as revocation per
         // EIP-7702).
         vm.etch(alice, abi.encodePacked(hex"EF0100", address(1)));
 
-        // Bridge the token.
         vm.prank(alice);
-        l1ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
+        l1ERC721Bridge.bridgeERC721(
+            address(localToken), address(remoteToken), tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA
+        );
 
-        // Token is locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), true);
-        assertEq(localToken.ownerOf(tokenId), address(l1ERC721Bridge));
+        _assertTokenEscrowed();
     }
 
     /// @notice Tests that the ERC721 bridge reverts for non externally owned accounts.
     function test_bridgeERC721_fromContract_reverts() external {
-        // Bridge the token.
         vm.etch(alice, hex"01");
         vm.prank(alice);
         vm.expectRevert("ERC721Bridge: account is not externally owned");
-        l1ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
+        l1ERC721Bridge.bridgeERC721(
+            address(localToken), address(remoteToken), tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA
+        );
 
-        // Token is not locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), false);
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenNotEscrowed(alice);
     }
 
     /// @notice Tests that the ERC721 bridge reverts for a zero address local token.
     function test_bridgeERC721_localTokenZeroAddress_reverts() external {
-        // Bridge the token.
         vm.prank(alice, alice);
         vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
-        l1ERC721Bridge.bridgeERC721(address(0), address(remoteToken), tokenId, 1234, hex"5678");
+        l1ERC721Bridge.bridgeERC721(address(0), address(remoteToken), tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
 
-        // Token is not locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), false);
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenNotEscrowed(alice);
     }
 
     /// @notice Tests that the ERC721 bridge reverts for a zero address remote token.
     function test_bridgeERC721_remoteTokenZeroAddress_reverts() external {
-        // Bridge the token.
         vm.prank(alice, alice);
         vm.expectRevert("L1ERC721Bridge: remote token cannot be address(0)");
-        l1ERC721Bridge.bridgeERC721(address(localToken), address(0), tokenId, 1234, hex"5678");
+        l1ERC721Bridge.bridgeERC721(address(localToken), address(0), tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
 
-        // Token is not locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), false);
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenNotEscrowed(alice);
     }
 
     /// @notice Tests bridgeERC721 with various gas limits succeeds.
     /// @param _minGasLimit Random gas limit for testing.
     function testFuzz_bridgeERC721_variousGasLimits_succeeds(uint32 _minGasLimit) external {
-        // Bound gas limit to avoid out of gas errors
         _minGasLimit = uint32(bound(uint256(_minGasLimit), 21000, 10000000));
 
-        // Bridge the token.
         vm.prank(alice, alice);
-        l1ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, _minGasLimit, hex"5678");
+        l1ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, _minGasLimit, EXTRA_DATA);
 
-        // Token is locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), true);
-        assertEq(localToken.ownerOf(tokenId), address(l1ERC721Bridge));
+        _assertTokenEscrowed();
     }
 
     /// @notice Tests that the ERC721 bridge reverts for an incorrect owner.
     function test_bridgeERC721_wrongOwner_reverts() external {
-        // Bridge the token.
         vm.prank(bob, bob);
         vm.expectRevert("ERC721: transfer from incorrect owner");
-        l1ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
+        l1ERC721Bridge.bridgeERC721(
+            address(localToken), address(remoteToken), tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA
+        );
 
-        // Token is not locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), false);
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenNotEscrowed(alice);
     }
 
     /// @notice Tests that the ERC721 bridge successfully sends a token to a different address than
     ///         the owner.
     function test_bridgeERC721To_succeeds() external {
-        // Expect a call to the messenger.
-        vm.expectCall(
-            address(l1CrossDomainMessenger),
-            abi.encodeCall(
-                l1CrossDomainMessenger.sendMessage,
-                (
-                    address(Predeploys.L2_ERC721_BRIDGE),
-                    abi.encodeCall(
-                        IL2ERC721Bridge.finalizeBridgeERC721,
-                        (address(remoteToken), address(localToken), alice, bob, tokenId, hex"5678")
-                    ),
-                    1234
-                )
-            )
+        _expectBridgeMessage(bob);
+        _expectBridgeInitiated(bob);
+
+        vm.prank(alice);
+        l1ERC721Bridge.bridgeERC721To(
+            address(localToken), address(remoteToken), bob, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA
         );
 
-        // Expect an event to be emitted.
-        vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeInitiated(address(localToken), address(remoteToken), alice, bob, tokenId, hex"5678");
-
-        // Bridge the token.
-        vm.prank(alice);
-        l1ERC721Bridge.bridgeERC721To(address(localToken), address(remoteToken), bob, tokenId, 1234, hex"5678");
-
-        // Token is locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), true);
-        assertEq(localToken.ownerOf(tokenId), address(l1ERC721Bridge));
+        _assertTokenEscrowed();
     }
 
     /// @notice Tests that the ERC721 bridge reverts for non externally owned accounts when sending
     ///         to a different address than the owner.
     function test_bridgeERC721To_localTokenZeroAddress_reverts() external {
-        // Bridge the token.
         vm.prank(alice);
         vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
-        l1ERC721Bridge.bridgeERC721To(address(0), address(remoteToken), bob, tokenId, 1234, hex"5678");
+        l1ERC721Bridge.bridgeERC721To(address(0), address(remoteToken), bob, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
 
-        // Token is not locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), false);
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenNotEscrowed(alice);
     }
 
     /// @notice Tests that the ERC721 bridge reverts for a zero address remote token when sending
     ///         to a different address than the owner.
     function test_bridgeERC721To_remoteTokenZeroAddress_reverts() external {
-        // Bridge the token.
         vm.prank(alice);
         vm.expectRevert("L1ERC721Bridge: remote token cannot be address(0)");
-        l1ERC721Bridge.bridgeERC721To(address(localToken), address(0), bob, tokenId, 1234, hex"5678");
+        l1ERC721Bridge.bridgeERC721To(address(localToken), address(0), bob, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
 
-        // Token is not locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), false);
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenNotEscrowed(alice);
     }
 
     /// @notice Tests that the ERC721 bridge reverts for an incorrect owner when sending to a
     ///         different address than the owner.
     function test_bridgeERC721To_wrongOwner_reverts() external {
-        // Bridge the token.
         vm.prank(bob);
         vm.expectRevert("ERC721: transfer from incorrect owner");
-        l1ERC721Bridge.bridgeERC721To(address(localToken), address(remoteToken), bob, tokenId, 1234, hex"5678");
+        l1ERC721Bridge.bridgeERC721To(
+            address(localToken), address(remoteToken), bob, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA
+        );
 
-        // Token is not locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), false);
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenNotEscrowed(alice);
     }
 
     /// @notice Tests that `bridgeERC721To` reverts if the to address is the zero address.
     function test_bridgeERC721To_toZeroAddress_reverts() external {
-        // Bridge the token.
         vm.prank(bob);
         vm.expectRevert("ERC721Bridge: nft recipient cannot be address(0)");
-        l1ERC721Bridge.bridgeERC721To(address(localToken), address(remoteToken), address(0), tokenId, 1234, hex"5678");
+        l1ERC721Bridge.bridgeERC721To(
+            address(localToken), address(remoteToken), address(0), tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA
+        );
     }
 
     /// @notice Tests bridgeERC721To with random valid recipient addresses.
@@ -555,28 +492,13 @@ contract L1ERC721Bridge_Uncategorized_Test is L1ERC721Bridge_TestInit {
     function testFuzz_bridgeERC721To_validRecipient_succeeds(address _to) external {
         vm.assume(_to != address(0));
 
-        // Expect a call to the messenger.
-        vm.expectCall(
-            address(l1CrossDomainMessenger),
-            abi.encodeCall(
-                l1CrossDomainMessenger.sendMessage,
-                (
-                    address(Predeploys.L2_ERC721_BRIDGE),
-                    abi.encodeCall(
-                        IL2ERC721Bridge.finalizeBridgeERC721,
-                        (address(remoteToken), address(localToken), alice, _to, tokenId, hex"5678")
-                    ),
-                    1234
-                )
-            )
+        _expectBridgeMessage(_to);
+
+        vm.prank(alice);
+        l1ERC721Bridge.bridgeERC721To(
+            address(localToken), address(remoteToken), _to, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA
         );
 
-        // Bridge the token.
-        vm.prank(alice);
-        l1ERC721Bridge.bridgeERC721To(address(localToken), address(remoteToken), _to, tokenId, 1234, hex"5678");
-
-        // Token is locked in the bridge.
-        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), true);
-        assertEq(localToken.ownerOf(tokenId), address(l1ERC721Bridge));
+        _assertTokenEscrowed();
     }
 }

--- a/test/L1/L1StandardBridge.t.sol
+++ b/test/L1/L1StandardBridge.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { stdStorage, StdStorage } from "lib/forge-std/src/Test.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
 
@@ -26,6 +25,40 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 /// @title L1StandardBridge_TestInit
 /// @notice Reusable test initialization for `L1StandardBridge` tests.
 abstract contract L1StandardBridge_TestInit is CommonTest {
+    function _assertETHBridgeCustody(
+        uint256 _portalBalanceBefore,
+        uint256 _ethLockboxBalanceBefore,
+        uint256 _amount
+    )
+        internal
+        view
+    {
+        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
+            assertEq(address(optimismPortal2).balance, _portalBalanceBefore);
+            assertEq(address(ethLockbox).balance, _ethLockboxBalanceBefore + _amount);
+        } else {
+            assertEq(address(optimismPortal2).balance, _portalBalanceBefore + _amount);
+        }
+    }
+
+    function _mockXDomainMessageSender(address _sender) internal {
+        vm.mockCall(
+            address(l1StandardBridge.messenger()),
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(_sender)
+        );
+    }
+
+    function _mockOtherBridge() internal {
+        _mockXDomainMessageSender(address(l1StandardBridge.OTHER_BRIDGE()));
+    }
+
+    function _setupFinalizeBridgeETH() internal returns (address messenger) {
+        messenger = address(l1StandardBridge.messenger());
+        _mockOtherBridge();
+        vm.deal(messenger, 100);
+    }
+
     /// @notice Asserts the expected calls and events for bridging ETH depending on whether the
     ///         bridge call is legacy or not.
     function _preBridgeETH(bool isLegacy, uint256 value) internal {
@@ -33,7 +66,6 @@ abstract contract L1StandardBridge_TestInit is CommonTest {
             assertEq(address(optimismPortal2).balance, 0, "OptimismPortal2 balance should be 0");
         }
         uint256 nonce = l1CrossDomainMessenger.messageNonce();
-        uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
         address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
 
         bytes memory message = abi.encodeCall(StandardBridge.finalizeBridgeETH, (alice, alice, value, hex"dead"));
@@ -68,23 +100,20 @@ abstract contract L1StandardBridge_TestInit is CommonTest {
             )
         );
 
-        bytes memory opaqueData = abi.encodePacked(uint256(value), uint256(value), baseGas, false, innerMessage);
-
         vm.expectEmit(address(l1StandardBridge));
         emit ETHDepositInitiated(alice, alice, value, hex"dead");
 
         vm.expectEmit(address(l1StandardBridge));
         emit ETHBridgeInitiated(alice, alice, value, hex"dead");
 
-        // OptimismPortal emits a TransactionDeposited event on `depositTransaction` call
         vm.expectEmit(address(optimismPortal2));
-        emit TransactionDeposited(l1MessengerAliased, address(l2CrossDomainMessenger), version, opaqueData);
+        emitTransactionDeposited(
+            l1MessengerAliased, address(l2CrossDomainMessenger), value, value, baseGas, false, innerMessage
+        );
 
-        // SentMessage event emitted by the CrossDomainMessenger
         vm.expectEmit(address(l1CrossDomainMessenger));
         emit SentMessage(address(l2StandardBridge), address(l1StandardBridge), message, nonce, 50000);
 
-        // SentMessageExtension1 event emitted by the CrossDomainMessenger
         vm.expectEmit(address(l1CrossDomainMessenger));
         emit SentMessageExtension1(address(l1StandardBridge), value);
 
@@ -95,7 +124,6 @@ abstract contract L1StandardBridge_TestInit is CommonTest {
     ///         depending on whether the bridge call is legacy or not.
     function _preBridgeETHTo(bool isLegacy, uint256 value) internal {
         uint256 nonce = l1CrossDomainMessenger.messageNonce();
-        uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
         address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
 
         if (isLegacy) {
@@ -110,8 +138,6 @@ abstract contract L1StandardBridge_TestInit is CommonTest {
 
         bytes memory message = abi.encodeCall(StandardBridge.finalizeBridgeETH, (alice, bob, value, hex"dead"));
 
-        // the L1 bridge should call
-        // L1CrossDomainMessenger.sendMessage
         vm.expectCall(
             address(l1CrossDomainMessenger),
             abi.encodeCall(ICrossDomainMessenger.sendMessage, (address(l2StandardBridge), message, 60000))
@@ -131,27 +157,23 @@ abstract contract L1StandardBridge_TestInit is CommonTest {
             )
         );
 
-        bytes memory opaqueData = abi.encodePacked(uint256(value), uint256(value), baseGas, false, innerMessage);
-
         vm.expectEmit(address(l1StandardBridge));
         emit ETHDepositInitiated(alice, bob, value, hex"dead");
 
         vm.expectEmit(address(l1StandardBridge));
         emit ETHBridgeInitiated(alice, bob, value, hex"dead");
 
-        // OptimismPortal emits a TransactionDeposited event on `depositTransaction` call
         vm.expectEmit(address(optimismPortal2));
-        emit TransactionDeposited(l1MessengerAliased, address(l2CrossDomainMessenger), version, opaqueData);
+        emitTransactionDeposited(
+            l1MessengerAliased, address(l2CrossDomainMessenger), value, value, baseGas, false, innerMessage
+        );
 
-        // SentMessage event emitted by the CrossDomainMessenger
         vm.expectEmit(address(l1CrossDomainMessenger));
         emit SentMessage(address(l2StandardBridge), address(l1StandardBridge), message, nonce, 60000);
 
-        // SentMessageExtension1 event emitted by the CrossDomainMessenger
         vm.expectEmit(address(l1CrossDomainMessenger));
         emit SentMessageExtension1(address(l1StandardBridge), value);
 
-        // deposit eth to bob
         vm.prank(alice, alice);
     }
 }
@@ -178,6 +200,23 @@ contract L1StandardBridge_Constructor_Test is CommonTest {
 /// @title L1StandardBridge_Initialize_Test
 /// @notice Tests the `initialize` function of the `L1StandardBridge` contract.
 contract L1StandardBridge_Initialize_Test is CommonTest {
+    StorageSlot internal initializedSlot;
+
+    function setUp() public override {
+        super.setUp();
+
+        initializedSlot = ForgeArtifacts.getSlot("L1StandardBridge", "_initialized");
+    }
+
+    function _resetInitialized() internal {
+        vm.store(address(l1StandardBridge), bytes32(initializedSlot.slot), bytes32(0));
+    }
+
+    function _initializedValue() internal view returns (uint8) {
+        bytes32 slotVal = vm.load(address(l1StandardBridge), bytes32(initializedSlot.slot));
+        return uint8((uint256(slotVal) >> (initializedSlot.offset * 8)) & 0xFF);
+    }
+
     /// @notice Test that the initialize function sets the correct values.
     function test_initialize_succeeds() external view {
         assertEq(address(l1StandardBridge.systemConfig()), address(systemConfig));
@@ -193,8 +232,7 @@ contract L1StandardBridge_Initialize_Test is CommonTest {
     function testFuzz_initialize_notProxyAdminOrProxyAdminOwner_reverts(address _sender) public {
         vm.assume(_sender != address(proxyAdmin) && _sender != proxyAdminOwner);
 
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1StandardBridge", "_initialized");
-        vm.store(address(l1StandardBridge), bytes32(slot.slot), bytes32(0));
+        _resetInitialized();
 
         vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
         vm.prank(_sender);
@@ -205,36 +243,27 @@ contract L1StandardBridge_Initialize_Test is CommonTest {
     ///         but confirms that the initValue is not incremented incorrectly if an upgrade
     ///         function is not present.
     function test_initialize_correctInitializerValue_succeeds() public view {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1StandardBridge", "_initialized");
-
-        // Get the initializer value.
-        bytes32 slotVal = vm.load(address(l1StandardBridge), bytes32(slot.slot));
-        uint8 val = uint8(uint256(slotVal) & 0xFF);
-
-        // Assert that the initializer value matches the expected value.
-        assertEq(val, l1StandardBridge.initVersion());
+        assertEq(_initializedValue(), l1StandardBridge.initVersion());
     }
 }
 
 /// @title L1StandardBridge_Paused_Test
 /// @notice Tests the `paused` function of the `L1StandardBridge` contract.
-contract L1StandardBridge_Paused_Test is CommonTest {
-    /// @notice Sets up the test by pausing the bridge, giving ether to the bridge and mocking the
-    ///         calls to the xDomainMessageSender so that it returns the correct value.
-    function _setupPausedBridge() internal {
+contract L1StandardBridge_Paused_Test is L1StandardBridge_TestInit {
+    /// @notice Pauses the bridge and mocks the xDomainMessageSender to return the other bridge.
+    function _pauseBridge() internal {
         vm.startPrank(systemConfig.guardian());
         systemConfig.superchainConfig().pause(address(0));
         vm.stopPrank();
         assertTrue(l1StandardBridge.paused());
 
-        vm.deal(address(l1StandardBridge.messenger()), 1 ether);
+        _mockOtherBridge();
+    }
 
-        vm.mockCall(
-            address(l1StandardBridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.otherBridge()))
-        );
+    /// @notice Pauses the bridge and funds the messenger for payable ETH finalization tests.
+    function _setupPausedBridge() internal {
+        _pauseBridge();
+        vm.deal(address(l1StandardBridge.messenger()), 1 ether);
     }
 
     /// @notice Verifies that the `paused` accessor returns the same value as the `paused` function
@@ -289,7 +318,7 @@ contract L1StandardBridge_Paused_Test is CommonTest {
     /// @notice Confirms that the `finalizeERC20Withdrawal` function reverts when the bridge is
     ///         paused.
     function test_paused_finalizeERC20Withdrawal_reverts() external {
-        _setupPausedBridge();
+        _pauseBridge();
 
         vm.prank(address(l1StandardBridge.messenger()));
         vm.expectRevert("StandardBridge: paused");
@@ -305,7 +334,7 @@ contract L1StandardBridge_Paused_Test is CommonTest {
 
     /// @notice Confirms that the `finalizeBridgeERC20` function reverts when the bridge is paused.
     function test_paused_finalizeBridgeERC20_reverts() external {
-        _setupPausedBridge();
+        _pauseBridge();
 
         vm.prank(address(l1StandardBridge.messenger()));
         vm.expectRevert("StandardBridge: paused");
@@ -322,7 +351,7 @@ contract L1StandardBridge_Paused_Test is CommonTest {
 
 /// @title L1StandardBridge_Receive_Test
 /// @notice Tests the `receive` function of the `L1StandardBridge` contract.
-contract L1StandardBridge_Receive_Test is CommonTest {
+contract L1StandardBridge_Receive_Test is L1StandardBridge_TestInit {
     /// @notice Tests receive bridges ETH successfully.
     function test_receive_succeeds() external {
         skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
@@ -350,14 +379,9 @@ contract L1StandardBridge_Receive_Test is CommonTest {
 
         vm.prank(alice, alice);
         (bool success,) = address(l1StandardBridge).call{ value: 100 }(hex"");
-        assertEq(success, true);
+        assertTrue(success);
 
-        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore);
-            assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 100);
-        } else {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore + 100);
-        }
+        _assertETHBridgeCustody(portalBalanceBefore, ethLockboxBalanceBefore, 100);
     }
 
     /// @notice Verifies receive function reverts when called by contracts
@@ -365,7 +389,7 @@ contract L1StandardBridge_Receive_Test is CommonTest {
         vm.etch(alice, hex"ffff");
         vm.deal(alice, 100);
         vm.prank(alice);
-        vm.expectRevert(bytes("StandardBridge: function can only be called from an EOA"));
+        vm.expectRevert("StandardBridge: function can only be called from an EOA");
         (bool revertsAsExpected,) = address(l1StandardBridge).call{ value: 100 }(hex"");
         assertTrue(revertsAsExpected, "expectRevert: call did not revert");
     }
@@ -386,31 +410,21 @@ contract L1StandardBridge_DepositETH_Test is L1StandardBridge_TestInit {
         uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
         l1StandardBridge.depositETH{ value: 500 }(50000, hex"dead");
 
-        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore);
-            assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 500);
-        } else {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore + 500);
-        }
+        _assertETHBridgeCustody(portalBalanceBefore, ethLockboxBalanceBefore, 500);
     }
 
     /// @notice Tests that depositing ETH succeeds for an EOA using 7702 delegation.
     function test_depositETH_fromEOA7702_succeeds() external {
         skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
-        // Set alice to have 7702 code.
-        vm.etch(alice, abi.encodePacked(hex"EF0100", address(0)));
+        // EIP-7702 treats address(0) as revocation, so use a non-zero delegation target.
+        vm.etch(alice, abi.encodePacked(hex"EF0100", address(1)));
 
         _preBridgeETH({ isLegacy: true, value: 500 });
         uint256 portalBalanceBefore = address(optimismPortal2).balance;
         uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
         l1StandardBridge.depositETH{ value: 500 }(50000, hex"dead");
 
-        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore);
-            assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 500);
-        } else {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore + 500);
-        }
+        _assertETHBridgeCustody(portalBalanceBefore, ethLockboxBalanceBefore, 500);
     }
 
     /// @notice Tests that depositing ETH reverts if the call is not from an EOA.
@@ -437,12 +451,7 @@ contract L1StandardBridge_DepositETHTo_Test is L1StandardBridge_TestInit {
         uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
         l1StandardBridge.depositETHTo{ value: 600 }(bob, 60000, hex"dead");
 
-        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore);
-            assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 600);
-        } else {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore + 600);
-        }
+        _assertETHBridgeCustody(portalBalanceBefore, ethLockboxBalanceBefore, 600);
     }
 
     /// @notice Verifies depositETHTo succeeds with various recipients and amounts
@@ -461,25 +470,13 @@ contract L1StandardBridge_DepositETHTo_Test is L1StandardBridge_TestInit {
         vm.prank(alice);
         l1StandardBridge.depositETHTo{ value: _amount }(_to, 60000, hex"dead");
 
-        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
-            assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + _amount);
-        } else {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore + _amount);
-        }
+        _assertETHBridgeCustody(portalBalanceBefore, ethLockboxBalanceBefore, _amount);
     }
 }
 
 /// @title L1StandardBridge_DepositERC20_Test
 /// @notice Tests the `depositERC20` function of the `L1StandardBridge` contract.
 contract L1StandardBridge_DepositERC20_Test is CommonTest {
-    using stdStorage for StdStorage;
-
-    // depositERC20
-    // - updates bridge.deposits
-    // - emits ERC20DepositInitiated
-    // - calls optimismPortal.depositTransaction
-    // - only callable by EOA
-
     /// @notice Tests that depositing ERC20 to the bridge succeeds.
     ///         Bridge deposits are updated.
     ///         Emits ERC20DepositInitiated event.
@@ -487,13 +484,11 @@ contract L1StandardBridge_DepositERC20_Test is CommonTest {
     ///         Only EOA can call depositERC20.
     function test_depositERC20_succeeds() external {
         uint256 nonce = l1CrossDomainMessenger.messageNonce();
-        uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
         address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
 
-        // Deal Alice's ERC20 State
-        deal(address(L1Token), alice, 100000, true);
+        deal(address(L1Token), alice, 100000);
         vm.prank(alice);
-        L1Token.approve(address(l1StandardBridge), type(uint256).max);
+        L1Token.approve(address(l1StandardBridge), 100);
 
         // The l1StandardBridge should transfer alice's tokens to itself
         vm.expectCall(address(L1Token), abi.encodeCall(ERC20.transferFrom, (alice, address(l1StandardBridge), 100)));
@@ -521,24 +516,20 @@ contract L1StandardBridge_DepositERC20_Test is CommonTest {
             )
         );
 
-        bytes memory opaqueData = abi.encodePacked(uint256(0), uint256(0), baseGas, false, innerMessage);
-
-        // Should emit both the bedrock and legacy events
         vm.expectEmit(address(l1StandardBridge));
         emit ERC20DepositInitiated(address(L1Token), address(L2Token), alice, alice, 100, hex"");
 
         vm.expectEmit(address(l1StandardBridge));
         emit ERC20BridgeInitiated(address(L1Token), address(L2Token), alice, alice, 100, hex"");
 
-        // OptimismPortal emits a TransactionDeposited event on `depositTransaction` call
         vm.expectEmit(address(optimismPortal2));
-        emit TransactionDeposited(l1MessengerAliased, address(l2CrossDomainMessenger), version, opaqueData);
+        emitTransactionDeposited(
+            l1MessengerAliased, address(l2CrossDomainMessenger), 0, 0, baseGas, false, innerMessage
+        );
 
-        // SentMessage event emitted by the CrossDomainMessenger
         vm.expectEmit(address(l1CrossDomainMessenger));
         emit SentMessage(address(l2StandardBridge), address(l1StandardBridge), message, nonce, 10000);
 
-        // SentMessageExtension1 event emitted by the CrossDomainMessenger
         vm.expectEmit(address(l1CrossDomainMessenger));
         emit SentMessageExtension1(address(l1StandardBridge), 0);
 
@@ -564,7 +555,7 @@ contract L1StandardBridge_DepositERC20_Test is CommonTest {
         _amount = bound(_amount, 1, 1000000);
         _gasLimit = uint32(bound(uint256(_gasLimit), 21000, 10000000));
 
-        deal(address(L1Token), alice, _amount, true);
+        deal(address(L1Token), alice, _amount);
         vm.prank(alice);
         L1Token.approve(address(l1StandardBridge), _amount);
 
@@ -584,7 +575,6 @@ contract L1StandardBridge_DepositERC20To_Test is CommonTest {
     ///         Contracts can call depositERC20.
     function test_depositERC20To_succeeds() external {
         uint256 nonce = l1CrossDomainMessenger.messageNonce();
-        uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
         address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
 
         bytes memory message = abi.encodeCall(
@@ -597,29 +587,25 @@ contract L1StandardBridge_DepositERC20To_Test is CommonTest {
         );
 
         uint64 baseGas = l1CrossDomainMessenger.baseGas(message, 10000);
-        bytes memory opaqueData = abi.encodePacked(uint256(0), uint256(0), baseGas, false, innerMessage);
-
-        deal(address(L1Token), alice, 100000, true);
+        deal(address(L1Token), alice, 100000);
 
         vm.prank(alice);
-        L1Token.approve(address(l1StandardBridge), type(uint256).max);
+        L1Token.approve(address(l1StandardBridge), 1000);
 
-        // Should emit both the bedrock and legacy events
         vm.expectEmit(address(l1StandardBridge));
         emit ERC20DepositInitiated(address(L1Token), address(L2Token), alice, bob, 1000, hex"");
 
         vm.expectEmit(address(l1StandardBridge));
         emit ERC20BridgeInitiated(address(L1Token), address(L2Token), alice, bob, 1000, hex"");
 
-        // OptimismPortal emits a TransactionDeposited event on `depositTransaction` call
         vm.expectEmit(address(optimismPortal2));
-        emit TransactionDeposited(l1MessengerAliased, address(l2CrossDomainMessenger), version, opaqueData);
+        emitTransactionDeposited(
+            l1MessengerAliased, address(l2CrossDomainMessenger), 0, 0, baseGas, false, innerMessage
+        );
 
-        // SentMessage event emitted by the CrossDomainMessenger
         vm.expectEmit(address(l1CrossDomainMessenger));
         emit SentMessage(address(l2StandardBridge), address(l1StandardBridge), message, nonce, 10000);
 
-        // SentMessageExtension1 event emitted by the CrossDomainMessenger
         vm.expectEmit(address(l1CrossDomainMessenger));
         emit SentMessageExtension1(address(l1StandardBridge), 0);
 
@@ -645,10 +631,6 @@ contract L1StandardBridge_DepositERC20To_Test is CommonTest {
 
     /// @notice Verifies depositERC20To succeeds with zero amount
     function test_depositERC20To_zeroAmount_succeeds() external {
-        deal(address(L1Token), alice, 1000, true);
-        vm.prank(alice);
-        L1Token.approve(address(l1StandardBridge), 0);
-
         vm.prank(alice);
         l1StandardBridge.depositERC20To(address(L1Token), address(L2Token), bob, 0, 10000, hex"");
         assertEq(l1StandardBridge.deposits(address(L1Token), address(L2Token)), 0);
@@ -657,9 +639,7 @@ contract L1StandardBridge_DepositERC20To_Test is CommonTest {
 
 /// @title L1StandardBridge_FinalizeETHWithdrawal_Test
 /// @notice Tests the `finalizeETHWithdrawal` function of the `L1StandardBridge` contract.
-contract L1StandardBridge_FinalizeETHWithdrawal_Test is CommonTest {
-    using stdStorage for StdStorage;
-
+contract L1StandardBridge_FinalizeETHWithdrawal_Test is L1StandardBridge_TestInit {
     /// @notice Tests that finalizing an ETH withdrawal succeeds.
     ///         Emits ETHWithdrawalFinalized event.
     ///         Only callable by the L2 bridge.
@@ -674,14 +654,8 @@ contract L1StandardBridge_FinalizeETHWithdrawal_Test is CommonTest {
 
         vm.expectCall(alice, hex"");
 
-        vm.mockCall(
-            address(l1StandardBridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
-        // ensure that the messenger has ETH to call with
-        vm.deal(address(l1StandardBridge.messenger()), 100);
-        vm.prank(address(l1StandardBridge.messenger()));
+        address messenger = _setupFinalizeBridgeETH();
+        vm.prank(messenger);
         l1StandardBridge.finalizeETHWithdrawal{ value: 100 }(alice, alice, 100, hex"");
 
         assertEq(address(l1StandardBridge.messenger()).balance, 0);
@@ -691,21 +665,19 @@ contract L1StandardBridge_FinalizeETHWithdrawal_Test is CommonTest {
 
 /// @title L1StandardBridge_FinalizeERC20Withdrawal_Test
 /// @notice Tests the `finalizeERC20Withdrawal` function of the `L1StandardBridge` contract.
-contract L1StandardBridge_FinalizeERC20Withdrawal_Test is CommonTest {
-    using stdStorage for StdStorage;
-
+contract L1StandardBridge_FinalizeERC20Withdrawal_Test is L1StandardBridge_TestInit {
     /// @notice Tests that finalizing an ERC20 withdrawal succeeds.
     ///         Bridge deposits are updated.
     ///         Emits ERC20WithdrawalFinalized event.
     ///         Only callable by the L2 bridge.
     function test_finalizeERC20Withdrawal_succeeds() external {
-        deal(address(L1Token), address(l1StandardBridge), 100, true);
+        deal(address(L1Token), address(l1StandardBridge), 100);
 
-        uint256 slot = stdstore.target(address(l1StandardBridge)).sig("deposits(address,address)")
-            .with_key(address(L1Token)).with_key(address(L2Token)).find();
+        StorageSlot memory depositsSlot = ForgeArtifacts.getSlot("L1StandardBridge", "deposits");
+        bytes32 localTokenDepositsSlot = keccak256(abi.encode(address(L1Token), uint256(depositsSlot.slot)));
+        bytes32 depositSlot = keccak256(abi.encode(address(L2Token), localTokenDepositsSlot));
 
-        // Give the L1 bridge some ERC20 tokens
-        vm.store(address(l1StandardBridge), bytes32(slot), bytes32(uint256(100)));
+        vm.store(address(l1StandardBridge), depositSlot, bytes32(uint256(100)));
         assertEq(l1StandardBridge.deposits(address(L1Token), address(L2Token)), 100);
 
         vm.expectEmit(address(l1StandardBridge));
@@ -716,11 +688,7 @@ contract L1StandardBridge_FinalizeERC20Withdrawal_Test is CommonTest {
 
         vm.expectCall(address(L1Token), abi.encodeCall(ERC20.transfer, (alice, 100)));
 
-        vm.mockCall(
-            address(l1StandardBridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
+        _mockOtherBridge();
         vm.prank(address(l1StandardBridge.messenger()));
         l1StandardBridge.finalizeERC20Withdrawal(address(L1Token), address(L2Token), alice, alice, 100, hex"");
 
@@ -733,11 +701,6 @@ contract L1StandardBridge_FinalizeERC20Withdrawal_Test is CommonTest {
     function testFuzz_finalizeERC20Withdrawal_notMessenger_reverts(address _caller) external {
         vm.assume(_caller != address(l1StandardBridge.messenger()));
 
-        vm.mockCall(
-            address(l1StandardBridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
         vm.expectRevert("StandardBridge: function can only be called from the other bridge");
         vm.prank(_caller);
         l1StandardBridge.finalizeERC20Withdrawal(address(L1Token), address(L2Token), alice, alice, 100, hex"");
@@ -746,11 +709,7 @@ contract L1StandardBridge_FinalizeERC20Withdrawal_Test is CommonTest {
     /// @notice Tests that finalizing an ERC20 withdrawal reverts if the caller is not the L2
     ///         bridge.
     function test_finalizeERC20Withdrawal_notOtherBridge_reverts() external {
-        vm.mockCall(
-            address(l1StandardBridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(0))
-        );
+        _mockXDomainMessageSender(address(0));
         vm.prank(address(l1StandardBridge.messenger()));
         vm.expectRevert("StandardBridge: function can only be called from the other bridge");
         l1StandardBridge.finalizeERC20Withdrawal(address(L1Token), address(L2Token), alice, alice, 100, hex"");
@@ -763,12 +722,12 @@ contract L1StandardBridge_FinalizeERC20Withdrawal_Test is CommonTest {
 contract L1StandardBridge_Uncategorized_Test is L1StandardBridge_TestInit {
     /// @notice Test that the accessors return the correct initialized values.
     function test_getters_succeeds() external view {
-        assert(l1StandardBridge.l2TokenBridge() == address(l2StandardBridge));
-        assert(address(l1StandardBridge.OTHER_BRIDGE()) == address(l2StandardBridge));
-        assert(address(l1StandardBridge.messenger()) == address(l1CrossDomainMessenger));
-        assert(address(l1StandardBridge.MESSENGER()) == address(l1CrossDomainMessenger));
-        assert(l1StandardBridge.systemConfig() == systemConfig);
-        assert(l1StandardBridge.superchainConfig() == systemConfig.superchainConfig());
+        assertEq(l1StandardBridge.l2TokenBridge(), address(l2StandardBridge));
+        assertEq(address(l1StandardBridge.OTHER_BRIDGE()), address(l2StandardBridge));
+        assertEq(address(l1StandardBridge.messenger()), address(l1CrossDomainMessenger));
+        assertEq(address(l1StandardBridge.MESSENGER()), address(l1CrossDomainMessenger));
+        assertEq(address(l1StandardBridge.systemConfig()), address(systemConfig));
+        assertEq(address(l1StandardBridge.superchainConfig()), address(systemConfig.superchainConfig()));
     }
 
     /// @notice Tests that bridging ETH succeeds.
@@ -783,12 +742,7 @@ contract L1StandardBridge_Uncategorized_Test is L1StandardBridge_TestInit {
         uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
         l1StandardBridge.bridgeETH{ value: 500 }(50000, hex"dead");
 
-        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore);
-            assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 500);
-        } else {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore + 500);
-        }
+        _assertETHBridgeCustody(portalBalanceBefore, ethLockboxBalanceBefore, 500);
     }
 
     /// @notice Tests that bridging ETH to a different address succeeds.
@@ -803,23 +757,12 @@ contract L1StandardBridge_Uncategorized_Test is L1StandardBridge_TestInit {
         uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
         l1StandardBridge.bridgeETHTo{ value: 600 }(bob, 60000, hex"dead");
 
-        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore);
-            assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 600);
-        } else {
-            assertEq(address(optimismPortal2).balance, portalBalanceBefore + 600);
-        }
+        _assertETHBridgeCustody(portalBalanceBefore, ethLockboxBalanceBefore, 600);
     }
 
     /// @notice Tests that finalizing bridged ETH succeeds.
     function test_finalizeBridgeETH_succeeds() external {
-        address messenger = address(l1StandardBridge.messenger());
-        vm.mockCall(
-            messenger,
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.deal(messenger, 100);
+        address messenger = _setupFinalizeBridgeETH();
         vm.prank(messenger);
 
         vm.expectEmit(address(l1StandardBridge));
@@ -830,13 +773,7 @@ contract L1StandardBridge_Uncategorized_Test is L1StandardBridge_TestInit {
 
     /// @notice Tests that finalizing bridged ETH reverts if the amount is incorrect.
     function test_finalizeBridgeETH_incorrectValue_reverts() external {
-        address messenger = address(l1StandardBridge.messenger());
-        vm.mockCall(
-            messenger,
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.deal(messenger, 100);
+        address messenger = _setupFinalizeBridgeETH();
         vm.prank(messenger);
         vm.expectRevert("StandardBridge: amount sent does not match amount required");
         l1StandardBridge.finalizeBridgeETH{ value: 50 }(alice, alice, 100, hex"");
@@ -844,13 +781,7 @@ contract L1StandardBridge_Uncategorized_Test is L1StandardBridge_TestInit {
 
     /// @notice Tests that finalizing bridged ETH reverts if the destination is the L1 bridge.
     function test_finalizeBridgeETH_sendToSelf_reverts() external {
-        address messenger = address(l1StandardBridge.messenger());
-        vm.mockCall(
-            messenger,
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.deal(messenger, 100);
+        address messenger = _setupFinalizeBridgeETH();
         vm.prank(messenger);
         vm.expectRevert("StandardBridge: cannot send to self");
         l1StandardBridge.finalizeBridgeETH{ value: 100 }(alice, address(l1StandardBridge), 100, hex"");
@@ -858,13 +789,7 @@ contract L1StandardBridge_Uncategorized_Test is L1StandardBridge_TestInit {
 
     /// @notice Tests that finalizing bridged ETH reverts if the destination is the messenger.
     function test_finalizeBridgeETH_sendToMessenger_reverts() external {
-        address messenger = address(l1StandardBridge.messenger());
-        vm.mockCall(
-            messenger,
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.deal(messenger, 100);
+        address messenger = _setupFinalizeBridgeETH();
         vm.prank(messenger);
         vm.expectRevert("StandardBridge: cannot send to messenger");
         l1StandardBridge.finalizeBridgeETH{ value: 100 }(alice, messenger, 100, hex"");

--- a/test/L1/OptimismPortal2.t.sol
+++ b/test/L1/OptimismPortal2.t.sol
@@ -19,7 +19,6 @@ import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
-import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { Features } from "src/libraries/Features.sol";
 import { AggregateVerifier } from "src/L1/proofs/AggregateVerifier.sol";
 import "src/libraries/bridge/Types.sol";
@@ -31,8 +30,6 @@ import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPort
 import { IAggregateVerifier } from "interfaces/L1/proofs/IAggregateVerifier.sol";
 import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
-import { IAnchorStateRegistry } from "interfaces/L1/proofs/IAnchorStateRegistry.sol";
-import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 import { IVerifier } from "interfaces/L1/proofs/IVerifier.sol";
 
@@ -122,14 +119,10 @@ abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
     }
 
     function _createDisputeGame(Claim _rootClaim, uint256 _salt) internal returns (IAggregateVerifier game_) {
-        bytes memory intermediateRoots;
         AggregateVerifier gameImpl = AggregateVerifier(address(disputeGameFactory.gameImpls(respectedGameType)));
-        for (uint256 i = 1; i < gameImpl.intermediateOutputRootsCount(); i++) {
-            intermediateRoots =
-                abi.encodePacked(intermediateRoots, keccak256(abi.encode(_proposedBlockNumber, i, _salt)));
-        }
-        bytes memory extraData =
-            abi.encodePacked(_proposedBlockNumber, address(anchorStateRegistry), intermediateRoots, _rootClaim.raw());
+        bytes memory intermediateRoots =
+            _generateIntermediateRoots(_rootClaim, _salt, gameImpl.intermediateOutputRootsCount());
+        bytes memory extraData = abi.encodePacked(_proposedBlockNumber, address(anchorStateRegistry), intermediateRoots);
         bytes memory proof = abi.encodePacked(
             uint8(AggregateVerifier.ProofType.TEE), blockhash(block.number - 1), block.number - 1, bytes32(0)
         );
@@ -141,6 +134,97 @@ abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
                     )
                 ))
         );
+    }
+
+    function _generateIntermediateRoots(
+        Claim _rootClaim,
+        uint256 _salt,
+        uint256 _intermediateRootsCount
+    )
+        private
+        view
+        returns (bytes memory)
+    {
+        bytes32[] memory intermediateRoots = new bytes32[](_intermediateRootsCount);
+        for (uint256 i = 1; i < _intermediateRootsCount; i++) {
+            intermediateRoots[i - 1] = keccak256(abi.encode(_proposedBlockNumber, i, _salt));
+        }
+        intermediateRoots[_intermediateRootsCount - 1] = _rootClaim.raw();
+
+        return abi.encodePacked(intermediateRoots);
+    }
+
+    function _expectWithdrawalProven(bytes32 _withdrawalHash_, address _proofSubmitter) internal {
+        vm.expectEmit(true, true, true, true, address(optimismPortal2));
+        emit WithdrawalProven(_withdrawalHash_, alice, bob);
+        vm.expectEmit(true, true, true, true, address(optimismPortal2));
+        emit WithdrawalProvenExtension1(_withdrawalHash_, _proofSubmitter);
+    }
+
+    function _proveDefaultWithdrawal() internal {
+        _expectWithdrawalProven(_withdrawalHash, address(this));
+        optimismPortal2.proveWithdrawalTransaction({
+            _tx: _defaultTx,
+            _disputeGameIndex: _proposedGameIndex,
+            _outputRootProof: _outputRootProof,
+            _withdrawalProof: _withdrawalProof
+        });
+    }
+
+    function _resolveGameAndWarpPastProofMaturity(IDisputeGame _game) internal {
+        _game.resolve();
+        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1 seconds);
+    }
+
+    function _proveFuzzedWithdrawal(
+        address _sender,
+        address _target,
+        uint256 _value,
+        uint256 _gasLimit,
+        bytes memory _data
+    )
+        internal
+        returns (Types.WithdrawalTransaction memory withdrawalTx_, bytes32 withdrawalHash_)
+    {
+        uint256 value = bound(_value, 0, 200_000_000 ether);
+        vm.deal(address(optimismPortal2), value);
+        if (isUsingLockbox()) {
+            vm.deal(address(ethLockbox), value);
+        }
+
+        uint256 gasLimit = bound(_gasLimit, 0, 50_000_000);
+        withdrawalTx_ = Types.WithdrawalTransaction({
+            nonce: l2ToL1MessagePasser.messageNonce(),
+            sender: _sender,
+            target: _target,
+            value: value,
+            gasLimit: gasLimit,
+            data: _data
+        });
+
+        (
+            bytes32 stateRoot,
+            bytes32 storageRoot,
+            bytes32 outputRoot,
+            bytes32 withdrawalHash,
+            bytes[] memory withdrawalProof
+        ) = ffi.getProveWithdrawalTransactionInputs(withdrawalTx_);
+        withdrawalHash_ = withdrawalHash;
+
+        Types.OutputRootProof memory proof = Types.OutputRootProof({
+            version: bytes32(uint256(0)),
+            stateRoot: stateRoot,
+            messagePasserStorageRoot: storageRoot,
+            latestBlockhash: bytes32(uint256(0))
+        });
+
+        assertEq(outputRoot, Hashing.hashOutputRootProof(proof));
+        assertEq(withdrawalHash_, Hashing.hashWithdrawal(withdrawalTx_));
+
+        vm.mockCall(address(game), abi.encodeCall(game.rootClaim, ()), abi.encode(outputRoot));
+        optimismPortal2.proveWithdrawalTransaction(withdrawalTx_, _proposedGameIndex, proof, withdrawalProof);
+        (IDisputeGame provenGame,) = optimismPortal2.provenWithdrawals(withdrawalHash_, address(this));
+        assertTrue(provenGame.rootClaim().raw() != bytes32(0));
     }
 
     /// @notice Asserts that the reentrant call will revert.
@@ -157,14 +241,14 @@ abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
 
     /// @notice Checks if the ETHLockbox feature is enabled.
     /// @return bool True if the ETHLockbox feature is enabled.
-    function isUsingLockbox() public view returns (bool) {
+    function isUsingLockbox() internal view returns (bool) {
         return
             systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX) && address(optimismPortal2.ethLockbox()) != address(0);
     }
 
     /// @notice Enables the ETHLockbox feature if not enabled.
     /// @param _lockbox Address of the lockbox to enable.
-    function forceEnableLockbox(address _lockbox) public {
+    function forceEnableLockbox(address _lockbox) internal {
         if (!isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
             vm.prank(address(proxyAdmin));
             systemConfig.setFeature(Features.ETH_LOCKBOX, true);
@@ -200,7 +284,6 @@ contract OptimismPortal2_Constructor_Test is OptimismPortal2_TestInit {
         assertEq(address(opImpl.anchorStateRegistry()), address(0));
         assertEq(address(opImpl.systemConfig()), address(0));
         assertEq(opImpl.l2Sender(), address(0));
-        assertEq(address(opImpl.anchorStateRegistry()), address(0));
         assertEq(address(opImpl.ethLockbox()), address(0));
     }
 }
@@ -430,13 +513,7 @@ contract OptimismPortal2_NumProofSubmitters_Test is OptimismPortal2_TestInit {
     function test_numProofSubmitters_provenWithdrawal_succeeds() external {
         bytes32 withdrawalHash = Hashing.hashWithdrawal(_defaultTx);
 
-        // Prove the withdrawal
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         assertEq(optimismPortal2.numProofSubmitters(withdrawalHash), 1);
     }
@@ -446,13 +523,7 @@ contract OptimismPortal2_NumProofSubmitters_Test is OptimismPortal2_TestInit {
         vm.assume(_prover != address(0) && _prover != address(this));
         bytes32 withdrawalHash = Hashing.hashWithdrawal(_defaultTx);
 
-        // First proof by this contract
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Second proof by different prover
         vm.prank(_prover);
@@ -565,10 +636,8 @@ contract OptimismPortal2_DonateETH_Test is OptimismPortal2_TestInit {
         optimismPortal2.donateETH{ value: _amount }();
         VmSafe.AccountAccess[] memory accountAccesses = vm.stopAndReturnStateDiff();
 
-        // not necessary since it's checked below
         assertEq(address(optimismPortal2).balance, preBalance + _amount);
 
-        // check that the ETHLockbox balance is unchanged
         assertEq(address(ethLockbox).balance, lockboxBalanceBefore);
 
         // 0 for extcodesize of proxy before being called by this test,
@@ -578,28 +647,13 @@ contract OptimismPortal2_DonateETH_Test is OptimismPortal2_TestInit {
         assertEq(uint8(accountAccesses[1].kind), uint8(VmSafe.AccountAccessKind.Call));
         assertEq(uint8(accountAccesses[2].kind), uint8(VmSafe.AccountAccessKind.DelegateCall));
 
-        // to of 1 is the optimism portal proxy
         assertEq(accountAccesses[1].account, address(optimismPortal2));
-
-        // accessor is the pranked address
         assertEq(accountAccesses[1].accessor, alice);
-
-        // value is the amount of ETH donated
         assertEq(accountAccesses[1].value, _amount);
-
-        // old balance is the balance of the optimism portal before the donation
         assertEq(accountAccesses[1].oldBalance, preBalance);
-
-        // new balance is the balance of the optimism portal after the donation
         assertEq(accountAccesses[1].newBalance, preBalance + _amount);
-
-        // data is the selector of the donateETH function
         assertEq(accountAccesses[1].data, abi.encodePacked(optimismPortal2.donateETH.selector));
-
-        // reverted of alice call to proxy is false
         assertEq(accountAccesses[1].reverted, false);
-
-        // reverted of delegate call of proxy to impl is false
         assertEq(accountAccesses[2].reverted, false);
 
         // storage accesses of delegate call of proxy to impl is empty (No storage read or write!)
@@ -698,22 +752,13 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
     /// @notice Tests that `proveWithdrawalTransaction` reverts when the withdrawal has already
     ///         been proven, and the new game has the `CHALLENGER_WINS` status.
     function test_proveWithdrawalTransaction_replayProveDifferentGameChallengerWins_reverts() external {
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Create a new dispute game, and mock both games to be CHALLENGER_WINS.
         IDisputeGame game2 = _createDisputeGame(Claim.wrap(_outputRoot), 1);
         _proposedGameIndex = disputeGameFactory.gameCount() - 1;
         vm.mockCall(address(game), abi.encodeCall(game.status, ()), abi.encode(GameStatus.CHALLENGER_WINS));
-        vm.mockCall(address(game2), abi.encodeCall(game.status, ()), abi.encode(GameStatus.CHALLENGER_WINS));
+        vm.mockCall(address(game2), abi.encodeCall(game2.status, ()), abi.encode(GameStatus.CHALLENGER_WINS));
 
         vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidDisputeGame.selector);
         optimismPortal2.proveWithdrawalTransaction({
@@ -741,7 +786,7 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
     ///         does not implement `wasRespectedGameTypeWhenCreated`.
     function test_proveWithdrawalTransaction_legacyGame_reverts() external {
         vm.mockCallRevert(address(game), abi.encodeCall(game.wasRespectedGameTypeWhenCreated, ()), "");
-        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
+        vm.expectRevert(bytes(""));
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
             _disputeGameIndex: _proposedGameIndex,
@@ -783,16 +828,7 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
     /// @notice Tests that `proveWithdrawalTransaction` can be re-executed if the dispute game
     ///         proven against has resolved against the favor of the root claim.
     function test_proveWithdrawalTransaction_replayProveBadProposal_succeeds() external {
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Mock the status of the dispute game we just proved against to be CHALLENGER_WINS.
         vm.mockCall(address(game), abi.encodeCall(game.status, ()), abi.encode(GameStatus.CHALLENGER_WINS));
@@ -804,32 +840,14 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
         // Warp 1 second into the future so we're not in the same block as the dispute game.
         vm.warp(block.timestamp + 1 seconds);
 
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
     }
 
     /// @notice Tests that `proveWithdrawalTransaction` can be re-executed if the dispute game
     ///         proven against is no longer of the respected game type.
     function test_proveWithdrawalTransaction_replayRespectedGameTypeChanged_succeeds() external {
         // Prove the withdrawal against a game with the current respected game type.
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Create a new game.
         IDisputeGame newGame = _createDisputeGame(Claim.wrap(_outputRoot), 1);
@@ -849,10 +867,7 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
         vm.warp(block.timestamp + 1 seconds);
 
         // Re-proving should be successful against the new game.
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
+        _expectWithdrawalProven(_withdrawalHash, address(this));
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
             _disputeGameIndex: _proposedGameIndex + 1,
@@ -863,16 +878,7 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
 
     /// @notice Tests that `proveWithdrawalTransaction` succeeds.
     function test_proveWithdrawalTransaction_validWithdrawalProof_succeeds() external {
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
     }
 }
 
@@ -903,9 +909,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
         emit WithdrawalProven(_withdrawalHash, alice, bob);
         optimismPortal2.proveWithdrawalTransaction(_defaultTx, _proposedGameIndex, _outputRootProof, _withdrawalProof);
 
-        // Warp and resolve the dispute game.
-        game.resolve();
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1 seconds);
+        _resolveGameAndWarpPastProofMaturity(game);
 
         vm.startPrank(alice, Constants.ESTIMATION_ADDRESS);
         vm.expectRevert(IOptimismPortal.OptimismPortal_GasEstimation.selector);
@@ -918,30 +922,28 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
 
         // Get withdrawal proof data we can use for testing.
         (
-            bytes32 _stateRoot_noData,
-            bytes32 _storageRoot_noData,
-            bytes32 _outputRoot_noData,
-            bytes32 _withdrawalHash_noData,
-            bytes[] memory _withdrawalProof_noData
+            bytes32 stateRootNoData,
+            bytes32 storageRootNoData,
+            bytes32 outputRootNoData,
+            bytes32 withdrawalHashNoData,
+            bytes[] memory withdrawalProofNoData
         ) = ffi.getProveWithdrawalTransactionInputs(_defaultTx);
 
         // Setup a dummy output root proof for reuse.
-        Types.OutputRootProof memory _outputRootProof_noData = Types.OutputRootProof({
+        Types.OutputRootProof memory outputRootProofNoData = Types.OutputRootProof({
             version: bytes32(uint256(0)),
-            stateRoot: _stateRoot_noData,
-            messagePasserStorageRoot: _storageRoot_noData,
+            stateRoot: stateRootNoData,
+            messagePasserStorageRoot: storageRootNoData,
             latestBlockhash: bytes32(uint256(0))
         });
 
-        IAggregateVerifier game_noData = _createDisputeGame(Claim.wrap(_outputRoot_noData), 0);
+        IAggregateVerifier gameNoData = _createDisputeGame(Claim.wrap(outputRootNoData), 0);
 
-        uint256 _proposedGameIndex_noData = disputeGameFactory.gameCount() - 1;
+        uint256 proposedGameIndexNoData = disputeGameFactory.gameCount() - 1;
 
         // Warp beyond the resolution delay.
-        vm.warp(game_noData.expectedResolution().raw() + 1 seconds);
+        vm.warp(gameNoData.expectedResolution().raw() + 1 seconds);
 
-        // Fund the portal so that we can withdraw ETH.
-        vm.store(address(optimismPortal2), bytes32(uint256(61)), bytes32(uint256(0xFFFFFFFF)));
         vm.deal(address(optimismPortal2), 0xFFFFFFFF);
         if (isUsingLockbox()) {
             vm.deal(address(ethLockbox), 0xFFFFFFFF);
@@ -949,23 +951,18 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
 
         uint256 bobBalanceBefore = bob.balance;
 
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProven(_withdrawalHash_noData, alice, bob);
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProvenExtension1(_withdrawalHash_noData, address(this));
+        _expectWithdrawalProven(withdrawalHashNoData, address(this));
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex_noData,
-            _outputRootProof: _outputRootProof_noData,
-            _withdrawalProof: _withdrawalProof_noData
+            _disputeGameIndex: proposedGameIndexNoData,
+            _outputRootProof: outputRootProofNoData,
+            _withdrawalProof: withdrawalProofNoData
         });
 
-        // Warp and resolve the dispute game.
-        game_noData.resolve();
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1 seconds);
+        _resolveGameAndWarpPastProofMaturity(gameNoData);
 
         vm.expectEmit(true, true, false, true);
-        emit WithdrawalFinalized(_withdrawalHash_noData, true);
+        emit WithdrawalFinalized(withdrawalHashNoData, true);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
         assert(bob.balance == bobBalanceBefore + _defaultTx.value);
@@ -975,20 +972,9 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
     function test_finalizeWithdrawalTransaction_provenWithdrawalHashEther_succeeds() external {
         uint256 bobBalanceBefore = address(bob).balance;
 
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
-        // Warp and resolve the dispute game.
-        game.resolve();
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1 seconds);
+        _resolveGameAndWarpPastProofMaturity(game);
 
         vm.expectEmit(true, true, false, true);
         emit WithdrawalFinalized(_withdrawalHash, true);
@@ -1009,10 +995,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
         vm.warp(block.timestamp + 1);
 
         // Prove the withdrawal transaction against the invalid dispute game, as 0xb0b.
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(0xb0b));
+        _expectWithdrawalProven(_withdrawalHash, address(0xb0b));
         vm.prank(address(0xb0b));
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
@@ -1022,24 +1005,13 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
         });
 
         // Mock the status of the dispute game 0xb0b proves against to be CHALLENGER_WINS.
-        vm.mockCall(address(secondGame), abi.encodeCall(game.status, ()), abi.encode(GameStatus.CHALLENGER_WINS));
+        vm.mockCall(address(secondGame), abi.encodeCall(secondGame.status, ()), abi.encode(GameStatus.CHALLENGER_WINS));
 
         // Prove the withdrawal transaction against the invalid dispute game, as the test contract, against the original
         // game.
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
-        // Warp and resolve the original dispute game.
-        game.resolve();
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1 seconds);
+        _resolveGameAndWarpPastProofMaturity(game);
 
         // Ensure both proofs are registered successfully.
         assertEq(optimismPortal2.numProofSubmitters(_withdrawalHash), 2);
@@ -1080,16 +1052,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
     function test_finalizeWithdrawalTransaction_ifWithdrawalProofNotOldEnough_reverts() external {
         uint256 bobBalanceBefore = address(bob).balance;
 
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         vm.expectRevert(IOptimismPortal.OptimismPortal_ProofNotOldEnough.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
@@ -1103,16 +1066,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
         uint256 bobBalanceBefore = address(bob).balance;
 
         // Prove our withdrawal
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Warp to after the finalization period
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
@@ -1134,16 +1088,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
         uint256 bobBalanceBefore = address(bob).balance;
 
         // Prove our withdrawal
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Warp to after the finalization period
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
@@ -1165,21 +1110,9 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
         uint256 bobBalanceBefore = address(bob).balance;
         vm.etch(bob, hex"fe"); // Contract with just the invalid opcode.
 
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
-        // Resolve the dispute game.
-        game.resolve();
-
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
+        _resolveGameAndWarpPastProofMaturity(game);
         vm.expectEmit(true, true, true, true);
         emit WithdrawalFinalized(_withdrawalHash, false);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
@@ -1205,21 +1138,9 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
         uint256 bobBalanceBefore = address(bob).balance;
         vm.etch(bob, hex"fe"); // Contract with just the invalid opcode.
 
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
-        // Resolve the dispute game.
-        game.resolve();
-
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
+        _resolveGameAndWarpPastProofMaturity(game);
         vm.expectEmit(true, true, true, true);
         emit WithdrawalFinalized(_withdrawalHash, false);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
@@ -1234,21 +1155,9 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
     /// @notice Tests that `finalizeWithdrawalTransaction` reverts if the withdrawal has already
     ///         been finalized.
     function test_finalizeWithdrawalTransaction_onReplay_reverts() external {
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
-        // Resolve the dispute game.
-        game.resolve();
-
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
+        _resolveGameAndWarpPastProofMaturity(game);
         vm.expectEmit(true, true, true, true);
         emit WithdrawalFinalized(_withdrawalHash, true);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
@@ -1285,10 +1194,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
             _withdrawalProof: withdrawalProof
         });
 
-        // Resolve the dispute game.
-        game.resolve();
-
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
+        _resolveGameAndWarpPastProofMaturity(game);
         vm.expectRevert("SafeCall: Not enough gas");
         optimismPortal2.finalizeWithdrawalTransaction{ gas: _defaultTx.gasLimit }(_defaultTx);
     }
@@ -1328,10 +1234,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
         emit WithdrawalProvenExtension1(withdrawalHash, address(this));
         optimismPortal2.proveWithdrawalTransaction(_testTx, _proposedGameIndex, outputRootProof, withdrawalProof);
 
-        // Resolve the dispute game.
-        game.resolve();
-
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
+        _resolveGameAndWarpPastProofMaturity(game);
         vm.expectCall(address(this), _testTx.data);
         vm.expectEmit(true, true, true, true);
         emit WithdrawalFinalized(withdrawalHash, true);
@@ -1360,57 +1263,13 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
                 && uint160(_target) > 9 // No precompiles (or zero address)
         );
 
-        // Total ETH supply is currently about 120M ETH.
-        uint256 value = bound(_value, 0, 200_000_000 ether);
-        vm.deal(address(optimismPortal2), value);
-        if (isUsingLockbox()) {
-            vm.deal(address(ethLockbox), value);
-        }
+        (Types.WithdrawalTransaction memory withdrawalTx, bytes32 withdrawalHash) =
+            _proveFuzzedWithdrawal(_sender, _target, _value, _gasLimit, _data);
 
-        uint256 gasLimit = bound(_gasLimit, 0, 50_000_000);
-        uint256 nonce = l2ToL1MessagePasser.messageNonce();
+        _resolveGameAndWarpPastProofMaturity(game);
 
-        // Get a withdrawal transaction and mock proof from the differential testing script.
-        Types.WithdrawalTransaction memory _tx = Types.WithdrawalTransaction({
-            nonce: nonce, sender: _sender, target: _target, value: value, gasLimit: gasLimit, data: _data
-        });
-        (
-            bytes32 stateRoot,
-            bytes32 storageRoot,
-            bytes32 outputRoot,
-            bytes32 withdrawalHash,
-            bytes[] memory withdrawalProof
-        ) = ffi.getProveWithdrawalTransactionInputs(_tx);
-
-        // Create the output root proof
-        Types.OutputRootProof memory proof = Types.OutputRootProof({
-            version: bytes32(uint256(0)),
-            stateRoot: stateRoot,
-            messagePasserStorageRoot: storageRoot,
-            latestBlockhash: bytes32(uint256(0))
-        });
-
-        // Ensure the values returned from ffi are correct
-        assertEq(outputRoot, Hashing.hashOutputRootProof(proof));
-        assertEq(withdrawalHash, Hashing.hashWithdrawal(_tx));
-
-        // Setup the dispute game to return the output root
-        vm.mockCall(address(game), abi.encodeCall(game.rootClaim, ()), abi.encode(outputRoot));
-
-        // Prove the withdrawal transaction
-        optimismPortal2.proveWithdrawalTransaction(_tx, _proposedGameIndex, proof, withdrawalProof);
-        (IDisputeGame _game,) = optimismPortal2.provenWithdrawals(withdrawalHash, address(this));
-        assertTrue(_game.rootClaim().raw() != bytes32(0));
-
-        // Resolve the dispute game
-        game.resolve();
-
-        // Warp past the finalization period
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
-
-        // Finalize the withdrawal transaction
-        vm.expectCallMinGas(_tx.target, _tx.value, uint64(_tx.gasLimit), _tx.data);
-        optimismPortal2.finalizeWithdrawalTransaction(_tx);
+        vm.expectCallMinGas(withdrawalTx.target, withdrawalTx.value, uint64(withdrawalTx.gasLimit), withdrawalTx.data);
+        optimismPortal2.finalizeWithdrawalTransaction(withdrawalTx);
         assertTrue(optimismPortal2.finalizedWithdrawals(withdrawalHash));
     }
 
@@ -1438,77 +1297,25 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
         // Bound to prevent changes in retirementTimestamp
         _newGameType = GameType.wrap(uint32(bound(_newGameType.raw(), 0, type(uint32).max - 1)));
 
-        // Total ETH supply is currently about 120M ETH.
-        uint256 value = bound(_value, 0, 200_000_000 ether);
-        vm.deal(address(optimismPortal2), value);
-        if (isUsingLockbox()) {
-            vm.deal(address(ethLockbox), value);
-        }
+        (Types.WithdrawalTransaction memory withdrawalTx, bytes32 withdrawalHash) =
+            _proveFuzzedWithdrawal(_sender, _target, _value, _gasLimit, _data);
 
-        uint256 gasLimit = bound(_gasLimit, 0, 50_000_000);
-        uint256 nonce = l2ToL1MessagePasser.messageNonce();
-
-        // Get a withdrawal transaction and mock proof from the differential testing script.
-        Types.WithdrawalTransaction memory _tx = Types.WithdrawalTransaction({
-            nonce: nonce, sender: _sender, target: _target, value: value, gasLimit: gasLimit, data: _data
-        });
-        (
-            bytes32 stateRoot,
-            bytes32 storageRoot,
-            bytes32 outputRoot,
-            bytes32 withdrawalHash,
-            bytes[] memory withdrawalProof
-        ) = ffi.getProveWithdrawalTransactionInputs(_tx);
-
-        // Create the output root proof
-        Types.OutputRootProof memory proof = Types.OutputRootProof({
-            version: bytes32(uint256(0)),
-            stateRoot: stateRoot,
-            messagePasserStorageRoot: storageRoot,
-            latestBlockhash: bytes32(uint256(0))
-        });
-
-        // Ensure the values returned from ffi are correct
-        assertEq(outputRoot, Hashing.hashOutputRootProof(proof));
-        assertEq(withdrawalHash, Hashing.hashWithdrawal(_tx));
-
-        // Setup the dispute game to return the output root
-        vm.mockCall(address(game), abi.encodeCall(game.rootClaim, ()), abi.encode(outputRoot));
-
-        // Prove the withdrawal transaction
-        optimismPortal2.proveWithdrawalTransaction(_tx, _proposedGameIndex, proof, withdrawalProof);
-        (IDisputeGame _game,) = optimismPortal2.provenWithdrawals(withdrawalHash, address(this));
-        assertTrue(_game.rootClaim().raw() != bytes32(0));
-
-        // Resolve the dispute game
-        game.resolve();
-
-        // Warp past the finalization period
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
+        _resolveGameAndWarpPastProofMaturity(game);
 
         // Change the respectedGameType
         vm.prank(optimismPortal2.guardian());
         anchorStateRegistry.setRespectedGameType(_newGameType);
 
         // Withdrawal transaction still finalizable
-        vm.expectCallMinGas(_tx.target, _tx.value, uint64(_tx.gasLimit), _tx.data);
-        optimismPortal2.finalizeWithdrawalTransaction(_tx);
+        vm.expectCallMinGas(withdrawalTx.target, withdrawalTx.value, uint64(withdrawalTx.gasLimit), withdrawalTx.data);
+        optimismPortal2.finalizeWithdrawalTransaction(withdrawalTx);
         assertTrue(optimismPortal2.finalizedWithdrawals(withdrawalHash));
     }
 
     /// @notice Tests that `finalizeWithdrawalTransaction` reverts if the withdrawal's dispute game
     ///         has been blacklisted.
     function test_finalizeWithdrawalTransaction_blacklisted_reverts() external {
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Resolve the dispute game.
         game.resolve();
@@ -1525,16 +1332,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
     /// @notice Tests that `finalizeWithdrawalTransaction` reverts if the withdrawal's dispute game
     ///         is still in the air gap.
     function test_finalizeWithdrawalTransaction_gameInAirGap_reverts() external {
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Warp past the finalization period.
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
@@ -1555,16 +1353,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
     /// @notice Tests that `finalizeWithdrawalTransaction` reverts if the respected game type was
     ///         updated after the dispute game was created.
     function test_finalizeWithdrawalTransaction_gameOlderThanRespectedGameTypeUpdate_reverts() external {
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Warp past the finalization period.
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
@@ -1588,16 +1377,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
     ///         respected game type when it was created. `proveWithdrawalTransaction` should
     ///         already prevent this, but we remove that assumption here.
     function test_finalizeWithdrawalTransaction_gameWasNotRespectedGameType_reverts() external {
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Warp past the finalization period.
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
@@ -1619,16 +1399,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
     ///         `proveWithdrawalTransaction` should already prevent this, but we remove that
     ///         assumption here.
     function test_finalizeWithdrawalTransaction_legacyGame_reverts() external {
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(address(optimismPortal2));
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Warp past the finalization period.
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
@@ -1642,8 +1413,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
         // Mock the wasRespectedGameTypeWhenCreated call to revert.
         vm.mockCallRevert(address(game), abi.encodeCall(game.wasRespectedGameTypeWhenCreated, ()), "");
 
-        // Should revert.
-        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
+        vm.expectRevert(bytes(""));
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
     }
 
@@ -1651,16 +1421,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
     ///         correctness.
     function test_finalizeWithdrawalTransaction_delayEdges_succeeds() external {
         // Prove the withdrawal transaction.
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Attempt to finalize the withdrawal transaction 1 second before the proof has matured.
         // This should fail.
@@ -1698,22 +1459,10 @@ contract OptimismPortal2_FinalizeWithdrawalTransactionExternalProof_Test is Opti
         uint256 bobBalanceBefore = address(bob).balance;
 
         // Submit the first proof for the withdrawal hash.
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Submit a second proof for the same withdrawal hash.
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(0xb0b));
+        _expectWithdrawalProven(_withdrawalHash, address(0xb0b));
         vm.prank(address(0xb0b));
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
@@ -1722,9 +1471,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransactionExternalProof_Test is Opti
             _withdrawalProof: _withdrawalProof
         });
 
-        // Warp and resolve the dispute game.
-        game.resolve();
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1 seconds);
+        _resolveGameAndWarpPastProofMaturity(game);
 
         vm.expectEmit(true, true, false, true);
         emit WithdrawalFinalized(_withdrawalHash, true);
@@ -1744,16 +1491,7 @@ contract OptimismPortal2_CheckWithdrawal_Test is OptimismPortal2_TestInit {
     ///         game has been finalized, and the root claim is valid.
     function test_checkWithdrawal_succeeds() external {
         // Prove the withdrawal transaction.
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Warp past the finalization period.
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
@@ -1773,20 +1511,9 @@ contract OptimismPortal2_CheckWithdrawal_Test is OptimismPortal2_TestInit {
     /// @notice Tests that checkWithdrawal reverts if the withdrawal has already been finalized.
     function test_checkWithdrawal_ifAlreadyFinalized_reverts() external {
         // Prove the withdrawal transaction.
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProven(_withdrawalHash, alice, bob);
-        vm.expectEmit(true, true, true, true);
-        emit WithdrawalProvenExtension1(_withdrawalHash, address(this));
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
-        // Warp and resolve the dispute game.
-        game.resolve();
-        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
+        _resolveGameAndWarpPastProofMaturity(game);
 
         // Finalize the withdrawal.
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
@@ -1807,13 +1534,7 @@ contract OptimismPortal2_CheckWithdrawal_Test is OptimismPortal2_TestInit {
     /// @notice Tests that checkWithdrawal reverts if the proof timestamp is greater than the game
     ///         creation timestamp.
     function testFuzz_checkWithdrawal_ifInvalidProofTimestamp_reverts(uint64 _createdAt) external {
-        // Prove the withdrawal transaction.
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Mock the game creation timestamp to be greater than the proof timestamp.
         _createdAt = uint64(bound(_createdAt, block.timestamp, type(uint64).max));
@@ -1838,13 +1559,7 @@ contract OptimismPortal2_CheckWithdrawal_Test is OptimismPortal2_TestInit {
     /// @notice Tests that checkWithdrawal reverts if the proof timestamp is less than the proof
     ///         maturity delay.
     function test_checkWithdrawal_ifProofNotOldEnough_reverts() external {
-        // Prove but don't warp ahead past the proof maturity delay.
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Should revert.
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() - 1);
@@ -1854,13 +1569,7 @@ contract OptimismPortal2_CheckWithdrawal_Test is OptimismPortal2_TestInit {
 
     /// @notice Tests that checkWithdrawal reverts if the root claim is invalid.
     function test_checkWithdrawal_ifInvalidRootClaim_reverts() external {
-        // Prove the withdrawal.
-        optimismPortal2.proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameIndex: _proposedGameIndex,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
+        _proveDefaultWithdrawal();
 
         // Warp past the proof maturity delay.
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);

--- a/test/L1/ResourceMetering.t.sol
+++ b/test/L1/ResourceMetering.t.sol
@@ -1,32 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing
-import { Test } from "lib/forge-std/src/Test.sol";
-
-// Contracts
+import { Test, stdError } from "lib/forge-std/src/Test.sol";
 import { ResourceMetering } from "src/L1/ResourceMetering.sol";
-
-// Libraries
 import { Constants } from "src/libraries/Constants.sol";
-
-// Interfaces
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
+
+uint256 constant MAX_EMPTY_BLOCK_GAP = 433_576_281_058_164_217_753_225_238_677_900_874_458_690;
+
+function defaultResourceConfig() pure returns (ResourceMetering.ResourceConfig memory) {
+    IResourceMetering.ResourceConfig memory rcfg = Constants.DEFAULT_RESOURCE_CONFIG();
+    ResourceMetering.ResourceConfig memory config;
+    assembly ("memory-safe") {
+        config := rcfg
+    }
+    return config;
+}
 
 contract MeterUser is ResourceMetering {
     ResourceMetering.ResourceConfig public innerConfig;
 
     constructor() {
         initialize();
-        IResourceMetering.ResourceConfig memory rcfg = Constants.DEFAULT_RESOURCE_CONFIG();
-        innerConfig = ResourceMetering.ResourceConfig({
-            maxResourceLimit: rcfg.maxResourceLimit,
-            elasticityMultiplier: rcfg.elasticityMultiplier,
-            baseFeeMaxChangeDenominator: rcfg.baseFeeMaxChangeDenominator,
-            minimumBaseFee: rcfg.minimumBaseFee,
-            systemTxMaxGas: rcfg.systemTxMaxGas,
-            maximumBaseFee: rcfg.maximumBaseFee
-        });
+        innerConfig = defaultResourceConfig();
     }
 
     function initialize() public initializer {
@@ -43,6 +39,12 @@ contract MeterUser is ResourceMetering {
 
     function use(uint64 _amount) public metered(_amount) { }
 
+    function measuredUse(uint64 _amount) public returns (uint256) {
+        uint256 initialGas = gasleft();
+        _metered(_amount, initialGas);
+        return initialGas - gasleft();
+    }
+
     function set(uint128 _prevBaseFee, uint64 _prevBoughtGas, uint64 _prevBlockNum) public {
         params = ResourceMetering.ResourceParams({
             prevBaseFee: _prevBaseFee, prevBoughtGas: _prevBoughtGas, prevBlockNum: _prevBlockNum
@@ -54,48 +56,14 @@ contract MeterUser is ResourceMetering {
     }
 }
 
-/// @title CustomMeterUser
-/// @notice A simple wrapper around `ResourceMetering` that allows the initial params to be set in
-///         the constructor.
-contract CustomMeterUser is ResourceMetering {
-    uint256 public startGas;
-    uint256 public endGas;
-
-    constructor(uint128 _prevBaseFee, uint64 _prevBoughtGas, uint64 _prevBlockNum) {
-        params = ResourceMetering.ResourceParams({
-            prevBaseFee: _prevBaseFee, prevBoughtGas: _prevBoughtGas, prevBlockNum: _prevBlockNum
-        });
-    }
-
-    function _resourceConfig() internal pure override returns (ResourceMetering.ResourceConfig memory) {
-        IResourceMetering.ResourceConfig memory rcfg = Constants.DEFAULT_RESOURCE_CONFIG();
-        return ResourceMetering.ResourceConfig({
-            maxResourceLimit: rcfg.maxResourceLimit,
-            elasticityMultiplier: rcfg.elasticityMultiplier,
-            baseFeeMaxChangeDenominator: rcfg.baseFeeMaxChangeDenominator,
-            minimumBaseFee: rcfg.minimumBaseFee,
-            systemTxMaxGas: rcfg.systemTxMaxGas,
-            maximumBaseFee: rcfg.maximumBaseFee
-        });
-    }
-
-    function use(uint64 _amount) public returns (uint256) {
-        uint256 initialGas = gasleft();
-        _metered(_amount, initialGas);
-        return initialGas - gasleft();
-    }
-}
-
 /// @title ResourceMetering_TestInit
 /// @notice Reusable test initialization for `ResourceMetering` tests.
 abstract contract ResourceMetering_TestInit is Test {
     MeterUser internal meter;
-    uint64 initialBlockNum;
 
     /// @notice Sets up the test contract.
     function setUp() public {
         meter = new MeterUser();
-        initialBlockNum = uint64(block.number);
     }
 }
 
@@ -119,13 +87,14 @@ contract ResourceMetering_Metered_Test is ResourceMetering_TestInit {
     /// @notice Tests that updating after multiple empty blocks maintains correct base fee.
     function testFuzz_metered_emptyBlocks_succeeds(uint256 _blockDiff) external {
         _blockDiff = bound(_blockDiff, 1, 100);
-        vm.roll(initialBlockNum + _blockDiff);
+        uint256 startBlock = block.number;
+        vm.roll(startBlock + _blockDiff);
         meter.use(0);
         (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum) = meter.params();
 
         assertEq(prevBaseFee, 1 gwei);
         assertEq(prevBoughtGas, 0);
-        assertEq(prevBlockNum, initialBlockNum + _blockDiff);
+        assertEq(prevBlockNum, startBlock + _blockDiff);
     }
 
     /// @notice Tests that updating the gas delta sets the meter params correctly.
@@ -135,23 +104,22 @@ contract ResourceMetering_Metered_Test is ResourceMetering_TestInit {
         meter.use(uint64(target));
         (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum) = meter.params();
 
-        assertEq(prevBaseFee, 1000000000);
+        assertEq(prevBaseFee, rcfg.minimumBaseFee);
         assertEq(prevBoughtGas, target);
-        assertEq(prevBlockNum, initialBlockNum);
+        assertEq(prevBlockNum, block.number);
     }
 
     /// @notice Tests that the meter params are set correctly for the maximum gas delta.
     function test_metered_useMax_succeeds() external {
         ResourceMetering.ResourceConfig memory rcfg = meter.resourceConfig();
-        uint64 target = uint64(rcfg.maxResourceLimit) / uint64(rcfg.elasticityMultiplier);
-        uint64 elasticityMultiplier = uint64(rcfg.elasticityMultiplier);
+        uint64 maxResourceLimit = uint64(rcfg.maxResourceLimit);
 
-        meter.use(target * elasticityMultiplier);
+        meter.use(maxResourceLimit);
 
         (, uint64 prevBoughtGas,) = meter.params();
-        assertEq(prevBoughtGas, target * elasticityMultiplier);
+        assertEq(prevBoughtGas, maxResourceLimit);
 
-        vm.roll(initialBlockNum + 1);
+        vm.roll(block.number + 1);
         meter.use(0);
         (uint128 postBaseFee,,) = meter.params();
         assertEq(postBaseFee, 2125000000);
@@ -163,16 +131,15 @@ contract ResourceMetering_Metered_Test is ResourceMetering_TestInit {
     ///         computed as 0.
     function test_metered_denominatorEq1_reverts() external {
         ResourceMetering.ResourceConfig memory rcfg = meter.resourceConfig();
-        uint64 target = uint64(rcfg.maxResourceLimit) / uint64(rcfg.elasticityMultiplier);
-        uint64 elasticityMultiplier = uint64(rcfg.elasticityMultiplier);
+        uint64 maxResourceLimit = uint64(rcfg.maxResourceLimit);
         rcfg.baseFeeMaxChangeDenominator = 1;
         meter.setParams(rcfg);
-        meter.use(target * elasticityMultiplier);
+        meter.use(maxResourceLimit);
 
         (, uint64 prevBoughtGas,) = meter.params();
-        assertEq(prevBoughtGas, target * elasticityMultiplier);
+        assertEq(prevBoughtGas, maxResourceLimit);
 
-        vm.roll(initialBlockNum + 2);
+        vm.roll(block.number + 2);
 
         vm.expectRevert("UNDEFINED");
         meter.use(0);
@@ -181,26 +148,21 @@ contract ResourceMetering_Metered_Test is ResourceMetering_TestInit {
     /// @notice Tests that the metered modifier reverts if the value is greater than allowed.
     function test_metered_useMoreThanMax_reverts() external {
         ResourceMetering.ResourceConfig memory rcfg = meter.resourceConfig();
-        uint64 target = uint64(rcfg.maxResourceLimit) / uint64(rcfg.elasticityMultiplier);
-        uint64 elasticityMultiplier = uint64(rcfg.elasticityMultiplier);
 
         vm.expectRevert(ResourceMetering.OutOfGas.selector);
-        meter.use(target * elasticityMultiplier + 1);
+        meter.use(uint64(rcfg.maxResourceLimit) + 1);
     }
 
     /// @notice Tests that resource metering can handle large gaps between deposits.
     function testFuzz_metered_largeBlockDiff_succeeds(uint64 _amount, uint256 _blockDiff) external {
-        // This test fails if the following line is commented out.
-        // At 12 seconds per block, this number is effectively unreachable.
-        _blockDiff = uint256(bound(_blockDiff, 0, 433576281058164217753225238677900874458690));
+        // Bounds the empty block gap to values that keep the base fee decay math in range.
+        _blockDiff = uint256(bound(_blockDiff, 0, MAX_EMPTY_BLOCK_GAP));
 
         ResourceMetering.ResourceConfig memory rcfg = meter.resourceConfig();
-        uint64 target = uint64(rcfg.maxResourceLimit) / uint64(rcfg.elasticityMultiplier);
-        uint64 elasticityMultiplier = uint64(rcfg.elasticityMultiplier);
 
-        _amount = uint64(bound(_amount, 0, target * elasticityMultiplier));
+        _amount = uint64(bound(_amount, 0, rcfg.maxResourceLimit));
 
-        vm.roll(initialBlockNum + _blockDiff);
+        vm.roll(block.number + _blockDiff);
         meter.use(_amount);
     }
 
@@ -274,7 +236,7 @@ contract ResourceMetering_ResourceMeteringInit_Test is ResourceMetering_TestInit
 
         assertEq(prevBaseFee, rcfg.minimumBaseFee);
         assertEq(prevBoughtGas, 0);
-        assertEq(prevBlockNum, initialBlockNum);
+        assertEq(prevBlockNum, block.number);
     }
 
     /// @notice Tests that reinitializing the resource params are set correctly.
@@ -298,35 +260,7 @@ contract ResourceMetering_ResourceMeteringInit_Test is ResourceMetering_TestInit
 ///         information about how much gas is used and how expensive it is in USD terms to purchase
 ///         the deposit gas.
 contract ArtifactResourceMetering_Metered_Test is Test {
-    uint128 internal minimumBaseFee;
-    uint128 internal maximumBaseFee;
-    uint64 internal maxResourceLimit;
-    uint64 internal targetResourceLimit;
-
     string internal outfile;
-
-    // keccak256(abi.encodeWithSignature("Error(string)", "ResourceMetering: cannot buy more gas
-    // than available gas limit"))
-    bytes32 internal cannotBuyMoreGas = 0x84edc668cfd5e050b8999f43ff87a1faaa93e5f935b20bc1dd4d3ff157ccf429;
-    // keccak256(abi.encodeWithSignature("Panic(uint256)", 0x11))
-    bytes32 internal overflowErr = 0x1ca389f2c8264faa4377de9ce8e14d6263ef29c68044a9272d405761bab2db27;
-    // keccak256(hex"")
-    bytes32 internal emptyReturnData = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
-
-    /// @notice Sets up the tests with constants from the ResourceMetering contract.
-    function setUp() public {
-        vm.roll(1_000_000);
-
-        MeterUser base = new MeterUser();
-        ResourceMetering.ResourceConfig memory rcfg = base.resourceConfig();
-        minimumBaseFee = uint128(rcfg.minimumBaseFee);
-        maximumBaseFee = rcfg.maximumBaseFee;
-        maxResourceLimit = uint64(rcfg.maxResourceLimit);
-        targetResourceLimit = uint64(rcfg.maxResourceLimit) / uint64(rcfg.elasticityMultiplier);
-
-        outfile = string.concat(vm.projectRoot(), "/.resource-metering.csv");
-        try vm.removeFile(outfile) { } catch { }
-    }
 
     /// @notice Generates a CSV file. No more than the L1 block gas limit should be supplied to the
     ///         `meter` function to avoid long execution time. This test is skipped because there
@@ -335,6 +269,16 @@ contract ArtifactResourceMetering_Metered_Test is Test {
     ///         that the gas usage needs to be analyzed, the skip may be removed.
     function test_meter_generateArtifact_succeeds() external {
         vm.skip({ skipTest: true });
+
+        vm.roll(1_000_000);
+
+        ResourceMetering.ResourceConfig memory rcfg = defaultResourceConfig();
+        uint128 minimumBaseFee = uint128(rcfg.minimumBaseFee);
+        uint128 maximumBaseFee = rcfg.maximumBaseFee;
+        uint64 maxResourceLimit = uint64(rcfg.maxResourceLimit);
+        uint64 targetResourceLimit = uint64(rcfg.maxResourceLimit) / uint64(rcfg.elasticityMultiplier);
+        outfile = string.concat(vm.projectRoot(), "/.resource-metering.csv");
+        try vm.removeFile(outfile) { } catch { }
 
         vm.writeLine(
             outfile,
@@ -348,10 +292,6 @@ contract ArtifactResourceMetering_Metered_Test is Test {
         prevBaseFees[2] = uint128(50 gwei);
         prevBaseFees[3] = uint128(100 gwei);
         prevBaseFees[4] = uint128(200 gwei);
-
-        // prevBoughtGas value in ResourceParams
-        uint64[] memory prevBoughtGases = new uint64[](1);
-        prevBoughtGases[0] = uint64(0);
 
         // prevBlockNum diff, simulates blocks with no deposits when non zero
         uint64[] memory prevBlockNumDiffs = new uint64[](2);
@@ -378,79 +318,77 @@ contract ArtifactResourceMetering_Metered_Test is Test {
 
         // Iterate over all of the test values and run a test
         for (uint256 i; i < prevBaseFees.length; i++) {
-            for (uint256 j; j < prevBoughtGases.length; j++) {
-                for (uint256 k; k < prevBlockNumDiffs.length; k++) {
-                    for (uint256 l; l < requestedGases.length; l++) {
-                        for (uint256 m; m < l1BaseFees.length; m++) {
-                            for (uint256 n; n < ethPrices.length; n++) {
-                                uint256 snapshotId = vm.snapshot();
+            for (uint256 k; k < prevBlockNumDiffs.length; k++) {
+                for (uint256 l; l < requestedGases.length; l++) {
+                    for (uint256 m; m < l1BaseFees.length; m++) {
+                        for (uint256 n; n < ethPrices.length; n++) {
+                            uint256 snapshotId = vm.snapshot();
 
-                                uint128 prevBaseFee = prevBaseFees[i];
-                                uint64 prevBoughtGas = prevBoughtGases[j];
-                                uint64 prevBlockNumDiff = prevBlockNumDiffs[k];
-                                uint64 requestedGas = requestedGases[l];
-                                uint256 l1BaseFee = l1BaseFees[m];
-                                uint256 ethPrice = ethPrices[n];
-                                string memory result = "success";
+                            uint128 prevBaseFee = prevBaseFees[i];
+                            uint64 prevBoughtGas = 0;
+                            uint64 prevBlockNumDiff = prevBlockNumDiffs[k];
+                            uint64 requestedGas = requestedGases[l];
+                            uint256 l1BaseFee = l1BaseFees[m];
+                            uint256 ethPrice = ethPrices[n];
+                            string memory result = "success";
 
-                                vm.fee(l1BaseFee);
+                            vm.fee(l1BaseFee);
 
-                                CustomMeterUser meter = new CustomMeterUser({
-                                    _prevBaseFee: prevBaseFee,
-                                    _prevBoughtGas: prevBoughtGas,
-                                    _prevBlockNum: uint64(block.number)
-                                });
+                            MeterUser meter = new MeterUser();
+                            meter.set(prevBaseFee, prevBoughtGas, uint64(block.number));
 
-                                vm.roll(block.number + prevBlockNumDiff);
+                            vm.roll(block.number + prevBlockNumDiff);
 
-                                // Call the metering code and catch the various
-                                // types of errors.
-                                uint256 gasConsumed = 0;
-                                try meter.use{ gas: 30_000_000 }(requestedGas) returns (uint256 gasConsumed_) {
-                                    gasConsumed = gasConsumed_;
-                                } catch (bytes memory err) {
-                                    bytes32 hash = keccak256(err);
-                                    if (hash == cannotBuyMoreGas) {
-                                        result = "ResourceMetering: cannot buy more gas than available gas limit";
-                                    } else if (hash == overflowErr) {
-                                        result = "arithmetic overflow/underflow";
-                                    } else if (hash == emptyReturnData) {
-                                        result = "out of gas";
-                                    } else {
-                                        result = "UNKNOWN ERROR";
+                            uint256 gasConsumed = 0;
+                            try meter.measuredUse{ gas: 30_000_000 }(requestedGas) returns (uint256 gasConsumed_) {
+                                gasConsumed = gasConsumed_;
+                            } catch (bytes memory err) {
+                                bytes4 selector;
+                                if (err.length >= 4) {
+                                    assembly {
+                                        selector := mload(add(err, 0x20))
                                     }
                                 }
 
-                                // Compute the USD cost of the gas used
-                                uint256 usdCost = (gasConsumed * l1BaseFee * ethPrice) / 1 ether;
-
-                                vm.writeLine(
-                                    outfile,
-                                    string.concat(
-                                        vm.toString(prevBaseFee),
-                                        ",",
-                                        vm.toString(prevBoughtGas),
-                                        ",",
-                                        vm.toString(prevBlockNumDiff),
-                                        ",",
-                                        vm.toString(l1BaseFee),
-                                        ",",
-                                        vm.toString(requestedGas),
-                                        ",",
-                                        vm.toString(gasConsumed),
-                                        ",",
-                                        "$",
-                                        vm.toString(ethPrice),
-                                        ",",
-                                        "$",
-                                        vm.toString(usdCost),
-                                        ",",
-                                        result
-                                    )
-                                );
-
-                                assertTrue(vm.revertTo(snapshotId));
+                                if (selector == ResourceMetering.OutOfGas.selector) {
+                                    result = "ResourceMetering: cannot buy more gas than available gas limit";
+                                } else if (keccak256(err) == keccak256(stdError.arithmeticError)) {
+                                    result = "arithmetic overflow/underflow";
+                                } else if (err.length == 0) {
+                                    result = "out of gas";
+                                } else {
+                                    result = "UNKNOWN ERROR";
+                                }
                             }
+
+                            uint256 usdCost = (gasConsumed * l1BaseFee * ethPrice) / 1 ether;
+
+                            vm.writeLine(
+                                outfile,
+                                string.concat(
+                                    vm.toString(prevBaseFee),
+                                    ",",
+                                    vm.toString(prevBoughtGas),
+                                    ",",
+                                    vm.toString(prevBlockNumDiff),
+                                    ",",
+                                    vm.toString(l1BaseFee),
+                                    ",",
+                                    vm.toString(requestedGas),
+                                    ",",
+                                    vm.toString(gasConsumed),
+                                    ",",
+                                    "$",
+                                    vm.toString(ethPrice),
+                                    ",",
+                                    "$",
+                                    vm.toString(usdCost),
+                                    ",",
+                                    result
+                                )
+                            );
+
+                            assertTrue(vm.revertTo(snapshotId));
                         }
                     }
                 }

--- a/test/L1/SuperchainConfig.t.sol
+++ b/test/L1/SuperchainConfig.t.sol
@@ -10,9 +10,16 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 /// @title SuperchainConfig_TestInit
 /// @notice Initialization contract for SuperchainConfig tests.
 abstract contract SuperchainConfig_TestInit is CommonTest {
+    uint256 internal constant PAUSE_EXPIRY = 7_884_000;
+
     function setUp() public virtual override {
         super.setUp();
         skipIfForkTest("SuperchainConfig_TestInit: cannot test initialization on forked network");
+    }
+
+    function _pauseAsGuardian(address _identifier) internal {
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(_identifier);
     }
 }
 
@@ -31,7 +38,7 @@ contract SuperchainConfig_Constructor_Test is SuperchainConfig_TestInit {
 contract SuperchainConfig_PauseExpiry_Test is SuperchainConfig_TestInit {
     /// @notice Tests that `pauseExpiry` returns the correct constant value.
     function test_pauseExpiry_succeeds() external view {
-        assertEq(superchainConfig.pauseExpiry(), 7_884_000);
+        assertEq(superchainConfig.pauseExpiry(), PAUSE_EXPIRY);
     }
 }
 
@@ -40,67 +47,41 @@ contract SuperchainConfig_PauseExpiry_Test is SuperchainConfig_TestInit {
 contract SuperchainConfig_Paused_Test is SuperchainConfig_TestInit {
     /// @notice Tests that `paused` returns true when the specific identifier is paused.
     /// @param _identifier The identifier to test.
-    function testFuzz_paused_specificIdentifier_succeeds(address _identifier) external {
-        // Assume the identifier is not the zero address.
+    /// @param _other The unpaused identifier to test.
+    function testFuzz_paused_specificIdentifier_succeeds(address _identifier, address _other) external {
         vm.assume(_identifier != address(0));
+        vm.assume(_other != _identifier);
 
-        // Pause with the specific identifier.
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(_identifier);
-
-        // Assert that the specific identifier is paused.
+        _pauseAsGuardian(_identifier);
         assertTrue(superchainConfig.paused(_identifier));
-
-        // Pick a random address that is not the identifier.
-        address other = vm.randomAddress();
-        while (other == _identifier) {
-            other = vm.randomAddress();
-        }
-
-        // Assert that the other address is not paused.
-        assertFalse(superchainConfig.paused(other));
+        assertFalse(superchainConfig.paused(_other));
     }
 
     /// @notice Tests that `paused` returns true when the global superchain system is paused.
     function test_paused_global_succeeds() external {
-        // Pause the global superchain system.
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(address(0));
+        _pauseAsGuardian(address(0));
 
-        // Assert that the global superchain system is paused.
         assertTrue(superchainConfig.paused());
         assertTrue(superchainConfig.paused(address(0)));
-
-        // Pick a random address that is not the zero address.
-        address other = vm.randomAddress();
-        while (other == address(0)) {
-            other = vm.randomAddress();
-        }
-
-        // Assert that the other address is not paused.
-        assertFalse(superchainConfig.paused(other));
+        assertFalse(superchainConfig.paused(address(1)));
     }
 
     /// @notice Tests that `paused` returns false after pause expires.
     /// @param _identifier The identifier to test.
     function testFuzz_paused_expired_succeeds(address _identifier) external {
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(_identifier);
+        _pauseAsGuardian(_identifier);
         assertTrue(superchainConfig.paused(_identifier));
 
-        // Warp past expiry
-        vm.warp(block.timestamp + superchainConfig.pauseExpiry() + 1);
+        vm.warp(block.timestamp + PAUSE_EXPIRY + 1);
         assertFalse(superchainConfig.paused(_identifier));
     }
 
     /// @notice Tests that `paused` returns true just before expiry.
     /// @param _identifier The identifier to test.
     function testFuzz_paused_beforeExpiry_succeeds(address _identifier) external {
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(_identifier);
+        _pauseAsGuardian(_identifier);
 
-        // Warp to just before expiry
-        vm.warp(block.timestamp + superchainConfig.pauseExpiry() - 1);
+        vm.warp(block.timestamp + PAUSE_EXPIRY - 1);
         assertTrue(superchainConfig.paused(_identifier));
     }
 }
@@ -130,18 +111,15 @@ contract SuperchainConfig_Pause_Test is SuperchainConfig_TestInit {
         vm.expectRevert(ISuperchainConfig.SuperchainConfig_OnlyGuardianOrIncidentResponder.selector);
         vm.prank(_caller);
         superchainConfig.pause(address(this));
-
-        assertFalse(superchainConfig.paused(address(this)));
     }
 
     /// @notice Tests that `pause` reverts when the identifier is already used.
     /// @param _identifier The identifier to test.
     function testFuzz_pause_alreadyUsed_reverts(address _identifier) external {
-        vm.startPrank(superchainConfig.guardian());
-        superchainConfig.pause(_identifier);
+        _pauseAsGuardian(_identifier);
 
+        vm.prank(superchainConfig.guardian());
         vm.expectRevert(abi.encodeWithSelector(ISuperchainConfig.SuperchainConfig_AlreadyPaused.selector, _identifier));
-
         superchainConfig.pause(_identifier);
     }
 }
@@ -152,12 +130,12 @@ contract SuperchainConfig_Unpause_Test is SuperchainConfig_TestInit {
     /// @notice Tests that `unpause` successfully unpauses when called by the guardian.
     /// @param _identifier The identifier to test.
     function testFuzz_unpause_succeeds(address _identifier) external {
-        vm.startPrank(superchainConfig.guardian());
-        superchainConfig.pause(_identifier);
+        _pauseAsGuardian(_identifier);
         assertTrue(superchainConfig.paused(_identifier));
 
         vm.expectEmit(address(superchainConfig));
         emit Unpaused(_identifier);
+        vm.prank(superchainConfig.guardian());
         superchainConfig.unpause(_identifier);
 
         assertFalse(superchainConfig.paused(_identifier));
@@ -168,15 +146,12 @@ contract SuperchainConfig_Unpause_Test is SuperchainConfig_TestInit {
     function testFuzz_unpause_notGuardian_reverts(address _caller) external {
         vm.assume(_caller != superchainConfig.guardian());
 
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(address(this));
+        _pauseAsGuardian(address(this));
         assertTrue(superchainConfig.paused(address(this)));
 
         vm.expectRevert(ISuperchainConfig.SuperchainConfig_OnlyGuardian.selector);
         vm.prank(_caller);
         superchainConfig.unpause(address(this));
-
-        assertTrue(superchainConfig.paused(address(this)));
     }
 }
 
@@ -186,14 +161,14 @@ contract SuperchainConfig_Extend_Test is SuperchainConfig_TestInit {
     /// @notice Tests that `extend` successfully resets and re-pauses an identifier.
     /// @param _identifier The identifier to test.
     function testFuzz_extend_succeeds(address _identifier) external {
-        vm.startPrank(superchainConfig.guardian());
-        superchainConfig.pause(_identifier);
+        _pauseAsGuardian(_identifier);
         uint256 firstPauseTimestamp = block.timestamp;
 
         vm.warp(block.timestamp + 1);
 
         vm.expectEmit(address(superchainConfig));
         emit PauseExtended(_identifier);
+        vm.prank(superchainConfig.guardian());
         superchainConfig.extend(_identifier);
         assertTrue(superchainConfig.pauseTimestamps(_identifier) > firstPauseTimestamp);
         assertTrue(superchainConfig.paused(_identifier));
@@ -204,11 +179,10 @@ contract SuperchainConfig_Extend_Test is SuperchainConfig_TestInit {
     function testFuzz_extend_notGuardian_reverts(address _caller) external {
         vm.assume(_caller != superchainConfig.guardian());
 
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(address(this));
+        _pauseAsGuardian(address(this));
 
-        vm.prank(_caller);
         vm.expectRevert(ISuperchainConfig.SuperchainConfig_OnlyGuardian.selector);
+        vm.prank(_caller);
         superchainConfig.extend(address(this));
     }
 
@@ -235,23 +209,19 @@ contract SuperchainConfig_Pausable_Test is SuperchainConfig_TestInit {
     /// @notice Tests that `pausable` returns false when the identifier is paused.
     /// @param _identifier The identifier to test.
     function testFuzz_pausable_paused_succeeds(address _identifier) external {
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(_identifier);
+        _pauseAsGuardian(_identifier);
         assertFalse(superchainConfig.pausable(_identifier));
     }
 
     /// @notice Tests that `pausable` returns false even after pause expires.
     /// @param _identifier The identifier to test.
     function testFuzz_pausable_expired_succeeds(address _identifier) external {
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(_identifier);
+        _pauseAsGuardian(_identifier);
 
-        // Warp past expiry
-        vm.warp(block.timestamp + superchainConfig.pauseExpiry() + 1);
+        vm.warp(block.timestamp + PAUSE_EXPIRY + 1);
 
-        // pausable() should still return false because timestamp is set
+        // Expired pauses remain unpausable because the timestamp stays set.
         assertFalse(superchainConfig.pausable(_identifier));
-        // But paused() should return false because pause expired
         assertFalse(superchainConfig.paused(_identifier));
     }
 }
@@ -277,18 +247,17 @@ contract SuperchainConfig_PauseTimestamps_Test is SuperchainConfig_TestInit {
     /// @notice Tests that `pauseTimestamps` returns the correct timestamp for paused identifiers.
     /// @param _identifier The identifier to test.
     function testFuzz_pauseTimestamps_paused_succeeds(address _identifier) external {
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(_identifier);
+        _pauseAsGuardian(_identifier);
         assertEq(superchainConfig.pauseTimestamps(_identifier), block.timestamp);
     }
 
     /// @notice Tests that `pauseTimestamps` returns 0 after unpausing.
     /// @param _identifier The identifier to test.
     function testFuzz_pauseTimestamps_afterUnpause_succeeds(address _identifier) external {
-        vm.startPrank(superchainConfig.guardian());
-        superchainConfig.pause(_identifier);
+        _pauseAsGuardian(_identifier);
         assertTrue(superchainConfig.pauseTimestamps(_identifier) != 0);
 
+        vm.prank(superchainConfig.guardian());
         superchainConfig.unpause(_identifier);
         assertEq(superchainConfig.pauseTimestamps(_identifier), 0);
     }
@@ -314,39 +283,27 @@ contract SuperchainConfig_Expiration_Test is SuperchainConfig_TestInit {
     /// @notice Tests that `expiration` returns the correct timestamp when the identifier is
     ///         paused.
     function test_expiration_paused_succeeds() external {
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(address(this));
-        uint256 expectedExpiration = block.timestamp + superchainConfig.pauseExpiry();
-        assertEq(superchainConfig.expiration(address(this)), expectedExpiration);
+        _pauseAsGuardian(address(this));
+        assertEq(superchainConfig.expiration(address(this)), block.timestamp + PAUSE_EXPIRY);
     }
 
     /// @notice Tests that `expiration` returns the updated timestamp after extending the pause.
     function test_expiration_afterExtend_succeeds() external {
-        vm.startPrank(superchainConfig.guardian());
-        superchainConfig.pause(address(this));
-        uint256 firstExpiration = superchainConfig.expiration(address(this));
-
-        // Warp forward in time
+        _pauseAsGuardian(address(this));
         vm.warp(block.timestamp + 100);
 
-        // Extend the pause
+        vm.prank(superchainConfig.guardian());
         superchainConfig.extend(address(this));
-        uint256 newExpiration = superchainConfig.expiration(address(this));
 
-        assertTrue(newExpiration > firstExpiration);
-        assertEq(newExpiration, block.timestamp + superchainConfig.pauseExpiry());
+        assertEq(superchainConfig.expiration(address(this)), block.timestamp + PAUSE_EXPIRY);
     }
 
     /// @notice Tests that `expiration` works correctly with fuzzed identifiers.
     /// @param _identifier The identifier to test.
     function testFuzz_expiration_succeeds(address _identifier) external {
-        // Test unpaused state
         assertEq(superchainConfig.expiration(_identifier), 0);
 
-        // Test paused state
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(_identifier);
-        uint256 expectedExpiration = block.timestamp + superchainConfig.pauseExpiry();
-        assertEq(superchainConfig.expiration(_identifier), expectedExpiration);
+        _pauseAsGuardian(_identifier);
+        assertEq(superchainConfig.expiration(_identifier), block.timestamp + PAUSE_EXPIRY);
     }
 }

--- a/test/L1/SystemConfig.t.sol
+++ b/test/L1/SystemConfig.t.sol
@@ -24,6 +24,7 @@ abstract contract SystemConfig_TestInit is CommonTest {
     event ConfigUpdate(uint256 indexed version, ISystemConfig.UpdateType indexed updateType, bytes data);
 
     bytes32 public constant EXAMPLE_FEATURE = "EXAMPLE_FEATURE";
+    bytes32 internal constant INITIALIZED_SLOT = bytes32(0);
 
     address owner;
     bytes32 batcherHash;
@@ -44,6 +45,42 @@ abstract contract SystemConfig_TestInit is CommonTest {
         unsafeBlockSigner = deploy.cfg().p2pSequencerAddress();
         systemConfigImpl = EIP1967Helper.getImplementation(address(systemConfig));
         optimismMintableERC20Factory = artifacts.mustGetAddress("OptimismMintableERC20FactoryProxy");
+    }
+
+    function _resetInitialized() internal {
+        vm.store(address(systemConfig), INITIALIZED_SLOT, bytes32(0));
+    }
+
+    function _initializedValue() internal view returns (uint8) {
+        bytes32 slotVal = vm.load(address(systemConfig), INITIALIZED_SLOT);
+        return uint8(uint256(slotVal) & 0xFF);
+    }
+
+    function _emptyAddresses() internal pure returns (ISystemConfig.Addresses memory) {
+        return ISystemConfig.Addresses({
+            l1CrossDomainMessenger: address(0),
+            l1ERC721Bridge: address(0),
+            l1StandardBridge: address(0),
+            optimismPortal: address(0),
+            optimismMintableERC20Factory: address(0),
+            delayedWETH: address(0)
+        });
+    }
+
+    function _initializeSystemConfig(uint64 _gasLimit, IResourceMetering.ResourceConfig memory _config) internal {
+        systemConfig.initialize({
+            _owner: alice,
+            _basefeeScalar: basefeeScalar,
+            _blobbasefeeScalar: blobbasefeeScalar,
+            _batcherHash: bytes32(hex"abcd"),
+            _gasLimit: _gasLimit,
+            _unsafeBlockSigner: address(1),
+            _config: _config,
+            _batchInbox: address(0),
+            _addresses: _emptyAddresses(),
+            _l2ChainId: 1234,
+            _superchainConfig: ISuperchainConfig(address(0))
+        });
     }
 }
 
@@ -139,48 +176,18 @@ contract SystemConfig_Initialize_Test is SystemConfig_TestInit {
     function test_initialize_lowGasLimit_reverts() external {
         uint64 minimumGasLimit = systemConfig.minimumGasLimit();
 
-        // Wipe out the initialized slot so the proxy can be initialized again
-        vm.store(address(systemConfig), bytes32(0), bytes32(0));
+        _resetInitialized();
 
-        address admin = address(uint160(uint256(vm.load(address(systemConfig), Constants.PROXY_OWNER_ADDRESS))));
-        vm.prank(admin);
-
+        vm.prank(address(systemConfig.proxyAdmin()));
         vm.expectRevert("SystemConfig: gas limit too low");
-        systemConfig.initialize({
-            _owner: alice,
-            _basefeeScalar: basefeeScalar,
-            _blobbasefeeScalar: blobbasefeeScalar,
-            _batcherHash: bytes32(hex"abcd"),
-            _gasLimit: minimumGasLimit - 1,
-            _unsafeBlockSigner: address(1),
-            _config: Constants.DEFAULT_RESOURCE_CONFIG(),
-            _batchInbox: address(0),
-            _addresses: ISystemConfig.Addresses({
-                l1CrossDomainMessenger: address(0),
-                l1ERC721Bridge: address(0),
-                l1StandardBridge: address(0),
-                optimismPortal: address(0),
-                optimismMintableERC20Factory: address(0),
-                delayedWETH: address(0)
-            }),
-            _l2ChainId: 1234,
-            _superchainConfig: ISuperchainConfig(address(0))
-        });
+        _initializeSystemConfig(minimumGasLimit - 1, Constants.DEFAULT_RESOURCE_CONFIG());
     }
 
     /// @notice Tests that the initializer value is correct. Trivial test for normal
     ///         initialization but confirms that the initValue is not incremented incorrectly if
     ///         an upgrade function is not present.
     function test_initialize_correctInitializerValue_succeeds() public view {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("SystemConfig", "_initialized");
-
-        // Get the initializer value.
-        bytes32 slotVal = vm.load(address(systemConfig), bytes32(slot.slot));
-        uint8 val = uint8(uint256(slotVal) & 0xFF);
-
-        // Assert that the initializer value matches the expected value.
-        assertEq(val, systemConfig.initVersion());
+        assertEq(_initializedValue(), systemConfig.initVersion());
     }
 
     /// @notice Tests that `initialize` reverts if called by a non-proxy admin or owner.
@@ -189,40 +196,16 @@ contract SystemConfig_Initialize_Test is SystemConfig_TestInit {
         // Prank as the not ProxyAdmin or ProxyAdmin owner.
         vm.assume(_sender != address(systemConfig.proxyAdmin()) && _sender != systemConfig.proxyAdminOwner());
 
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("SystemConfig", "_initialized");
-
-        // Set the initialized slot to 0.
-        vm.store(address(systemConfig), bytes32(slot.slot), bytes32(0));
+        _resetInitialized();
 
         // Get the minimum gas limit.
         uint64 minimumGasLimit = systemConfig.minimumGasLimit();
 
         // Expect the revert with `ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner` selector.
+        vm.prank(_sender);
         vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
 
-        // Call the `initialize` function with the sender
-        vm.prank(_sender);
-        systemConfig.initialize({
-            _owner: alice,
-            _basefeeScalar: basefeeScalar,
-            _blobbasefeeScalar: blobbasefeeScalar,
-            _batcherHash: bytes32(hex"abcd"),
-            _gasLimit: minimumGasLimit - 1,
-            _unsafeBlockSigner: address(1),
-            _config: Constants.DEFAULT_RESOURCE_CONFIG(),
-            _batchInbox: address(0),
-            _addresses: ISystemConfig.Addresses({
-                l1CrossDomainMessenger: address(0),
-                l1ERC721Bridge: address(0),
-                l1StandardBridge: address(0),
-                optimismPortal: address(0),
-                optimismMintableERC20Factory: address(0),
-                delayedWETH: address(0)
-            }),
-            _l2ChainId: 1234,
-            _superchainConfig: ISuperchainConfig(address(0))
-        });
+        _initializeSystemConfig(minimumGasLimit - 1, Constants.DEFAULT_RESOURCE_CONFIG());
     }
 }
 
@@ -231,65 +214,25 @@ contract SystemConfig_Initialize_Test is SystemConfig_TestInit {
 contract SystemConfig_StartBlock_Test is SystemConfig_TestInit {
     /// @notice Tests that startBlock is updated correctly when it's zero.
     function test_startBlock_update_succeeds() external {
-        // Wipe out the initialized slot so the proxy can be initialized again
-        vm.store(address(systemConfig), bytes32(0), bytes32(0));
+        _resetInitialized();
         // Set slot startBlock to zero
         vm.store(address(systemConfig), systemConfig.START_BLOCK_SLOT(), bytes32(uint256(0)));
 
         // Initialize and check that StartBlock updates to current block number
         vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.initialize({
-            _owner: alice,
-            _basefeeScalar: basefeeScalar,
-            _blobbasefeeScalar: blobbasefeeScalar,
-            _batcherHash: bytes32(hex"abcd"),
-            _gasLimit: gasLimit,
-            _unsafeBlockSigner: address(1),
-            _config: Constants.DEFAULT_RESOURCE_CONFIG(),
-            _batchInbox: address(0),
-            _addresses: ISystemConfig.Addresses({
-                l1CrossDomainMessenger: address(0),
-                l1ERC721Bridge: address(0),
-                l1StandardBridge: address(0),
-                optimismPortal: address(0),
-                optimismMintableERC20Factory: address(0),
-                delayedWETH: address(0)
-            }),
-            _l2ChainId: 1234,
-            _superchainConfig: ISuperchainConfig(address(0))
-        });
+        _initializeSystemConfig(gasLimit, Constants.DEFAULT_RESOURCE_CONFIG());
         assertEq(systemConfig.startBlock(), block.number);
     }
 
     /// @notice Tests that startBlock is not updated when it's not zero.
     function test_startBlock_update_fails() external {
-        // Wipe out the initialized slot so the proxy can be initialized again
-        vm.store(address(systemConfig), bytes32(0), bytes32(0));
+        _resetInitialized();
         // Set slot startBlock to non-zero value 1
         vm.store(address(systemConfig), systemConfig.START_BLOCK_SLOT(), bytes32(uint256(1)));
 
         // Initialize and check that StartBlock doesn't update
         vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.initialize({
-            _owner: alice,
-            _basefeeScalar: basefeeScalar,
-            _blobbasefeeScalar: blobbasefeeScalar,
-            _batcherHash: bytes32(hex"abcd"),
-            _gasLimit: gasLimit,
-            _unsafeBlockSigner: address(1),
-            _config: Constants.DEFAULT_RESOURCE_CONFIG(),
-            _batchInbox: address(0),
-            _addresses: ISystemConfig.Addresses({
-                l1CrossDomainMessenger: address(0),
-                l1ERC721Bridge: address(0),
-                l1StandardBridge: address(0),
-                optimismPortal: address(0),
-                optimismMintableERC20Factory: address(0),
-                delayedWETH: address(0)
-            }),
-            _l2ChainId: 1234,
-            _superchainConfig: ISuperchainConfig(address(0))
-        });
+        _initializeSystemConfig(gasLimit, Constants.DEFAULT_RESOURCE_CONFIG());
         assertEq(systemConfig.startBlock(), 1);
     }
 }
@@ -392,8 +335,7 @@ contract SystemConfig_SetGasConfigEcotone_Test is SystemConfig_TestInit {
     }
 
     function testFuzz_setGasConfigEcotone_succeeds(uint32 _basefeeScalar, uint32 _blobbasefeeScalar) external {
-        bytes32 encoded =
-            ffi.encodeScalarEcotone({ _basefeeScalar: _basefeeScalar, _blobbasefeeScalar: _blobbasefeeScalar });
+        uint256 encoded = (uint256(0x01) << 248) | (uint256(_blobbasefeeScalar) << 32) | _basefeeScalar;
 
         vm.expectEmit(address(systemConfig));
         emit ConfigUpdate(0, ISystemConfig.UpdateType.FEE_SCALARS, abi.encode(systemConfig.overhead(), encoded));
@@ -402,11 +344,10 @@ contract SystemConfig_SetGasConfigEcotone_Test is SystemConfig_TestInit {
         systemConfig.setGasConfigEcotone({ _basefeeScalar: _basefeeScalar, _blobbasefeeScalar: _blobbasefeeScalar });
         assertEq(systemConfig.basefeeScalar(), _basefeeScalar);
         assertEq(systemConfig.blobbasefeeScalar(), _blobbasefeeScalar);
-        assertEq(systemConfig.scalar(), uint256(encoded));
+        assertEq(systemConfig.scalar(), encoded);
 
-        (uint32 basefeeScalar, uint32 blobbbasefeeScalar) = ffi.decodeScalarEcotone(encoded);
-        assertEq(uint256(basefeeScalar), uint256(_basefeeScalar));
-        assertEq(uint256(blobbbasefeeScalar), uint256(_blobbasefeeScalar));
+        assertEq(uint32(encoded), _basefeeScalar);
+        assertEq(uint32(encoded >> 32), _blobbasefeeScalar);
     }
 }
 
@@ -579,9 +520,8 @@ contract SystemConfig_SetResourceConfig_Test is SystemConfig_TestInit {
     )
         internal
     {
-        // Wipe out the initialized slot so the proxy can be initialized again
-        vm.store(address(systemConfig), bytes32(0), bytes32(0));
-        // Fetch the current gas limit
+        _resetInitialized();
+
         uint64 gasLimit = systemConfig.gasLimit();
 
         vm.prank(address(systemConfig.proxyAdmin()));
@@ -595,14 +535,7 @@ contract SystemConfig_SetResourceConfig_Test is SystemConfig_TestInit {
             _unsafeBlockSigner: address(0),
             _config: config,
             _batchInbox: address(0),
-            _addresses: ISystemConfig.Addresses({
-                l1CrossDomainMessenger: address(0),
-                l1ERC721Bridge: address(0),
-                l1StandardBridge: address(0),
-                optimismPortal: address(0),
-                optimismMintableERC20Factory: address(0),
-                delayedWETH: address(0)
-            }),
+            _addresses: _emptyAddresses(),
             _l2ChainId: 1234,
             _superchainConfig: ISuperchainConfig(address(0))
         });
@@ -700,6 +633,15 @@ contract SystemConfig_Paused_Test is SystemConfig_TestInit {
 contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
     event FeatureSet(bytes32 indexed feature, bool indexed enabled);
 
+    function _enableEthLockboxIfDisabled(address proxyAdmin) internal {
+        if (!systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
+            vm.prank(proxyAdmin);
+            systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+        }
+
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+    }
+
     /// @notice Tests that `setFeature` reverts if the caller is not ProxyAdmin or ProxyAdmin owner.
     /// @param _sender The address to test.
     function testFuzz_setFeature_notProxyAdminOrProxyAdminOwner_reverts(address _sender) external {
@@ -789,7 +731,7 @@ contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
     function test_setFeature_alreadyDisabled_reverts() external {
         vm.prank(address(systemConfig.proxyAdmin()));
         vm.expectRevert(ISystemConfig.SystemConfig_InvalidFeatureState.selector);
-        systemConfig.setFeature("EXAMPLE FEATURE", false);
+        systemConfig.setFeature(EXAMPLE_FEATURE, false);
     }
 
     /// @notice Tests that disabling ETH_LOCKBOX reverts if the OptimismPortal has a non-zero
@@ -797,12 +739,7 @@ contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
     function test_setFeature_ethLockboxDisableWhileConfigured_reverts() external {
         address proxyAdmin = address(systemConfig.proxyAdmin());
 
-        // Ensure ETH_LOCKBOX is enabled first (no pause active in fresh setup).
-        if (!systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-            vm.prank(proxyAdmin);
-            systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-            assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
-        }
+        _enableEthLockboxIfDisabled(proxyAdmin);
 
         // Force the portal to have a configured ETHLockbox address.
         StorageSlot memory slot = ForgeArtifacts.getSlot("OptimismPortal2", "ethLockbox");
@@ -818,12 +755,7 @@ contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
     function test_setFeature_ethLockboxEnableWhilePaused_reverts() external {
         address proxyAdmin = address(systemConfig.proxyAdmin());
 
-        // Ensure ETH_LOCKBOX is enabled first (no pause active in fresh setup).
-        if (!systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-            vm.prank(proxyAdmin);
-            systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-            assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
-        }
+        _enableEthLockboxIfDisabled(proxyAdmin);
 
         // Pause globally.
         vm.prank(superchainConfig.guardian());
@@ -839,12 +771,7 @@ contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
     function test_setFeature_ethLockboxDisableWhilePaused_reverts() external {
         address proxyAdmin = address(systemConfig.proxyAdmin());
 
-        // Ensure ETH_LOCKBOX is enabled first.
-        if (!systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-            vm.prank(proxyAdmin);
-            systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-            assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
-        }
+        _enableEthLockboxIfDisabled(proxyAdmin);
 
         // Pause globally.
         vm.prank(superchainConfig.guardian());
@@ -897,9 +824,8 @@ contract SystemConfig_Guardian_Test is SystemConfig_TestInit {
     }
 }
 
-/// @title SystemConfig_Uncategorized_Test
-/// @notice General tests that are not testing any function directly of the `SystemConfig` contract
-///         are testing multiple functions at once.
+/// @title SystemConfig_SuperchainConfig_Test
+/// @notice Test contract for SystemConfig `superchainConfig` function.
 contract SystemConfig_SuperchainConfig_Test is SystemConfig_TestInit {
     /// @notice Tests that `superchainConfig()` returns the correct address.
     function test_superchainConfig_succeeds() external view {


### PR DESCRIPTION
Cleans up and simplifies the L1 test files for improved readability and maintainability.

- Promote ad-hoc test addresses and target balances to named `constant`s for clarity
- Inline single-use locals (e.g. proxy/implementation handles) inside `setUp`
- Replace repeated `vm.expectEmit(...)` boilerplate with focused `_expect*` helpers
- Use locally-scoped arrays instead of mutating shared storage in negative-path tests
- Tighten assertions to reduce duplication while preserving coverage