### PR TITLE
Fix inconsistent GitHub organization references in README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ For contract deployment artifacts, see [base-org/contract-deployments](https://g
 
 <!-- Badge row 1 - status -->
 
-[![GitHub contributors](https://img.shields.io/github/contributors/base-org/contracts)](https://github.com/base/contracts/graphs/contributors)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base-org/contracts)](https://github.com/base/contracts/graphs/contributors)
-[![GitHub Stars](https://img.shields.io/github/stars/base-org/contracts.svg)](https://github.com/base/contracts/stargazers)
+[![GitHub contributors](https://img.shields.io/github/contributors/base-org/contracts)](https://github.com/base-org/contracts/graphs/contributors)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base-org/contracts)](https://github.com/base-org/contracts/graphs/contributors)
+[![GitHub Stars](https://img.shields.io/github/stars/base-org/contracts.svg)](https://github.com/base-org/contracts/stargazers)
 ![GitHub repo size](https://img.shields.io/github/repo-size/base-org/contracts)
-[![GitHub](https://img.shields.io/github/license/base-org/contracts?color=blue)](https://github.com/base/contracts/blob/main/LICENSE)
+[![GitHub](https://img.shields.io/github/license/base-org/contracts?color=blue)](https://github.com/base-org/contracts/blob/main/LICENSE)
 
 <!-- Badge row 2 - links and profiles -->
 
@@ -24,8 +24,8 @@ For contract deployment artifacts, see [base-org/contract-deployments](https://g
 
 <!-- Badge row 3 - detailed status -->
 
-[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base-org/contracts)](https://github.com/base/contracts/pulls)
-[![GitHub Issues](https://img.shields.io/github/issues-raw/base-org/contracts.svg)](https://github.com/base/contracts/issues)
+[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base-org/contracts)](https://github.com/base-org/contracts/pulls)
+[![GitHub Issues](https://img.shields.io/github/issues-raw/base-org/contracts.svg)](https://github.com/base-org/contracts/issues)
 
 ### Fixing semver-lock CI failures
 


### PR DESCRIPTION
Fixes #259

The README.md had inconsistent GitHub organization references: the shields.io badge URLs used `base-org/contracts` while the hyperlink URLs used `base/contracts`. This PR makes all references consistently use `base-org/contracts` to match the badge URLs and the actual repository organization.

Changes:
- Updated all hyperlink URLs in badges from `https://github.com/base/contracts/...` to `https://github.com/base-org/contracts/...`

This ensures users are directed to the correct repository when clicking badge links.

**Base payout address:** `0x408f39B19266022FeC03076091e59D1f4f163658`

_Autonomous completion by Agentic Swarm Marketplace worker._