### PR TITLE
chore: clean up l2 tests

### DIFF
--- a/test/L2/BaseFeeVault.t.sol
+++ b/test/L2/BaseFeeVault.t.sol
@@ -18,7 +18,6 @@ contract BaseFeeVault_Uncategorized_Test is FeeVault_Uncategorized_Test {
     function setUp() public virtual override {
         super.setUp();
         recipient = deploy.cfg().baseFeeVaultRecipient();
-        feeVaultName = "BaseFeeVault";
         minWithdrawalAmount = deploy.cfg().baseFeeVaultMinimumWithdrawalAmount();
         feeVault = IFeeVault(payable(Predeploys.BASE_FEE_VAULT));
         withdrawalNetwork = Types.WithdrawalNetwork(uint8(deploy.cfg().baseFeeVaultWithdrawalNetwork()));

--- a/test/L2/FeeDisburser.t.sol
+++ b/test/L2/FeeDisburser.t.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.25;
 
 import { Test } from "lib/forge-std/src/Test.sol";
-import { console } from "lib/forge-std/src/console.sol";
 
 import { FeeDisburser } from "src/L2/FeeDisburser.sol";
 import { IFeeVault, Types } from "interfaces/L2/IFeeVault.sol";
+import { IStandardBridge } from "interfaces/universal/IStandardBridge.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 
 /// @title FeeDisburserTest
@@ -20,18 +20,19 @@ contract FeeDisburserTest is Test {
     uint32 constant WITHDRAWAL_MIN_GAS = 35_000;
     uint256 constant DEFAULT_MIN_WITHDRAWAL = 10 ether;
     uint256 constant DEFAULT_DISBURSEMENT_INTERVAL = 24 hours;
+    uint256 constant MAX_TEST_FEE = 10 ** 27;
 
     // Test addresses
-    address payable l1Wallet = payable(address(0x1001));
-    address alice = address(0xA11CE);
-    address bob = address(0xB0B);
+    address payable constant L1_WALLET = payable(address(0x1001));
+    address constant ALICE = address(0xA11CE);
+    address constant BOB = address(0xB0B);
 
     // Contract instances
     FeeDisburser feeDisburser;
 
     function setUp() public virtual {
         // Deploy FeeDisburser
-        feeDisburser = new FeeDisburser(l1Wallet, DEFAULT_DISBURSEMENT_INTERVAL);
+        feeDisburser = new FeeDisburser(L1_WALLET, DEFAULT_DISBURSEMENT_INTERVAL);
 
         // Warp time to allow first disbursement
         vm.warp(DEFAULT_DISBURSEMENT_INTERVAL + 1);
@@ -57,27 +58,43 @@ contract FeeDisburserTest is Test {
     )
         internal
     {
-        vm.mockCall(vault, abi.encodeWithSelector(IFeeVault.WITHDRAWAL_NETWORK.selector), abi.encode(network));
-        vm.mockCall(vault, abi.encodeWithSelector(IFeeVault.RECIPIENT.selector), abi.encode(recipient));
-        vm.mockCall(vault, abi.encodeWithSelector(IFeeVault.MIN_WITHDRAWAL_AMOUNT.selector), abi.encode(minWithdrawal));
+        vm.mockCall(vault, abi.encodeCall(IFeeVault.WITHDRAWAL_NETWORK, ()), abi.encode(network));
+        vm.mockCall(vault, abi.encodeCall(IFeeVault.RECIPIENT, ()), abi.encode(recipient));
+        vm.mockCall(vault, abi.encodeCall(IFeeVault.MIN_WITHDRAWAL_AMOUNT, ()), abi.encode(minWithdrawal));
     }
 
-    /// @notice Helper to setup a FeeVault withdrawal (vault sends ETH to recipient on withdraw())
-    function _setupVaultWithdrawal(address vault, uint256 balance) internal {
-        vm.deal(vault, balance);
-        // Mock withdraw() to send ETH to the feeDisburser
-        vm.mockCall(vault, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(balance));
-        // Make the vault actually send ETH on the mock call
-        vm.deal(address(feeDisburser), address(feeDisburser).balance + balance);
+    function _mockVaultWithdrawal(address vault, uint256 amount) internal {
+        vm.deal(vault, amount);
+        vm.mockCall(vault, abi.encodeCall(IFeeVault.withdraw, ()), abi.encode(amount));
+        vm.deal(address(feeDisburser), address(feeDisburser).balance + amount);
     }
 
-    /// @notice Helper to setup bridge mock
-    function _mockBridge() internal {
-        vm.mockCall(
-            Predeploys.L2_STANDARD_BRIDGE,
-            abi.encodeWithSignature("bridgeETHTo(address,uint32,bytes)", l1Wallet, WITHDRAWAL_MIN_GAS, bytes("")),
-            bytes("")
-        );
+    function _expectBridgeETH(uint256 amount) internal {
+        bytes memory bridgeCall =
+            abi.encodeCall(IStandardBridge.bridgeETHTo, (L1_WALLET, WITHDRAWAL_MIN_GAS, bytes("")));
+
+        vm.mockCall(Predeploys.L2_STANDARD_BRIDGE, bridgeCall, bytes(""));
+        vm.expectCall(Predeploys.L2_STANDARD_BRIDGE, amount, bridgeCall);
+    }
+
+    function _resetAfterMockedBridge() internal {
+        // vm.mockCall returns without moving ETH, so mirror the real bridge transfer between disbursements.
+        vm.deal(address(feeDisburser), 0);
+    }
+
+    function _expectFeesDisbursed(uint256 totalFees) internal {
+        vm.expectEmit(address(feeDisburser));
+        emit FeesDisbursed(block.timestamp, 0, totalFees);
+    }
+
+    function _expectFeesReceived(address sender, uint256 amount) internal {
+        vm.expectEmit(address(feeDisburser));
+        emit FeesReceived(sender, amount);
+    }
+
+    function _expectNoFeesCollected() internal {
+        vm.expectEmit(address(feeDisburser));
+        emit NoFeesCollected();
     }
 
     // ============================================================
@@ -85,22 +102,22 @@ contract FeeDisburserTest is Test {
     // ============================================================
 
     function test_constructor_success() public {
-        FeeDisburser newDisburser = new FeeDisburser(l1Wallet, DEFAULT_DISBURSEMENT_INTERVAL);
+        FeeDisburser newDisburser = new FeeDisburser(L1_WALLET, DEFAULT_DISBURSEMENT_INTERVAL);
 
-        assertEq(newDisburser.L1_WALLET(), l1Wallet);
+        assertEq(newDisburser.L1_WALLET(), L1_WALLET);
         assertEq(newDisburser.FEE_DISBURSEMENT_INTERVAL(), DEFAULT_DISBURSEMENT_INTERVAL);
         assertEq(newDisburser.WITHDRAWAL_MIN_GAS(), WITHDRAWAL_MIN_GAS);
         assertEq(newDisburser.lastDisbursementTime(), 0);
     }
 
     function test_constructor_success_exactlyMinimumInterval() public {
-        FeeDisburser newDisburser = new FeeDisburser(l1Wallet, 24 hours);
+        FeeDisburser newDisburser = new FeeDisburser(L1_WALLET, 24 hours);
         assertEq(newDisburser.FEE_DISBURSEMENT_INTERVAL(), 24 hours);
     }
 
     function test_constructor_success_largeInterval() public {
         uint256 largeInterval = 365 days;
-        FeeDisburser newDisburser = new FeeDisburser(l1Wallet, largeInterval);
+        FeeDisburser newDisburser = new FeeDisburser(L1_WALLET, largeInterval);
         assertEq(newDisburser.FEE_DISBURSEMENT_INTERVAL(), largeInterval);
     }
 
@@ -111,12 +128,12 @@ contract FeeDisburserTest is Test {
 
     function test_constructor_revert_intervalTooLow() public {
         vm.expectRevert(FeeDisburser.IntervalTooLow.selector);
-        new FeeDisburser(l1Wallet, 24 hours - 1);
+        new FeeDisburser(L1_WALLET, 24 hours - 1);
     }
 
     function test_constructor_revert_intervalZero() public {
         vm.expectRevert(FeeDisburser.IntervalTooLow.selector);
-        new FeeDisburser(l1Wallet, 0);
+        new FeeDisburser(L1_WALLET, 0);
     }
 
     // ============================================================
@@ -129,8 +146,7 @@ contract FeeDisburserTest is Test {
         vm.deal(Predeploys.BASE_FEE_VAULT, 0);
         vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit NoFeesCollected();
+        _expectNoFeesCollected();
 
         feeDisburser.disburseFees();
 
@@ -141,21 +157,13 @@ contract FeeDisburserTest is Test {
     function test_disburseFees_success_sequencerFeesOnly() public {
         uint256 feeAmount = DEFAULT_MIN_WITHDRAWAL;
 
-        // Setup sequencer vault withdrawal
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, feeAmount);
-        vm.mockCall(
-            Predeploys.SEQUENCER_FEE_WALLET, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(feeAmount)
-        );
-        vm.deal(address(feeDisburser), feeAmount);
-
-        // Other vaults below minimum
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, feeAmount);
         vm.deal(Predeploys.BASE_FEE_VAULT, 0);
         vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
-        _mockBridge();
+        _expectBridgeETH(feeAmount);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesDisbursed(block.timestamp, 0, feeAmount);
+        _expectFeesDisbursed(feeAmount);
 
         feeDisburser.disburseFees();
 
@@ -165,19 +173,13 @@ contract FeeDisburserTest is Test {
     function test_disburseFees_success_baseFeesOnly() public {
         uint256 feeAmount = DEFAULT_MIN_WITHDRAWAL;
 
-        // Setup base vault withdrawal
         vm.deal(Predeploys.SEQUENCER_FEE_WALLET, 0);
-        vm.deal(Predeploys.BASE_FEE_VAULT, feeAmount);
-        vm.mockCall(
-            Predeploys.BASE_FEE_VAULT, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(feeAmount)
-        );
-        vm.deal(address(feeDisburser), feeAmount);
+        _mockVaultWithdrawal(Predeploys.BASE_FEE_VAULT, feeAmount);
         vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
-        _mockBridge();
+        _expectBridgeETH(feeAmount);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesDisbursed(block.timestamp, 0, feeAmount);
+        _expectFeesDisbursed(feeAmount);
 
         feeDisburser.disburseFees();
 
@@ -187,17 +189,13 @@ contract FeeDisburserTest is Test {
     function test_disburseFees_success_l1FeesOnly() public {
         uint256 feeAmount = DEFAULT_MIN_WITHDRAWAL;
 
-        // Setup l1 fee vault withdrawal
         vm.deal(Predeploys.SEQUENCER_FEE_WALLET, 0);
         vm.deal(Predeploys.BASE_FEE_VAULT, 0);
-        vm.deal(Predeploys.L1_FEE_VAULT, feeAmount);
-        vm.mockCall(Predeploys.L1_FEE_VAULT, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(feeAmount));
-        vm.deal(address(feeDisburser), feeAmount);
+        _mockVaultWithdrawal(Predeploys.L1_FEE_VAULT, feeAmount);
 
-        _mockBridge();
+        _expectBridgeETH(feeAmount);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesDisbursed(block.timestamp, 0, feeAmount);
+        _expectFeesDisbursed(feeAmount);
 
         feeDisburser.disburseFees();
 
@@ -210,29 +208,13 @@ contract FeeDisburserTest is Test {
         uint256 l1Fees = DEFAULT_MIN_WITHDRAWAL * 3;
         uint256 totalFees = sequencerFees + baseFees + l1Fees;
 
-        // Setup all vault withdrawals
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, sequencerFees);
-        vm.mockCall(
-            Predeploys.SEQUENCER_FEE_WALLET,
-            abi.encodeWithSelector(IFeeVault.withdraw.selector),
-            abi.encode(sequencerFees)
-        );
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, sequencerFees);
+        _mockVaultWithdrawal(Predeploys.BASE_FEE_VAULT, baseFees);
+        _mockVaultWithdrawal(Predeploys.L1_FEE_VAULT, l1Fees);
 
-        vm.deal(Predeploys.BASE_FEE_VAULT, baseFees);
-        vm.mockCall(
-            Predeploys.BASE_FEE_VAULT, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(baseFees)
-        );
+        _expectBridgeETH(totalFees);
 
-        vm.deal(Predeploys.L1_FEE_VAULT, l1Fees);
-        vm.mockCall(Predeploys.L1_FEE_VAULT, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(l1Fees));
-
-        // FeeDisburser receives all the fees
-        vm.deal(address(feeDisburser), totalFees);
-
-        _mockBridge();
-
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesDisbursed(block.timestamp, 0, totalFees);
+        _expectFeesDisbursed(totalFees);
 
         feeDisburser.disburseFees();
 
@@ -245,8 +227,7 @@ contract FeeDisburserTest is Test {
         vm.deal(Predeploys.BASE_FEE_VAULT, DEFAULT_MIN_WITHDRAWAL - 1);
         vm.deal(Predeploys.L1_FEE_VAULT, DEFAULT_MIN_WITHDRAWAL - 1);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit NoFeesCollected();
+        _expectNoFeesCollected();
 
         feeDisburser.disburseFees();
 
@@ -257,39 +238,24 @@ contract FeeDisburserTest is Test {
         // Only sequencer vault has enough
         uint256 sequencerFees = DEFAULT_MIN_WITHDRAWAL;
 
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, sequencerFees);
-        vm.mockCall(
-            Predeploys.SEQUENCER_FEE_WALLET,
-            abi.encodeWithSelector(IFeeVault.withdraw.selector),
-            abi.encode(sequencerFees)
-        );
-        vm.deal(address(feeDisburser), sequencerFees);
-
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, sequencerFees);
         vm.deal(Predeploys.BASE_FEE_VAULT, DEFAULT_MIN_WITHDRAWAL - 1);
         vm.deal(Predeploys.L1_FEE_VAULT, DEFAULT_MIN_WITHDRAWAL - 1);
 
-        _mockBridge();
+        _expectBridgeETH(sequencerFees);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesDisbursed(block.timestamp, 0, sequencerFees);
+        _expectFeesDisbursed(sequencerFees);
 
         feeDisburser.disburseFees();
     }
 
     function test_disburseFees_revert_intervalNotReached() public {
         // First successful disbursal
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-        vm.mockCall(
-            Predeploys.SEQUENCER_FEE_WALLET,
-            abi.encodeWithSelector(IFeeVault.withdraw.selector),
-            abi.encode(DEFAULT_MIN_WITHDRAWAL)
-        );
-        vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
-
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
         vm.deal(Predeploys.BASE_FEE_VAULT, 0);
         vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
-        _mockBridge();
+        _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
 
         feeDisburser.disburseFees();
 
@@ -300,17 +266,11 @@ contract FeeDisburserTest is Test {
 
     function test_disburseFees_revert_intervalNotReached_oneSecondBefore() public {
         // First disbursal
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-        vm.mockCall(
-            Predeploys.SEQUENCER_FEE_WALLET,
-            abi.encodeWithSelector(IFeeVault.withdraw.selector),
-            abi.encode(DEFAULT_MIN_WITHDRAWAL)
-        );
-        vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
         vm.deal(Predeploys.BASE_FEE_VAULT, 0);
         vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
-        _mockBridge();
+        _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
 
         feeDisburser.disburseFees();
 
@@ -323,54 +283,41 @@ contract FeeDisburserTest is Test {
 
     function test_disburseFees_success_exactlyAtInterval() public {
         // First disbursal
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-        vm.mockCall(
-            Predeploys.SEQUENCER_FEE_WALLET,
-            abi.encodeWithSelector(IFeeVault.withdraw.selector),
-            abi.encode(DEFAULT_MIN_WITHDRAWAL)
-        );
-        vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
         vm.deal(Predeploys.BASE_FEE_VAULT, 0);
         vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
-        _mockBridge();
+        _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
 
         feeDisburser.disburseFees();
         uint256 firstDisbursementTime = block.timestamp;
+        _resetAfterMockedBridge();
 
         // Warp exactly to the interval
         vm.warp(firstDisbursementTime + DEFAULT_DISBURSEMENT_INTERVAL);
 
         // Fund vaults again
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-        vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
 
         // Should succeed
+        _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
         feeDisburser.disburseFees();
         assertEq(feeDisburser.lastDisbursementTime(), firstDisbursementTime + DEFAULT_DISBURSEMENT_INTERVAL);
     }
 
     function test_disburseFees_success_multipleDisbursements() public {
-        _mockBridge();
-
-        uint256 currentTime = block.timestamp;
         for (uint256 i = 0; i < 5; i++) {
-            vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-            vm.mockCall(
-                Predeploys.SEQUENCER_FEE_WALLET,
-                abi.encodeWithSelector(IFeeVault.withdraw.selector),
-                abi.encode(DEFAULT_MIN_WITHDRAWAL)
-            );
-            vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
+            _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
             vm.deal(Predeploys.BASE_FEE_VAULT, 0);
             vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
+            _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
             feeDisburser.disburseFees();
-            assertEq(feeDisburser.lastDisbursementTime(), currentTime);
+            assertEq(feeDisburser.lastDisbursementTime(), block.timestamp);
+            _resetAfterMockedBridge();
 
             // Warp past interval for next iteration
-            currentTime += DEFAULT_DISBURSEMENT_INTERVAL;
-            vm.warp(currentTime);
+            vm.warp(block.timestamp + DEFAULT_DISBURSEMENT_INTERVAL);
         }
     }
 
@@ -385,8 +332,8 @@ contract FeeDisburserTest is Test {
     }
 
     function test_disburseFees_revert_feeVaultWrongRecipient() public {
-        // Mock sequencer vault with wrong recipient (alice instead of feeDisburser)
-        _mockFeeVault(Predeploys.SEQUENCER_FEE_WALLET, alice, DEFAULT_MIN_WITHDRAWAL, Types.WithdrawalNetwork.L2);
+        // Mock sequencer vault with wrong recipient (ALICE instead of feeDisburser)
+        _mockFeeVault(Predeploys.SEQUENCER_FEE_WALLET, ALICE, DEFAULT_MIN_WITHDRAWAL, Types.WithdrawalNetwork.L2);
 
         vm.expectRevert(FeeDisburser.FeeVaultMustWithdrawToFeeDisburser.selector);
         feeDisburser.disburseFees();
@@ -414,7 +361,7 @@ contract FeeDisburserTest is Test {
         vm.deal(Predeploys.BASE_FEE_VAULT, 0);
 
         // L1 vault has wrong recipient
-        _mockFeeVault(Predeploys.L1_FEE_VAULT, bob, DEFAULT_MIN_WITHDRAWAL, Types.WithdrawalNetwork.L2);
+        _mockFeeVault(Predeploys.L1_FEE_VAULT, BOB, DEFAULT_MIN_WITHDRAWAL, Types.WithdrawalNetwork.L2);
 
         vm.expectRevert(FeeDisburser.FeeVaultMustWithdrawToFeeDisburser.selector);
         feeDisburser.disburseFees();
@@ -426,12 +373,11 @@ contract FeeDisburserTest is Test {
 
     function test_receive_success_anyAddress() public {
         uint256 amount = 1 ether;
-        vm.deal(alice, amount);
+        vm.deal(ALICE, amount);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesReceived(alice, amount);
+        _expectFeesReceived(ALICE, amount);
 
-        vm.prank(alice);
+        vm.prank(ALICE);
         (bool success,) = address(feeDisburser).call{ value: amount }("");
         assertTrue(success);
 
@@ -442,8 +388,7 @@ contract FeeDisburserTest is Test {
         uint256 amount = 5 ether;
         vm.deal(Predeploys.SEQUENCER_FEE_WALLET, amount);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesReceived(Predeploys.SEQUENCER_FEE_WALLET, amount);
+        _expectFeesReceived(Predeploys.SEQUENCER_FEE_WALLET, amount);
 
         vm.prank(Predeploys.SEQUENCER_FEE_WALLET);
         (bool success,) = address(feeDisburser).call{ value: amount }("");
@@ -454,8 +399,7 @@ contract FeeDisburserTest is Test {
         uint256 amount = 5 ether;
         vm.deal(Predeploys.BASE_FEE_VAULT, amount);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesReceived(Predeploys.BASE_FEE_VAULT, amount);
+        _expectFeesReceived(Predeploys.BASE_FEE_VAULT, amount);
 
         vm.prank(Predeploys.BASE_FEE_VAULT);
         (bool success,) = address(feeDisburser).call{ value: amount }("");
@@ -466,8 +410,7 @@ contract FeeDisburserTest is Test {
         uint256 amount = 5 ether;
         vm.deal(Predeploys.L1_FEE_VAULT, amount);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesReceived(Predeploys.L1_FEE_VAULT, amount);
+        _expectFeesReceived(Predeploys.L1_FEE_VAULT, amount);
 
         vm.prank(Predeploys.L1_FEE_VAULT);
         (bool success,) = address(feeDisburser).call{ value: amount }("");
@@ -475,10 +418,9 @@ contract FeeDisburserTest is Test {
     }
 
     function test_receive_success_zeroValue() public {
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesReceived(alice, 0);
+        _expectFeesReceived(ALICE, 0);
 
-        vm.prank(alice);
+        vm.prank(ALICE);
         (bool success,) = address(feeDisburser).call{ value: 0 }("");
         assertTrue(success);
     }
@@ -489,9 +431,9 @@ contract FeeDisburserTest is Test {
         for (uint256 i = 1; i <= 5; i++) {
             uint256 amount = i * 1 ether;
             totalExpected += amount;
-            vm.deal(alice, amount);
+            vm.deal(ALICE, amount);
 
-            vm.prank(alice);
+            vm.prank(ALICE);
             (bool success,) = address(feeDisburser).call{ value: amount }("");
             assertTrue(success);
         }
@@ -517,14 +459,14 @@ contract FeeDisburserTest is Test {
         vm.assume(_interval < 24 hours);
 
         vm.expectRevert(FeeDisburser.IntervalTooLow.selector);
-        new FeeDisburser(l1Wallet, _interval);
+        new FeeDisburser(L1_WALLET, _interval);
     }
 
     function testFuzz_disburseFees_varyingAmounts(uint256 _sequencerFees, uint256 _baseFees, uint256 _l1Fees) public {
         // Bound fees to reasonable values to avoid overflow
-        _sequencerFees = bound(_sequencerFees, 0, 10 ** 27);
-        _baseFees = bound(_baseFees, 0, 10 ** 27);
-        _l1Fees = bound(_l1Fees, 0, 10 ** 27);
+        _sequencerFees = bound(_sequencerFees, 0, MAX_TEST_FEE);
+        _baseFees = bound(_baseFees, 0, MAX_TEST_FEE);
+        _l1Fees = bound(_l1Fees, 0, MAX_TEST_FEE);
 
         // Setup vault balances and mocks
         vm.deal(Predeploys.SEQUENCER_FEE_WALLET, _sequencerFees);
@@ -534,37 +476,23 @@ contract FeeDisburserTest is Test {
         // Calculate expected total (only vaults >= MIN_WITHDRAWAL_AMOUNT will be withdrawn)
         uint256 expectedTotal = 0;
         if (_sequencerFees >= DEFAULT_MIN_WITHDRAWAL) {
-            vm.mockCall(
-                Predeploys.SEQUENCER_FEE_WALLET,
-                abi.encodeWithSelector(IFeeVault.withdraw.selector),
-                abi.encode(_sequencerFees)
-            );
+            _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, _sequencerFees);
             expectedTotal += _sequencerFees;
         }
         if (_baseFees >= DEFAULT_MIN_WITHDRAWAL) {
-            vm.mockCall(
-                Predeploys.BASE_FEE_VAULT, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(_baseFees)
-            );
+            _mockVaultWithdrawal(Predeploys.BASE_FEE_VAULT, _baseFees);
             expectedTotal += _baseFees;
         }
         if (_l1Fees >= DEFAULT_MIN_WITHDRAWAL) {
-            vm.mockCall(
-                Predeploys.L1_FEE_VAULT, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(_l1Fees)
-            );
+            _mockVaultWithdrawal(Predeploys.L1_FEE_VAULT, _l1Fees);
             expectedTotal += _l1Fees;
         }
 
-        // Give FeeDisburser the expected total
-        vm.deal(address(feeDisburser), expectedTotal);
-
-        _mockBridge();
-
         if (expectedTotal == 0) {
-            vm.expectEmit(true, true, true, true, address(feeDisburser));
-            emit NoFeesCollected();
+            _expectNoFeesCollected();
         } else {
-            vm.expectEmit(true, true, true, true, address(feeDisburser));
-            emit FeesDisbursed(block.timestamp, 0, expectedTotal);
+            _expectBridgeETH(expectedTotal);
+            _expectFeesDisbursed(expectedTotal);
         }
 
         feeDisburser.disburseFees();
@@ -577,38 +505,29 @@ contract FeeDisburserTest is Test {
     }
 
     function testFuzz_disburseFees_multipleIntervals(uint8 _numDisbursements) public {
-        vm.assume(_numDisbursements > 0 && _numDisbursements <= 50);
+        uint256 numDisbursements = bound(_numDisbursements, 1, 10);
 
-        _mockBridge();
-
-        uint256 currentTime = block.timestamp;
-        for (uint256 i = 0; i < _numDisbursements; i++) {
-            vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-            vm.mockCall(
-                Predeploys.SEQUENCER_FEE_WALLET,
-                abi.encodeWithSelector(IFeeVault.withdraw.selector),
-                abi.encode(DEFAULT_MIN_WITHDRAWAL)
-            );
-            vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
+        for (uint256 i = 0; i < numDisbursements; i++) {
+            _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
             vm.deal(Predeploys.BASE_FEE_VAULT, 0);
             vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
+            _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
             feeDisburser.disburseFees();
-            assertEq(feeDisburser.lastDisbursementTime(), currentTime);
+            assertEq(feeDisburser.lastDisbursementTime(), block.timestamp);
+            _resetAfterMockedBridge();
 
             // Warp past interval for next iteration
-            currentTime += DEFAULT_DISBURSEMENT_INTERVAL;
-            vm.warp(currentTime);
+            vm.warp(block.timestamp + DEFAULT_DISBURSEMENT_INTERVAL);
         }
     }
 
     function testFuzz_receive_anyAmount(address _sender, uint256 _amount) public {
         vm.assume(_sender != address(0));
-        _amount = bound(_amount, 0, 10 ** 27);
+        _amount = bound(_amount, 0, MAX_TEST_FEE);
         vm.deal(_sender, _amount);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesReceived(_sender, _amount);
+        _expectFeesReceived(_sender, _amount);
 
         vm.prank(_sender);
         (bool success,) = address(feeDisburser).call{ value: _amount }("");
@@ -619,35 +538,30 @@ contract FeeDisburserTest is Test {
 
     function testFuzz_intervalEnforcement(uint256 _timeWarp) public {
         // First disbursal
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-        vm.mockCall(
-            Predeploys.SEQUENCER_FEE_WALLET,
-            abi.encodeWithSelector(IFeeVault.withdraw.selector),
-            abi.encode(DEFAULT_MIN_WITHDRAWAL)
-        );
-        vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
         vm.deal(Predeploys.BASE_FEE_VAULT, 0);
         vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
-        _mockBridge();
+        _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
 
         feeDisburser.disburseFees();
 
         uint256 lastTime = feeDisburser.lastDisbursementTime();
+        _resetAfterMockedBridge();
 
         // Bound time warp to avoid overflow
         _timeWarp = bound(_timeWarp, 0, 365 days * 100);
         vm.warp(lastTime + _timeWarp);
 
         // Fund again
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-        vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
 
         if (_timeWarp < DEFAULT_DISBURSEMENT_INTERVAL) {
             vm.expectRevert(FeeDisburser.IntervalNotReached.selector);
             feeDisburser.disburseFees();
         } else {
             // Should succeed
+            _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
             feeDisburser.disburseFees();
             assertEq(feeDisburser.lastDisbursementTime(), lastTime + _timeWarp);
         }
@@ -664,33 +578,17 @@ contract FeeDisburserTest is Test {
         uint256 l1Fees = 200 ether;
         uint256 totalFees = sequencerFees + baseFees + l1Fees;
 
-        // Setup all vault withdrawals
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, sequencerFees);
-        vm.mockCall(
-            Predeploys.SEQUENCER_FEE_WALLET,
-            abi.encodeWithSelector(IFeeVault.withdraw.selector),
-            abi.encode(sequencerFees)
-        );
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, sequencerFees);
+        _mockVaultWithdrawal(Predeploys.BASE_FEE_VAULT, baseFees);
+        _mockVaultWithdrawal(Predeploys.L1_FEE_VAULT, l1Fees);
 
-        vm.deal(Predeploys.BASE_FEE_VAULT, baseFees);
-        vm.mockCall(
-            Predeploys.BASE_FEE_VAULT, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(baseFees)
-        );
-
-        vm.deal(Predeploys.L1_FEE_VAULT, l1Fees);
-        vm.mockCall(Predeploys.L1_FEE_VAULT, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(l1Fees));
-
-        // FeeDisburser receives all the fees
-        vm.deal(address(feeDisburser), totalFees);
-
-        _mockBridge();
+        _expectBridgeETH(totalFees);
 
         // Verify initial state
         assertEq(feeDisburser.lastDisbursementTime(), 0);
 
         // Execute disbursement
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesDisbursed(block.timestamp, 0, totalFees);
+        _expectFeesDisbursed(totalFees);
 
         feeDisburser.disburseFees();
 
@@ -725,20 +623,13 @@ contract FeeDisburserTest is Test {
 
     function test_edge_exactMinWithdrawalAmount() public {
         // Test with exactly the minimum withdrawal amount
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-        vm.mockCall(
-            Predeploys.SEQUENCER_FEE_WALLET,
-            abi.encodeWithSelector(IFeeVault.withdraw.selector),
-            abi.encode(DEFAULT_MIN_WITHDRAWAL)
-        );
-        vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
         vm.deal(Predeploys.BASE_FEE_VAULT, 0);
         vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
-        _mockBridge();
+        _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesDisbursed(block.timestamp, 0, DEFAULT_MIN_WITHDRAWAL);
+        _expectFeesDisbursed(DEFAULT_MIN_WITHDRAWAL);
 
         feeDisburser.disburseFees();
     }
@@ -749,36 +640,24 @@ contract FeeDisburserTest is Test {
         vm.deal(Predeploys.BASE_FEE_VAULT, DEFAULT_MIN_WITHDRAWAL - 1);
         vm.deal(Predeploys.L1_FEE_VAULT, DEFAULT_MIN_WITHDRAWAL - 1);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit NoFeesCollected();
+        _expectNoFeesCollected();
 
         feeDisburser.disburseFees();
     }
 
     function test_edge_veryLargeFees() public {
         // Test with very large fee amounts
-        uint256 largeFee = 10 ** 27; // 1 billion ETH
+        uint256 largeFee = MAX_TEST_FEE; // 1 billion ETH
 
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, largeFee);
-        vm.mockCall(
-            Predeploys.SEQUENCER_FEE_WALLET, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(largeFee)
-        );
-
-        vm.deal(Predeploys.BASE_FEE_VAULT, largeFee);
-        vm.mockCall(
-            Predeploys.BASE_FEE_VAULT, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(largeFee)
-        );
-
-        vm.deal(Predeploys.L1_FEE_VAULT, largeFee);
-        vm.mockCall(Predeploys.L1_FEE_VAULT, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(largeFee));
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, largeFee);
+        _mockVaultWithdrawal(Predeploys.BASE_FEE_VAULT, largeFee);
+        _mockVaultWithdrawal(Predeploys.L1_FEE_VAULT, largeFee);
 
         uint256 totalFees = largeFee * 3;
-        vm.deal(address(feeDisburser), totalFees);
 
-        _mockBridge();
+        _expectBridgeETH(totalFees);
 
-        vm.expectEmit(true, true, true, true, address(feeDisburser));
-        emit FeesDisbursed(block.timestamp, 0, totalFees);
+        _expectFeesDisbursed(totalFees);
 
         feeDisburser.disburseFees();
     }
@@ -788,17 +667,11 @@ contract FeeDisburserTest is Test {
         uint256 maxSafeTimestamp = type(uint256).max - DEFAULT_DISBURSEMENT_INTERVAL;
         vm.warp(maxSafeTimestamp);
 
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-        vm.mockCall(
-            Predeploys.SEQUENCER_FEE_WALLET,
-            abi.encodeWithSelector(IFeeVault.withdraw.selector),
-            abi.encode(DEFAULT_MIN_WITHDRAWAL)
-        );
-        vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
         vm.deal(Predeploys.BASE_FEE_VAULT, 0);
         vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
-        _mockBridge();
+        _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
 
         feeDisburser.disburseFees();
         assertEq(feeDisburser.lastDisbursementTime(), maxSafeTimestamp);
@@ -809,54 +682,38 @@ contract FeeDisburserTest is Test {
     // ============================================================
 
     function test_invariant_lastDisbursementTimeNeverDecreases() public {
-        _mockBridge();
-
         uint256 previousTime = 0;
-        uint256 currentWarpTime = block.timestamp;
 
         for (uint256 i = 0; i < 10; i++) {
-            vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-            vm.mockCall(
-                Predeploys.SEQUENCER_FEE_WALLET,
-                abi.encodeWithSelector(IFeeVault.withdraw.selector),
-                abi.encode(DEFAULT_MIN_WITHDRAWAL)
-            );
-            vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
+            _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
             vm.deal(Predeploys.BASE_FEE_VAULT, 0);
             vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
+            _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
             feeDisburser.disburseFees();
 
             uint256 currentTime = feeDisburser.lastDisbursementTime();
             assertTrue(currentTime >= previousTime, "lastDisbursementTime decreased!");
             previousTime = currentTime;
+            _resetAfterMockedBridge();
 
-            currentWarpTime += DEFAULT_DISBURSEMENT_INTERVAL;
-            vm.warp(currentWarpTime);
+            vm.warp(block.timestamp + DEFAULT_DISBURSEMENT_INTERVAL);
         }
     }
 
     function test_invariant_l1WalletNeverChanges() public {
         address initialL1Wallet = feeDisburser.L1_WALLET();
 
-        _mockBridge();
-
-        uint256 currentWarpTime = block.timestamp;
         // Perform multiple operations
         for (uint256 i = 0; i < 5; i++) {
-            vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-            vm.mockCall(
-                Predeploys.SEQUENCER_FEE_WALLET,
-                abi.encodeWithSelector(IFeeVault.withdraw.selector),
-                abi.encode(DEFAULT_MIN_WITHDRAWAL)
-            );
-            vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
+            _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
             vm.deal(Predeploys.BASE_FEE_VAULT, 0);
             vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
+            _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
             feeDisburser.disburseFees();
-            currentWarpTime += DEFAULT_DISBURSEMENT_INTERVAL;
-            vm.warp(currentWarpTime);
+            _resetAfterMockedBridge();
+            vm.warp(block.timestamp + DEFAULT_DISBURSEMENT_INTERVAL);
         }
 
         assertEq(feeDisburser.L1_WALLET(), initialL1Wallet, "L1_WALLET changed!");
@@ -865,24 +722,16 @@ contract FeeDisburserTest is Test {
     function test_invariant_disbursementIntervalNeverChanges() public {
         uint256 initialInterval = feeDisburser.FEE_DISBURSEMENT_INTERVAL();
 
-        _mockBridge();
-
-        uint256 currentWarpTime = block.timestamp;
         // Perform multiple operations
         for (uint256 i = 0; i < 5; i++) {
-            vm.deal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
-            vm.mockCall(
-                Predeploys.SEQUENCER_FEE_WALLET,
-                abi.encodeWithSelector(IFeeVault.withdraw.selector),
-                abi.encode(DEFAULT_MIN_WITHDRAWAL)
-            );
-            vm.deal(address(feeDisburser), DEFAULT_MIN_WITHDRAWAL);
+            _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, DEFAULT_MIN_WITHDRAWAL);
             vm.deal(Predeploys.BASE_FEE_VAULT, 0);
             vm.deal(Predeploys.L1_FEE_VAULT, 0);
 
+            _expectBridgeETH(DEFAULT_MIN_WITHDRAWAL);
             feeDisburser.disburseFees();
-            currentWarpTime += DEFAULT_DISBURSEMENT_INTERVAL;
-            vm.warp(currentWarpTime);
+            _resetAfterMockedBridge();
+            vm.warp(block.timestamp + DEFAULT_DISBURSEMENT_INTERVAL);
         }
 
         assertEq(feeDisburser.FEE_DISBURSEMENT_INTERVAL(), initialInterval, "FEE_DISBURSEMENT_INTERVAL changed!");
@@ -901,33 +750,22 @@ contract FeeDisburserTest is Test {
         feeDisburser.disburseFees();
         uint256 gasUsed = gasBefore - gasleft();
 
-        // Log for visibility (optional)
-        console.log("Gas used for no-fee disbursement:", gasUsed);
         assertTrue(gasUsed < 100_000, "Gas usage too high for no-fee case");
     }
 
     function test_gas_disburseFees_allVaults() public {
         uint256 fee = DEFAULT_MIN_WITHDRAWAL;
 
-        vm.deal(Predeploys.SEQUENCER_FEE_WALLET, fee);
-        vm.mockCall(
-            Predeploys.SEQUENCER_FEE_WALLET, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(fee)
-        );
+        _mockVaultWithdrawal(Predeploys.SEQUENCER_FEE_WALLET, fee);
+        _mockVaultWithdrawal(Predeploys.BASE_FEE_VAULT, fee);
+        _mockVaultWithdrawal(Predeploys.L1_FEE_VAULT, fee);
 
-        vm.deal(Predeploys.BASE_FEE_VAULT, fee);
-        vm.mockCall(Predeploys.BASE_FEE_VAULT, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(fee));
-
-        vm.deal(Predeploys.L1_FEE_VAULT, fee);
-        vm.mockCall(Predeploys.L1_FEE_VAULT, abi.encodeWithSelector(IFeeVault.withdraw.selector), abi.encode(fee));
-
-        vm.deal(address(feeDisburser), fee * 3);
-        _mockBridge();
+        _expectBridgeETH(fee * 3);
 
         uint256 gasBefore = gasleft();
         feeDisburser.disburseFees();
         uint256 gasUsed = gasBefore - gasleft();
 
-        console.log("Gas used for all-vault disbursement:", gasUsed);
         assertTrue(gasUsed < 200_000, "Gas usage too high for all-vault case");
     }
 }

--- a/test/L2/FeeVault.t.sol
+++ b/test/L2/FeeVault.t.sol
@@ -6,7 +6,6 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { Reverter } from "test/mocks/Callers.sol";
 
 // Interfaces
-import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
 import { IL2ToL1MessagePasser } from "interfaces/L2/IL2ToL1MessagePasser.sol";
 
@@ -17,9 +16,11 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Features } from "src/libraries/Features.sol";
 
 /// @title FeeVault_Uncategorized_Test
-/// @notice Abstract test contract for fee feeVault testing.
+/// @notice Abstract test contract for fee vault testing.
 ///         Subclasses can override the feeVault-specific variables.
 abstract contract FeeVault_Uncategorized_Test is CommonTest {
+    uint32 internal constant WITHDRAWAL_MIN_GAS = 400_000;
+
     // Variables that can be overridden by concrete test contracts
     address recipient;
     IFeeVault feeVault;
@@ -29,9 +30,15 @@ abstract contract FeeVault_Uncategorized_Test is CommonTest {
 
     /// @notice Helper function to set up L2 withdrawal configuration.
     function _setupL2Withdrawal() internal {
-        // Set the withdrawal network to L2
-        vm.prank(IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
+        vm.prank(proxyAdminOwner);
         feeVault.setWithdrawalNetwork(Types.WithdrawalNetwork.L2);
+    }
+
+    function _expectWithdrawalEvents(uint256 _amount, address _recipient, Types.WithdrawalNetwork _network) internal {
+        vm.expectEmit(address(feeVault));
+        emit Withdrawal(_amount, _recipient, address(this));
+        vm.expectEmit(address(feeVault));
+        emit Withdrawal(_amount, _recipient, address(this), _network);
     }
 
     /// @notice Tests that the initialize function succeeds.
@@ -63,19 +70,17 @@ abstract contract FeeVault_Uncategorized_Test is CommonTest {
         vm.prank(alice);
         (bool success,) = address(feeVault).call{ value: 100 }(hex"");
 
-        assertEq(success, true);
+        assertTrue(success);
         assertEq(address(feeVault).balance, balance + 100);
     }
 
     /// @notice Tests that `withdraw` reverts if the balance is less than the minimum withdrawal
     ///         amount.
     function testFuzz_withdraw_notEnough_reverts(uint256 _minWithdrawalAmount) external {
-        // Set the minimum withdrawal amount
         _minWithdrawalAmount = bound(_minWithdrawalAmount, 1, type(uint256).max);
-        vm.prank(IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
+        vm.prank(proxyAdminOwner);
         feeVault.setMinWithdrawalAmount(_minWithdrawalAmount);
 
-        // Set the balance to be less than the minimum withdrawal amount
         vm.deal(address(feeVault), _minWithdrawalAmount - 1);
 
         vm.expectRevert("FeeVault: withdrawal amount must be greater than minimum withdrawal amount");
@@ -86,61 +91,38 @@ abstract contract FeeVault_Uncategorized_Test is CommonTest {
     function test_withdraw_toL1_succeeds() external {
         skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
 
-        // Setup L1 withdrawal
-        vm.prank(IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
+        vm.prank(proxyAdminOwner);
         feeVault.setWithdrawalNetwork(Types.WithdrawalNetwork.L1);
 
-        // Set recipient
-        vm.prank(IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
-        feeVault.setRecipient(recipient);
-
-        // Set minimum withdrawal amount
-        vm.prank(IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
-        feeVault.setMinWithdrawalAmount(minWithdrawalAmount);
-
-        // Set the balance to be greater than the minimum withdrawal amount
-        uint256 amount = feeVault.minWithdrawalAmount() + 1;
+        uint256 amount = minWithdrawalAmount + 1;
         vm.deal(address(feeVault), amount);
 
-        // No ether has been withdrawn yet
         assertEq(feeVault.totalProcessed(), 0);
+        _expectWithdrawalEvents(amount, recipient, Types.WithdrawalNetwork.L1);
 
-        vm.expectEmit(address(address(feeVault)));
-        emit Withdrawal(address(feeVault).balance, recipient, address(this));
-        vm.expectEmit(address(address(feeVault)));
-        emit Withdrawal(address(feeVault).balance, recipient, address(this), Types.WithdrawalNetwork.L1);
-
-        // The entire feeVault's balance is withdrawn
         vm.expectCall(
             Predeploys.L2_TO_L1_MESSAGE_PASSER,
-            address(feeVault).balance,
-            abi.encodeCall(IL2ToL1MessagePasser.initiateWithdrawal, (recipient, 400_000, hex""))
+            amount,
+            abi.encodeCall(IL2ToL1MessagePasser.initiateWithdrawal, (recipient, WITHDRAWAL_MIN_GAS, hex""))
         );
 
-        // The message is passed to the correct recipient
-        vm.expectEmit(Predeploys.L2_TO_L1_MESSAGE_PASSER);
-        emit MessagePassed(
-            l2ToL1MessagePasser.messageNonce(),
-            address(feeVault),
-            recipient,
-            amount,
-            400_000,
-            hex"",
-            Hashing.hashWithdrawal(
-                Types.WithdrawalTransaction({
-                    nonce: l2ToL1MessagePasser.messageNonce(),
-                    sender: address(feeVault),
-                    target: recipient,
-                    value: amount,
-                    gasLimit: 400_000,
-                    data: hex""
-                })
-            )
+        uint256 nonce = l2ToL1MessagePasser.messageNonce();
+        bytes32 withdrawalHash = Hashing.hashWithdrawal(
+            Types.WithdrawalTransaction({
+                nonce: nonce,
+                sender: address(feeVault),
+                target: recipient,
+                value: amount,
+                gasLimit: WITHDRAWAL_MIN_GAS,
+                data: hex""
+            })
         );
+
+        vm.expectEmit(Predeploys.L2_TO_L1_MESSAGE_PASSER);
+        emit MessagePassed(nonce, address(feeVault), recipient, amount, WITHDRAWAL_MIN_GAS, hex"", withdrawalHash);
 
         feeVault.withdraw();
 
-        // The withdrawal was successful
         assertEq(feeVault.totalProcessed(), amount);
         assertEq(address(feeVault).balance, 0);
         assertEq(Predeploys.L2_TO_L1_MESSAGE_PASSER.balance, amount);
@@ -150,23 +132,16 @@ abstract contract FeeVault_Uncategorized_Test is CommonTest {
     function test_withdraw_toL2_succeeds() public {
         _setupL2Withdrawal();
 
-        uint256 amount = feeVault.minWithdrawalAmount() + 1;
+        uint256 amount = minWithdrawalAmount + 1;
         vm.deal(address(feeVault), amount);
 
-        // No ether has been withdrawn yet
         assertEq(feeVault.totalProcessed(), 0);
+        _expectWithdrawalEvents(amount, recipient, Types.WithdrawalNetwork.L2);
 
-        vm.expectEmit(address(address(feeVault)));
-        emit Withdrawal(address(feeVault).balance, feeVault.RECIPIENT(), address(this));
-        vm.expectEmit(address(address(feeVault)));
-        emit Withdrawal(address(feeVault).balance, feeVault.RECIPIENT(), address(this), Types.WithdrawalNetwork.L2);
-
-        // The entire feeVault's balance is withdrawn
-        vm.expectCall(recipient, address(feeVault).balance, bytes(""));
+        vm.expectCall(recipient, amount, bytes(""));
 
         uint256 withdrawnAmount = feeVault.withdraw();
 
-        // The withdrawal was successful
         assertEq(withdrawnAmount, amount);
         assertEq(feeVault.totalProcessed(), amount);
         assertEq(address(feeVault).balance, 0);
@@ -178,17 +153,15 @@ abstract contract FeeVault_Uncategorized_Test is CommonTest {
     function test_withdraw_toL2recipientReverts_fails() external {
         _setupL2Withdrawal();
 
-        uint256 amount = feeVault.minWithdrawalAmount();
+        uint256 amount = minWithdrawalAmount;
 
         vm.deal(address(feeVault), amount);
-        // No ether has been withdrawn yet
         assertEq(feeVault.totalProcessed(), 0);
 
         // Ensure the RECIPIENT reverts
-        vm.etch(feeVault.RECIPIENT(), type(Reverter).runtimeCode);
+        vm.etch(recipient, type(Reverter).runtimeCode);
 
-        // The entire feeVault's balance is withdrawn
-        vm.expectCall(recipient, address(feeVault).balance, bytes(""));
+        vm.expectCall(recipient, amount, bytes(""));
         vm.expectRevert("FeeVault: failed to send ETH to L2 fee recipient");
         feeVault.withdraw();
         assertEq(feeVault.totalProcessed(), 0);
@@ -196,77 +169,61 @@ abstract contract FeeVault_Uncategorized_Test is CommonTest {
 
     /// @notice Tests that the owner can successfully set minimum withdrawal amount with fuzz testing.
     function testFuzz_setMinWithdrawalAmount_succeeds(uint256 _newMinWithdrawalAmount) external {
-        address owner = IProxyAdmin(Predeploys.PROXY_ADMIN).owner();
+        vm.prank(proxyAdminOwner);
+        feeVault.setMinWithdrawalAmount(_newMinWithdrawalAmount);
 
-        vm.prank(owner);
-        IFeeVault(payable(address(feeVault))).setMinWithdrawalAmount(_newMinWithdrawalAmount);
-
-        // Verify the value was updated
         assertEq(feeVault.minWithdrawalAmount(), _newMinWithdrawalAmount);
     }
 
     /// @notice Tests that non-owner cannot set minimum withdrawal amount with fuzz testing.
     function testFuzz_setMinWithdrawalAmount_onlyOwner_reverts(address _caller, uint256 _newAmount) external {
-        address owner = IProxyAdmin(Predeploys.PROXY_ADMIN).owner();
-        vm.assume(_caller != owner);
+        vm.assume(_caller != proxyAdminOwner);
 
         uint256 initialAmount = feeVault.minWithdrawalAmount();
 
         vm.prank(_caller);
         vm.expectRevert(IFeeVault.FeeVault_OnlyProxyAdminOwner.selector);
-        IFeeVault(payable(address(feeVault))).setMinWithdrawalAmount(_newAmount);
+        feeVault.setMinWithdrawalAmount(_newAmount);
 
-        // Verify the value and boolean flag were NOT changed
         assertEq(feeVault.minWithdrawalAmount(), initialAmount);
     }
 
     /// @notice Tests that the owner can successfully set recipient with fuzz testing.
     function testFuzz_setRecipient_succeeds(address _newRecipient) external {
-        address owner = IProxyAdmin(Predeploys.PROXY_ADMIN).owner();
+        vm.prank(proxyAdminOwner);
+        feeVault.setRecipient(_newRecipient);
 
-        vm.prank(owner);
-        IFeeVault(payable(address(feeVault))).setRecipient(_newRecipient);
-
-        // Verify the value was updated
         assertEq(feeVault.recipient(), _newRecipient);
     }
 
     /// @notice Tests that non-owner cannot set recipient with fuzz testing.
     function testFuzz_setRecipient_onlyOwner_reverts(address _caller, address _newRecipient) external {
-        address owner = IProxyAdmin(Predeploys.PROXY_ADMIN).owner();
-        vm.assume(_caller != owner);
+        vm.assume(_caller != proxyAdminOwner);
 
         address initialRecipient = feeVault.recipient();
 
         vm.prank(_caller);
         vm.expectRevert(IFeeVault.FeeVault_OnlyProxyAdminOwner.selector);
-        IFeeVault(payable(address(feeVault))).setRecipient(_newRecipient);
+        feeVault.setRecipient(_newRecipient);
 
-        // Verify the value and boolean flag were NOT changed
         assertEq(feeVault.recipient(), initialRecipient);
     }
 
     /// @notice Tests that the owner can successfully set withdrawal network with fuzz testing.
     function testFuzz_setWithdrawalNetwork_succeeds(uint8 _networkValue) external {
-        // Bound to valid enum values (0 = L1, 1 = L2)
         _networkValue = uint8(bound(_networkValue, 0, 1));
         Types.WithdrawalNetwork newNetwork = Types.WithdrawalNetwork(_networkValue);
 
-        address owner = IProxyAdmin(Predeploys.PROXY_ADMIN).owner();
+        vm.prank(proxyAdminOwner);
+        feeVault.setWithdrawalNetwork(newNetwork);
 
-        vm.prank(owner);
-        IFeeVault(payable(address(feeVault))).setWithdrawalNetwork(newNetwork);
-
-        // Verify the value was updated
         assertEq(uint8(feeVault.withdrawalNetwork()), uint8(newNetwork));
     }
 
     /// @notice Tests that non-owner cannot set withdrawal network with fuzz testing.
     function testFuzz_setWithdrawalNetwork_onlyOwner_reverts(address _caller, uint8 _networkValue) external {
-        address owner = IProxyAdmin(Predeploys.PROXY_ADMIN).owner();
-        vm.assume(_caller != owner);
+        vm.assume(_caller != proxyAdminOwner);
 
-        // Bound to valid enum values
         _networkValue = uint8(bound(_networkValue, 0, 1));
         Types.WithdrawalNetwork newNetwork = Types.WithdrawalNetwork(_networkValue);
 
@@ -274,9 +231,8 @@ abstract contract FeeVault_Uncategorized_Test is CommonTest {
 
         vm.prank(_caller);
         vm.expectRevert(IFeeVault.FeeVault_OnlyProxyAdminOwner.selector);
-        IFeeVault(payable(address(feeVault))).setWithdrawalNetwork(newNetwork);
+        feeVault.setWithdrawalNetwork(newNetwork);
 
-        // Verify the value and boolean flag were NOT changed
         assertEq(uint8(feeVault.withdrawalNetwork()), uint8(initialNetwork));
     }
 }

--- a/test/L2/GasPriceOracle.t.sol
+++ b/test/L2/GasPriceOracle.t.sol
@@ -12,7 +12,6 @@ import { stdError } from "lib/forge-std/src/Test.sol";
 contract GasPriceOracle_Test is CommonTest {
     address depositor;
 
-    // The initial L1 context values
     uint64 constant number = 10;
     uint64 constant timestamp = 11;
     uint256 constant baseFee = 2 * (10 ** 6);
@@ -31,15 +30,43 @@ contract GasPriceOracle_Test is CommonTest {
     uint64 constant MAX_UINT64 = type(uint64).max;
     uint32 constant MAX_UINT32 = type(uint32).max;
 
-    /// @dev Sets up the test suite.
     function setUp() public virtual override {
         super.setUp();
         depositor = l1Block.DEPOSITOR_ACCOUNT();
     }
+
+    function _setEcotoneL1BlockValues() internal {
+        bytes memory calldataPacked = Encoding.encodeSetL1BlockValuesEcotone(
+            baseFeeScalar, blobBaseFeeScalar, sequenceNumber, timestamp, number, baseFee, blobBaseFee, hash, batcherHash
+        );
+
+        vm.prank(depositor);
+        (bool success,) = address(l1Block).call(calldataPacked);
+        require(success, "GasPriceOracle_Test: L1Block setup failed");
+    }
+
+    function _setIsthmusL1BlockValues(uint32 _operatorFeeScalar, uint64 _operatorFeeConstant) internal {
+        bytes memory calldataPacked = Encoding.encodeSetL1BlockValuesIsthmus(
+            baseFeeScalar,
+            blobBaseFeeScalar,
+            sequenceNumber,
+            timestamp,
+            number,
+            baseFee,
+            blobBaseFee,
+            hash,
+            batcherHash,
+            _operatorFeeScalar,
+            _operatorFeeConstant
+        );
+
+        vm.prank(depositor);
+        (bool success,) = address(l1Block).call(calldataPacked);
+        require(success, "GasPriceOracle_Test: L1Block setup failed");
+    }
 }
 
 contract GasPriceOracleBedrock_Test is GasPriceOracle_Test {
-    /// @dev Sets up the test suite.
     function setUp() public virtual override {
         // The gasPriceOracle tests rely on an L2 genesis that is not past Ecotone.
         l2Fork = Fork.DELTA;
@@ -59,42 +86,35 @@ contract GasPriceOracleBedrock_Test is GasPriceOracle_Test {
         });
     }
 
-    /// @dev Tests that `l1BaseFee` is set correctly.
     function test_l1BaseFee_succeeds() external view {
         assertEq(gasPriceOracle.l1BaseFee(), baseFee);
     }
 
-    /// @dev Tests that `gasPrice` is set correctly.
     function test_gasPrice_succeeds() external {
         vm.fee(100);
         uint256 gasPrice = gasPriceOracle.gasPrice();
         assertEq(gasPrice, 100);
     }
 
-    /// @dev Tests that `baseFee` is set correctly.
     function test_baseFee_succeeds() external {
         vm.fee(64);
         uint256 gasPrice = gasPriceOracle.baseFee();
         assertEq(gasPrice, 64);
     }
 
-    /// @dev Tests that `scalar` is set correctly.
     function test_scalar_succeeds() external view {
         assertEq(gasPriceOracle.scalar(), l1FeeScalar);
     }
 
-    /// @dev Tests that `overhead` is set correctly.
     function test_overhead_succeeds() external view {
         assertEq(gasPriceOracle.overhead(), l1FeeOverhead);
     }
 
-    /// @dev Tests that `decimals` is set correctly.
     function test_decimals_succeeds() external view {
         assertEq(gasPriceOracle.decimals(), 6);
         assertEq(gasPriceOracle.DECIMALS(), 6);
     }
 
-    /// @dev Tests that `setGasPrice` reverts since it was removed in bedrock.
     function test_setGasPrice_doesNotExist_reverts() external {
         // nosemgrep: sol-style-use-abi-encodecall
         (bool success, bytes memory returndata) =
@@ -104,7 +124,6 @@ contract GasPriceOracleBedrock_Test is GasPriceOracle_Test {
         assertEq(returndata, hex"");
     }
 
-    /// @dev Tests that `setL1BaseFee` reverts since it was removed in bedrock.
     function test_setL1BaseFee_doesNotExist_reverts() external {
         // nosemgrep: sol-style-use-abi-encodecall
         (bool success, bytes memory returndata) =
@@ -114,21 +133,18 @@ contract GasPriceOracleBedrock_Test is GasPriceOracle_Test {
         assertEq(returndata, hex"");
     }
 
-    /// @dev Tests that Fjord cannot be activated without activating Ecotone
     function test_setFjord_withoutEcotone_reverts() external {
         vm.prank(depositor);
         vm.expectRevert("GasPriceOracle: Fjord can only be activated after Ecotone");
         gasPriceOracle.setFjord();
     }
 
-    /// @dev Tests that Jovian activation requires Isthmus to be active first.
     function test_setJovian_requiresIsthmus_reverts() external {
         vm.prank(depositor);
         vm.expectRevert("GasPriceOracle: Jovian can only be activated after Isthmus");
         gasPriceOracle.setJovian();
     }
 
-    /// @dev Tests that `getL1Fee` returns the expected value when both fjord and ecotone are not active
     function test_getL1Fee_whenFjordAndEcotoneNotActive_succeeds() external {
         vm.store(address(gasPriceOracle), bytes32(uint256(0)), bytes32(0));
         bytes memory data = hex"1111";
@@ -139,7 +155,6 @@ contract GasPriceOracleBedrock_Test is GasPriceOracle_Test {
         // l1FeeScalar(i.e. 10)) / 1e6
     }
 
-    /// @dev Tests that `getL1GasUsed` returns the expected value when both fjord and ecotone are not active
     function test_getL1GasUsed_whenFjordAndEcotoneNotActive_succeeds() external {
         vm.store(address(gasPriceOracle), bytes32(uint256(0)), bytes32(0));
         bytes memory data = hex"1111";
@@ -150,81 +165,62 @@ contract GasPriceOracleBedrock_Test is GasPriceOracle_Test {
 }
 
 contract GasPriceOracleEcotone_Test is GasPriceOracle_Test {
-    /// @dev Sets up the test suite.
     function setUp() public virtual override {
         l2Fork = Fork.ECOTONE;
         super.setUp();
         assertEq(gasPriceOracle.isEcotone(), true);
 
-        bytes memory calldataPacked = Encoding.encodeSetL1BlockValuesEcotone(
-            baseFeeScalar, blobBaseFeeScalar, sequenceNumber, timestamp, number, baseFee, blobBaseFee, hash, batcherHash
-        );
-
-        // Execute the function call
-        vm.prank(depositor);
-        (bool success,) = address(l1Block).call(calldataPacked);
-        require(success, "GasPriceOracleEcotone_Test: Function call failed");
+        _setEcotoneL1BlockValues();
     }
 
-    /// @dev Tests that `setEcotone` is only callable by the depositor.
     function test_setEcotone_wrongCaller_reverts() external {
         vm.expectRevert("GasPriceOracle: only the depositor account can set isEcotone flag");
         gasPriceOracle.setEcotone();
     }
 
-    /// @dev Tests that `gasPrice` is set correctly.
     function test_gasPrice_succeeds() external {
         vm.fee(100);
         uint256 gasPrice = gasPriceOracle.gasPrice();
         assertEq(gasPrice, 100);
     }
 
-    /// @dev Tests that `baseFee` is set correctly.
     function test_baseFee_succeeds() external {
         vm.fee(64);
         uint256 gasPrice = gasPriceOracle.baseFee();
         assertEq(gasPrice, 64);
     }
 
-    /// @dev Tests that `overhead` reverts since it was removed in ecotone.
     function test_overhead_legacyFunction_reverts() external {
         vm.expectRevert("GasPriceOracle: overhead() is deprecated");
         gasPriceOracle.overhead();
     }
 
-    /// @dev Tests that `scalar` reverts since it was removed in ecotone.
     function test_scalar_legacyFunction_reverts() external {
         vm.expectRevert("GasPriceOracle: scalar() is deprecated");
         gasPriceOracle.scalar();
     }
 
-    /// @dev Tests that `l1BaseFee` is set correctly.
     function test_l1BaseFee_succeeds() external view {
         assertEq(gasPriceOracle.l1BaseFee(), baseFee);
     }
 
-    /// @dev Tests that `blobBaseFee` is set correctly.
     function test_blobBaseFee_succeeds() external view {
         assertEq(gasPriceOracle.blobBaseFee(), blobBaseFee);
     }
 
-    /// @dev Tests that `baseFeeScalar` is set correctly.
     function test_baseFeeScalar_succeeds() external view {
         assertEq(gasPriceOracle.baseFeeScalar(), baseFeeScalar);
     }
 
-    /// @dev Tests that `blobBaseFeeScalar` is set correctly.
     function test_blobBaseFeeScalar_succeeds() external view {
         assertEq(gasPriceOracle.blobBaseFeeScalar(), blobBaseFeeScalar);
     }
 
-    /// @dev Tests that `decimals` is set correctly.
     function test_decimals_succeeds() external view {
         assertEq(gasPriceOracle.decimals(), 6);
         assertEq(gasPriceOracle.DECIMALS(), 6);
     }
 
-    /// @dev Tests that `getL1GasUsed` and `getL1Fee` return expected values
     function test_getL1Fee_succeeds() external view {
         bytes memory data = hex"0000010203"; // 2 zero bytes, 3 non-zero bytes
         // (2*4) + (3*16) + (68*16) == 1144
@@ -235,7 +231,6 @@ contract GasPriceOracleEcotone_Test is GasPriceOracle_Test {
         assertEq(price, 48977);
     }
 
-    /// @dev Tests that `setFjord` is only callable by the depositor.
     function test_setFjord_wrongCaller_reverts() external {
         vm.expectRevert("GasPriceOracle: only the depositor account can set isFjord flag");
         gasPriceOracle.setFjord();
@@ -243,81 +238,62 @@ contract GasPriceOracleEcotone_Test is GasPriceOracle_Test {
 }
 
 contract GasPriceOracleFjordActive_Test is GasPriceOracle_Test {
-    /// @dev Sets up the test suite.
     function setUp() public virtual override {
         l2Fork = Fork.FJORD;
         super.setUp();
 
-        bytes memory calldataPacked = Encoding.encodeSetL1BlockValuesEcotone(
-            baseFeeScalar, blobBaseFeeScalar, sequenceNumber, timestamp, number, baseFee, blobBaseFee, hash, batcherHash
-        );
-
-        vm.prank(depositor);
-        (bool success,) = address(l1Block).call(calldataPacked);
-        require(success, "GasPriceOracleFjordActive_Test: Function call failed");
+        _setEcotoneL1BlockValues();
     }
 
-    /// @dev Tests that `setFjord` cannot be called when Fjord is already activate
     function test_setFjord_whenFjordActive_reverts() external {
         vm.expectRevert("GasPriceOracle: Fjord already active");
         vm.prank(depositor);
         gasPriceOracle.setFjord();
     }
 
-    /// @dev Tests that `gasPrice` is set correctly.
     function test_gasPrice_succeeds() external {
         vm.fee(100);
         uint256 gasPrice = gasPriceOracle.gasPrice();
         assertEq(gasPrice, 100);
     }
 
-    /// @dev Tests that `baseFee` is set correctly.
     function test_baseFee_succeeds() external {
         vm.fee(64);
         uint256 gasPrice = gasPriceOracle.baseFee();
         assertEq(gasPrice, 64);
     }
 
-    /// @dev Tests that `overhead` reverts since it was removed in ecotone.
     function test_overhead_legacyFunction_reverts() external {
         vm.expectRevert("GasPriceOracle: overhead() is deprecated");
         gasPriceOracle.overhead();
     }
 
-    /// @dev Tests that `scalar` reverts since it was removed in ecotone.
     function test_scalar_legacyFunction_reverts() external {
         vm.expectRevert("GasPriceOracle: scalar() is deprecated");
         gasPriceOracle.scalar();
     }
 
-    /// @dev Tests that `l1BaseFee` is set correctly.
     function test_l1BaseFee_succeeds() external view {
         assertEq(gasPriceOracle.l1BaseFee(), baseFee);
     }
 
-    /// @dev Tests that `blobBaseFee` is set correctly.
     function test_blobBaseFee_succeeds() external view {
         assertEq(gasPriceOracle.blobBaseFee(), blobBaseFee);
     }
 
-    /// @dev Tests that `baseFeeScalar` is set correctly.
     function test_baseFeeScalar_succeeds() external view {
         assertEq(gasPriceOracle.baseFeeScalar(), baseFeeScalar);
     }
 
-    /// @dev Tests that `blobBaseFeeScalar` is set correctly.
     function test_blobBaseFeeScalar_succeeds() external view {
         assertEq(gasPriceOracle.blobBaseFeeScalar(), blobBaseFeeScalar);
     }
 
-    /// @dev Tests that `decimals` is set correctly.
     function test_decimals_succeeds() external view {
         assertEq(gasPriceOracle.decimals(), 6);
         assertEq(gasPriceOracle.DECIMALS(), 6);
     }
 
-    /// @dev Tests that `getL1GasUsed`, `getL1Fee` and `getL1FeeUpperBound` return expected values
-    ///      for the minimum bound of the linear regression
     function test_getL1FeeMinimumBound_succeeds() external view {
         bytes memory data = hex"0000010203"; // fastlzSize: 74, inc signature
         uint256 gas = gasPriceOracle.getL1GasUsed(data);
@@ -337,8 +313,6 @@ contract GasPriceOracleFjordActive_Test is GasPriceOracle_Test {
         assertEq(upperBound, 68500);
     }
 
-    /// @dev Tests that `getL1GasUsed`, `getL1Fee` and `getL1FeeUpperBound` return expected values
-    ///      for a specific test transaction
     function test_getL1FeeRegression_succeeds() external view {
         // fastlzSize: 235, inc signature
         bytes memory data = hex"1d2c3ec4f5a9b3f3cd2c024e455c1143a74bbd637c324adcbd4f74e346786ac44e23e78f47d932abedd8d1"
@@ -361,7 +335,6 @@ contract GasPriceOracleFjordActive_Test is GasPriceOracle_Test {
         assertEq(upperBound, 111214);
     }
 
-    /// @dev Tests that `operatorFee` is 0 is Isthmus is not activated.
     function test_getOperatorFee_succeeds() external view {
         assertEq(gasPriceOracle.isIsthmus(), false);
         assertEq(gasPriceOracle.getOperatorFee(10), 0);
@@ -369,46 +342,25 @@ contract GasPriceOracleFjordActive_Test is GasPriceOracle_Test {
 }
 
 contract GasPriceOracleIsthmus_Test is GasPriceOracle_Test {
-    /// @dev Sets up the test suite.
     function setUp() public virtual override {
         l2Fork = Fork.ISTHMUS;
         super.setUp();
 
-        bytes memory calldataPacked = Encoding.encodeSetL1BlockValuesIsthmus(
-            baseFeeScalar,
-            blobBaseFeeScalar,
-            sequenceNumber,
-            timestamp,
-            number,
-            baseFee,
-            blobBaseFee,
-            hash,
-            batcherHash,
-            operatorFeeScalar,
-            operatorFeeConstant
-        );
-
-        vm.prank(depositor);
-        (bool success,) = address(l1Block).call(calldataPacked);
-        require(success, "GasPriceOracleIsthmus_Test: Function call failed");
+        _setIsthmusL1BlockValues(operatorFeeScalar, operatorFeeConstant);
     }
 
-    /// @dev Tests that `operatorFee` is set correctly using the Isthmus formula (divide by 1e6).
     function test_getOperatorFee_succeeds() external view {
         assertEq(gasPriceOracle.getOperatorFee(10), 10 * operatorFeeScalar / 1e6 + operatorFeeConstant);
     }
 
-    /// @dev Tests that `setIsthmus` is only callable by the depositor.
     function test_setIsthmus_wrongCaller_reverts() external {
         vm.expectRevert("GasPriceOracle: only the depositor account can set isIsthmus flag");
         gasPriceOracle.setIsthmus();
     }
 
-    /// @dev Tests that Jovian cannot be activated yet (since it's not activated by default).
     function test_setJovian_notActivated_succeeds() external {
         assertEq(gasPriceOracle.isJovian(), false);
 
-        // Activate Jovian
         vm.prank(depositor);
         gasPriceOracle.setJovian();
 
@@ -417,32 +369,14 @@ contract GasPriceOracleIsthmus_Test is GasPriceOracle_Test {
 }
 
 contract GasPriceOracleJovian_Test is GasPriceOracle_Test {
-    /// @dev Sets up the test suite with Isthmus parameters configured.
     function setUp() public virtual override {
         l2Fork = Fork.ISTHMUS;
         super.setUp();
 
-        // Configure Isthmus state on the L1 block.
-        bytes memory calldataPacked = Encoding.encodeSetL1BlockValuesIsthmus(
-            baseFeeScalar,
-            blobBaseFeeScalar,
-            sequenceNumber,
-            timestamp,
-            number,
-            baseFee,
-            blobBaseFee,
-            hash,
-            batcherHash,
-            operatorFeeScalar,
-            operatorFeeConstant
-        );
-
-        vm.prank(depositor);
-        (bool success,) = address(l1Block).call(calldataPacked);
-        require(success, "GasPriceOracleJovian_Test: L1Block setup failed");
+        _setIsthmusL1BlockValues(operatorFeeScalar, operatorFeeConstant);
 
         assertEq(gasPriceOracle.isIsthmus(), true, "Isthmus should be active before enabling Jovian");
-        assertEq(gasPriceOracle.isJovian(), false, "Jovian starts active");
+        assertEq(gasPriceOracle.isJovian(), false, "Jovian starts inactive");
     }
 
     function _activateJovian() internal {
@@ -451,40 +385,16 @@ contract GasPriceOracleJovian_Test is GasPriceOracle_Test {
         assertEq(gasPriceOracle.isJovian(), true, "Jovian activation failed");
     }
 
-    function _setOperatorFeeParams(uint32 _operatorFeeScalar, uint64 _operatorFeeConstant) internal {
-        vm.prank(depositor);
-        (bool success,) = address(l1Block)
-            .call(
-                Encoding.encodeSetL1BlockValuesIsthmus(
-                    baseFeeScalar,
-                    blobBaseFeeScalar,
-                    sequenceNumber,
-                    timestamp,
-                    number,
-                    baseFee,
-                    blobBaseFee,
-                    hash,
-                    batcherHash,
-                    _operatorFeeScalar,
-                    _operatorFeeConstant
-                )
-            );
-        require(success, "GasPriceOracleJovian_Test: L1Block setup failed");
-    }
-
-    /// @dev Tests that `operatorFee` is set correctly using the new Jovian formula (multiply by 100).
     function test_getOperatorFee_succeeds() external {
         _activateJovian();
         assertEq(gasPriceOracle.getOperatorFee(10), 10 * operatorFeeScalar * 100 + operatorFeeConstant);
     }
 
-    /// @dev Tests that `setJovian` is only callable by the depositor.
     function test_setJovian_wrongCaller_reverts() external {
         vm.expectRevert("GasPriceOracle: only the depositor account can set isJovian flag");
         gasPriceOracle.setJovian();
     }
 
-    /// @dev Tests that `setJovian` cannot be activated twice.
     function test_setJovian_alreadyActive_reverts() external {
         _activateJovian();
         vm.prank(depositor);
@@ -492,10 +402,9 @@ contract GasPriceOracleJovian_Test is GasPriceOracle_Test {
         gasPriceOracle.setJovian();
     }
 
-    /// @dev Tests the transition from Isthmus formula to Jovian formula.
     function test_formulaTransition_edgeCases_works() external {
         // Check Isthmus formula with a low gasUsed value (divide by 1e6)
-        _setOperatorFeeParams(operatorFeeScalar, operatorFeeConstant);
+        _setIsthmusL1BlockValues(operatorFeeScalar, operatorFeeConstant);
         uint256 isthmusFee = gasPriceOracle.getOperatorFee(10);
         assertEq(
             isthmusFee,
@@ -506,7 +415,7 @@ contract GasPriceOracleJovian_Test is GasPriceOracle_Test {
         // Use maximum values permitted by data types for scalars.
         // Use maximum value for gasUsed according to client implementations.
         // Assert that the fee is as expected (no overflow).
-        _setOperatorFeeParams(MAX_UINT32, MAX_UINT64);
+        _setIsthmusL1BlockValues(MAX_UINT32, MAX_UINT64);
         isthmusFee = gasPriceOracle.getOperatorFee(MAX_UINT64);
         assertEq(
             isthmusFee,
@@ -516,19 +425,18 @@ contract GasPriceOracleJovian_Test is GasPriceOracle_Test {
 
         // Show that the math saturates if the maximum
         // value for gasUsed (according to data type) is used.
-        _setOperatorFeeParams(1e6, 1);
+        _setIsthmusL1BlockValues(1e6, 1);
         uint256 saturatedIsthmusFee = gasPriceOracle.getOperatorFee(MAX_UINT256);
         assertEq(
             saturatedIsthmusFee,
-            115792089237316195423570985008687907853269984665640564039457584007913130,
+            MAX_UINT256 / 1e6 + 1,
             "Incorrect value for fee under Isthmus (saturating arithmetic triggered)"
         );
 
-        // Activate Jovian
         _activateJovian();
 
         // Check Jovian formula with a low gasUsed value (multiply by 100)
-        _setOperatorFeeParams(operatorFeeScalar, operatorFeeConstant);
+        _setIsthmusL1BlockValues(operatorFeeScalar, operatorFeeConstant);
         uint256 jovianFee = gasPriceOracle.getOperatorFee(10);
         assertEq(
             jovianFee,
@@ -539,7 +447,7 @@ contract GasPriceOracleJovian_Test is GasPriceOracle_Test {
         // Use maximum values permitted by data types for scalars.
         // Use maximum value for gasUsed according to client implementations.
         // Assert that the fee is as expected (no overflow).
-        _setOperatorFeeParams(MAX_UINT32, MAX_UINT64);
+        _setIsthmusL1BlockValues(MAX_UINT32, MAX_UINT64);
         jovianFee = gasPriceOracle.getOperatorFee(MAX_UINT64);
         assertEq(
             jovianFee,
@@ -549,7 +457,7 @@ contract GasPriceOracleJovian_Test is GasPriceOracle_Test {
 
         // Show that a revert is possible if the maximum
         // value for gasUsed (according to data type) is used.
-        _setOperatorFeeParams(1, 1);
+        _setIsthmusL1BlockValues(1, 1);
         vm.expectRevert(stdError.arithmeticError);
         gasPriceOracle.getOperatorFee(MAX_UINT256);
 

--- a/test/L2/L1Block.t.sol
+++ b/test/L2/L1Block.t.sol
@@ -3,16 +3,17 @@ pragma solidity 0.8.15;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
-import { stdStorage, StdStorage } from "lib/forge-std/src/Test.sol";
 
 // Libraries
 import { Encoding } from "src/libraries/Encoding.sol";
-import { Constants } from "src/libraries/Constants.sol";
-import { Features } from "src/libraries/Features.sol";
 
 /// @title L1Block_ TestInit
 /// @notice Reusable test initialization for `L1Block` tests.
 abstract contract L1Block_TestInit is CommonTest {
+    bytes4 internal constant NOT_DEPOSITOR_SELECTOR = 0x3cc50b45;
+    bytes32 internal constant LEGACY_HIGH_BITS_MASK =
+        hex"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000";
+
     address depositor;
 
     /// @notice Sets up the test suite.
@@ -23,14 +24,23 @@ abstract contract L1Block_TestInit is CommonTest {
 
     /// @notice Asserts that legacy high 128-bit ranges in key storage slots remain zeroed.
     function assertEmptyLegacySlotRanges() internal view {
-        // 128 high bits mask for 32-byte word
-        bytes32 mask128 = hex"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000";
-        // Check scalars and sequenceNumber slot (slot 3)
         bytes32 scalarsSlot = vm.load(address(l1Block), bytes32(uint256(3)));
-        assertEq(0, scalarsSlot & mask128);
-        // Check number and timestamp slot (slot 0)
+        assertEq(0, scalarsSlot & LEGACY_HIGH_BITS_MASK);
+
         bytes32 numberTimestampSlot = vm.load(address(l1Block), bytes32(uint256(0)));
-        assertEq(0, numberTimestampSlot & mask128);
+        assertEq(0, numberTimestampSlot & LEGACY_HIGH_BITS_MASK);
+    }
+
+    function assertDepositorCallSucceeds(bytes memory callData) internal {
+        vm.prank(depositor);
+        (bool success,) = address(l1Block).call(callData);
+        assertTrue(success, "function call failed");
+    }
+
+    function assertNotDepositorReverts(bytes memory callData) internal {
+        (bool success, bytes memory data) = address(l1Block).call(callData);
+        assertFalse(success, "function call should have failed");
+        assertEq(data, abi.encodeWithSelector(NOT_DEPOSITOR_SELECTOR));
     }
 }
 
@@ -40,7 +50,7 @@ contract L1Block_Version_Test is L1Block_TestInit {
     /// @notice Tests that the version function returns a valid string. We avoid testing the
     ///         specific value of the string as it changes frequently.
     function test_version_succeeds() external view {
-        assert(bytes(l1Block.version()).length > 0);
+        assertGt(bytes(l1Block.version()).length, 0);
     }
 }
 
@@ -106,6 +116,20 @@ contract L1Block_SetL1BlockValues_Test is L1Block_TestInit {
 /// @title L1Block_SetL1BlockValuesEcotone_Test
 /// @notice Tests the `setL1BlockValuesEcotone` function of the `L1Block` contract.
 contract L1Block_SetL1BlockValuesEcotone_Test is L1Block_TestInit {
+    function encodeMaxSetL1BlockValuesEcotone() internal pure returns (bytes memory) {
+        return Encoding.encodeSetL1BlockValuesEcotone(
+            type(uint32).max,
+            type(uint32).max,
+            type(uint64).max,
+            type(uint64).max,
+            type(uint64).max,
+            type(uint256).max,
+            type(uint256).max,
+            bytes32(type(uint256).max),
+            bytes32(type(uint256).max)
+        );
+    }
+
     /// @notice Tests that setL1BlockValuesEcotone updates the values appropriately.
     function testFuzz_setL1BlockValuesEcotone_succeeds(
         uint32 baseFeeScalar,
@@ -124,9 +148,7 @@ contract L1Block_SetL1BlockValuesEcotone_Test is L1Block_TestInit {
             baseFeeScalar, blobBaseFeeScalar, sequenceNumber, timestamp, number, baseFee, blobBaseFee, hash, batcherHash
         );
 
-        vm.prank(depositor);
-        (bool success,) = address(l1Block).call(functionCallDataPacked);
-        assertTrue(success, "Function call failed");
+        assertDepositorCallSucceeds(functionCallDataPacked);
 
         assertEq(l1Block.baseFeeScalar(), baseFeeScalar);
         assertEq(l1Block.blobBaseFeeScalar(), blobBaseFeeScalar);
@@ -143,48 +165,34 @@ contract L1Block_SetL1BlockValuesEcotone_Test is L1Block_TestInit {
 
     /// @notice Tests that `setL1BlockValuesEcotone` succeeds with max values
     function test_setL1BlockValuesEcotone_isDepositorMax_succeeds() external {
-        bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesEcotone(
-            type(uint32).max,
-            type(uint32).max,
-            type(uint64).max,
-            type(uint64).max,
-            type(uint64).max,
-            type(uint256).max,
-            type(uint256).max,
-            bytes32(type(uint256).max),
-            bytes32(type(uint256).max)
-        );
-
-        vm.prank(depositor);
-        (bool success,) = address(l1Block).call(functionCallDataPacked);
-        assertTrue(success, "function call failed");
+        assertDepositorCallSucceeds(encodeMaxSetL1BlockValuesEcotone());
     }
 
     /// @notice Tests that `setL1BlockValuesEcotone` reverts if sender address is not the depositor
     function test_setL1BlockValuesEcotone_notDepositor_reverts() external {
-        bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesEcotone(
-            type(uint32).max,
-            type(uint32).max,
-            type(uint64).max,
-            type(uint64).max,
-            type(uint64).max,
-            type(uint256).max,
-            type(uint256).max,
-            bytes32(type(uint256).max),
-            bytes32(type(uint256).max)
-        );
-
-        (bool success, bytes memory data) = address(l1Block).call(functionCallDataPacked);
-        assertTrue(!success, "function call should have failed");
-        // make sure return value is the expected function selector for "NotDepositor()"
-        bytes memory expReturn = hex"3cc50b45";
-        assertEq(data, expReturn);
+        assertNotDepositorReverts(encodeMaxSetL1BlockValuesEcotone());
     }
 }
 
 /// @title L1Block_SetL1BlockValuesIsthmus_Test
 /// @notice Tests the `setL1BlockValuesIsthmus` function of the `L1Block` contract.
 contract L1Block_SetL1BlockValuesIsthmus_Test is L1Block_TestInit {
+    function encodeMaxSetL1BlockValuesIsthmus() internal pure returns (bytes memory) {
+        return Encoding.encodeSetL1BlockValuesIsthmus(
+            type(uint32).max,
+            type(uint32).max,
+            type(uint64).max,
+            type(uint64).max,
+            type(uint64).max,
+            type(uint256).max,
+            type(uint256).max,
+            bytes32(type(uint256).max),
+            bytes32(type(uint256).max),
+            type(uint32).max,
+            type(uint64).max
+        );
+    }
+
     /// @notice Tests that setL1BlockValuesIsthmus updates the values appropriately.
     function testFuzz_setL1BlockValuesIsthmus_succeeds(
         uint32 baseFeeScalar,
@@ -215,9 +223,7 @@ contract L1Block_SetL1BlockValuesIsthmus_Test is L1Block_TestInit {
             operatorFeeConstant
         );
 
-        vm.prank(depositor);
-        (bool success,) = address(l1Block).call(functionCallDataPacked);
-        assertTrue(success, "Function call failed");
+        assertDepositorCallSucceeds(functionCallDataPacked);
 
         assertEq(l1Block.baseFeeScalar(), baseFeeScalar);
         assertEq(l1Block.blobBaseFeeScalar(), blobBaseFeeScalar);
@@ -236,46 +242,12 @@ contract L1Block_SetL1BlockValuesIsthmus_Test is L1Block_TestInit {
 
     /// @notice Tests that `setL1BlockValuesIsthmus` succeeds with max values
     function test_setL1BlockValuesIsthmus_isDepositorMax_succeeds() external {
-        bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesIsthmus(
-            type(uint32).max,
-            type(uint32).max,
-            type(uint64).max,
-            type(uint64).max,
-            type(uint64).max,
-            type(uint256).max,
-            type(uint256).max,
-            bytes32(type(uint256).max),
-            bytes32(type(uint256).max),
-            type(uint32).max,
-            type(uint64).max
-        );
-
-        vm.prank(depositor);
-        (bool success,) = address(l1Block).call(functionCallDataPacked);
-        assertTrue(success, "function call failed");
+        assertDepositorCallSucceeds(encodeMaxSetL1BlockValuesIsthmus());
     }
 
     /// @notice Tests that `setL1BlockValuesIsthmus` reverts if sender address is not the depositor
     function test_setL1BlockValuesIsthmus_notDepositor_reverts() external {
-        bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesIsthmus(
-            type(uint32).max,
-            type(uint32).max,
-            type(uint64).max,
-            type(uint64).max,
-            type(uint64).max,
-            type(uint256).max,
-            type(uint256).max,
-            bytes32(type(uint256).max),
-            bytes32(type(uint256).max),
-            type(uint32).max,
-            type(uint64).max
-        );
-
-        (bool success, bytes memory data) = address(l1Block).call(functionCallDataPacked);
-        assertTrue(!success, "function call should have failed");
-        // make sure return value is the expected function selector for "NotDepositor()"
-        bytes memory expReturn = hex"3cc50b45";
-        assertEq(data, expReturn);
+        assertNotDepositorReverts(encodeMaxSetL1BlockValuesIsthmus());
     }
 }
 
@@ -332,9 +304,7 @@ contract L1Block_SetL1BlockValuesJovian_Test is L1Block_TestInit {
             params.daFootprintGasScalar
         );
 
-        vm.prank(depositor);
-        (bool success,) = address(l1Block).call(functionCallDataPacked);
-        assertTrue(success, "Function call failed");
+        assertDepositorCallSucceeds(functionCallDataPacked);
 
         assertEq(l1Block.baseFeeScalar(), params.baseFeeScalar);
         assertEq(l1Block.blobBaseFeeScalar(), params.blobBaseFeeScalar);
@@ -354,11 +324,7 @@ contract L1Block_SetL1BlockValuesJovian_Test is L1Block_TestInit {
 
     /// @notice Tests that `setL1BlockValuesJovian` succeeds with max values
     function test_setL1BlockValuesJovian_isDepositorMax_succeeds() external {
-        bytes memory functionCallDataPacked = encodeMaxSetL1BlockValuesJovian();
-
-        vm.prank(depositor);
-        (bool success,) = address(l1Block).call(functionCallDataPacked);
-        assertTrue(success, "function call failed");
+        assertDepositorCallSucceeds(encodeMaxSetL1BlockValuesJovian());
     }
 
     /// @notice Prevents the L1 attributes system transaction from approaching its gas limit.
@@ -367,20 +333,12 @@ contract L1Block_SetL1BlockValuesJovian_Test is L1Block_TestInit {
 
         bytes memory functionCallDataPacked = encodeMaxSetL1BlockValuesJovian();
 
-        vm.prank(depositor);
-        (bool success,) = address(l1Block).call(functionCallDataPacked);
-        assertTrue(success, "function call failed");
+        assertDepositorCallSucceeds(functionCallDataPacked);
         assertLt(vm.lastCallGas().gasTotalUsed, 200_000);
     }
 
     /// @notice Tests that `setL1BlockValuesJovian` reverts if sender address is not the depositor
     function test_setL1BlockValuesJovian_notDepositor_reverts() external {
-        bytes memory functionCallDataPacked = encodeMaxSetL1BlockValuesJovian();
-
-        (bool success, bytes memory data) = address(l1Block).call(functionCallDataPacked);
-        assertTrue(!success, "function call should have failed");
-        // make sure return value is the expected function selector for "NotDepositor()"
-        bytes memory expReturn = hex"3cc50b45";
-        assertEq(data, expReturn);
+        assertNotDepositorReverts(encodeMaxSetL1BlockValuesJovian());
     }
 }

--- a/test/L2/L1FeeVault.t.sol
+++ b/test/L2/L1FeeVault.t.sol
@@ -1,35 +1,25 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Interfaces
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
-
-// Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { FeeVault_Uncategorized_Test } from "test/L2/FeeVault.t.sol";
 import { Types } from "src/libraries/Types.sol";
 import { SemverComp } from "src/libraries/SemverComp.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 
-/// @title L1FeeVault_Version_Test
-/// @notice Tests the `version` function of the `L1FeeVault` contract.
 contract L1FeeVault_Version_Test is CommonTest {
-    /// @notice Tests that the version returns a valid semver string.
     function test_version_succeeds() external view {
         SemverComp.parse(l1FeeVault.version());
     }
 }
 
-/// @title L1FeeVault_Uncategorized_Test
-/// @notice Test contract for the L1FeeVault contract's functionality
 contract L1FeeVault_Uncategorized_Test is FeeVault_Uncategorized_Test {
-    /// @dev Sets up the test suite.
     function setUp() public virtual override {
         super.setUp();
         recipient = deploy.cfg().l1FeeVaultRecipient();
-        feeVaultName = "L1FeeVault";
         minWithdrawalAmount = deploy.cfg().l1FeeVaultMinimumWithdrawalAmount();
         feeVault = IFeeVault(payable(Predeploys.L1_FEE_VAULT));
-        withdrawalNetwork = Types.WithdrawalNetwork(uint8(deploy.cfg().l1FeeVaultWithdrawalNetwork()));
+        withdrawalNetwork = Types.WithdrawalNetwork(deploy.cfg().l1FeeVaultWithdrawalNetwork());
     }
 }

--- a/test/L2/L2CrossDomainMessenger.t.sol
+++ b/test/L2/L2CrossDomainMessenger.t.sol
@@ -12,7 +12,6 @@ import { Hashing } from "src/libraries/Hashing.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
 import { Types } from "src/libraries/Types.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
-import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
 
 // Interfaces
 import { IL2CrossDomainMessenger } from "interfaces/L2/IL2CrossDomainMessenger.sol";
@@ -21,8 +20,7 @@ import { IL2ToL1MessagePasser } from "interfaces/L2/IL2ToL1MessagePasser.sol";
 /// @title L2CrossDomainMessenger_TestInit
 /// @notice Reusable test initialization for `L2CrossDomainMessenger` tests.
 abstract contract L2CrossDomainMessenger_TestInit is CommonTest {
-    /// @notice Receiver address for testing
-    address recipient = address(0xabbaacdc);
+    address internal constant recipient = address(0xabbaacdc);
 }
 
 /// @title L2CrossDomainMessenger_Constructor_Test
@@ -73,38 +71,42 @@ contract L2CrossDomainMessenger_SendMessage_Test is L2CrossDomainMessenger_TestI
 
     /// @notice Tests that `sendMessage` executes successfully with the original test case.
     function test_sendMessage_succeeds() external {
+        uint32 minGasLimit = 100;
+        bytes memory message = hex"ff";
+        uint256 nonce = l2CrossDomainMessenger.messageNonce();
+        uint256 withdrawalNonce = l2ToL1MessagePasser.messageNonce();
+        uint64 baseGas = l2CrossDomainMessenger.baseGas(message, minGasLimit);
         bytes memory xDomainCallData =
-            Encoding.encodeCrossDomainMessage(l2CrossDomainMessenger.messageNonce(), alice, recipient, 0, 100, hex"ff");
+            Encoding.encodeCrossDomainMessage(nonce, alice, recipient, 0, minGasLimit, message);
         vm.expectCall(
             address(l2ToL1MessagePasser),
             abi.encodeCall(
-                IL2ToL1MessagePasser.initiateWithdrawal,
-                (address(l1CrossDomainMessenger), l2CrossDomainMessenger.baseGas(hex"ff", 100), xDomainCallData)
+                IL2ToL1MessagePasser.initiateWithdrawal, (address(l1CrossDomainMessenger), baseGas, xDomainCallData)
             )
         );
 
         vm.expectEmit(true, true, true, true);
         emit MessagePassed(
-            l2ToL1MessagePasser.messageNonce(),
+            withdrawalNonce,
             address(l2CrossDomainMessenger),
             address(l1CrossDomainMessenger),
             0,
-            l2CrossDomainMessenger.baseGas(hex"ff", 100),
+            baseGas,
             xDomainCallData,
             Hashing.hashWithdrawal(
                 Types.WithdrawalTransaction({
-                    nonce: l2ToL1MessagePasser.messageNonce(),
+                    nonce: withdrawalNonce,
                     sender: address(l2CrossDomainMessenger),
                     target: address(l1CrossDomainMessenger),
                     value: 0,
-                    gasLimit: l2CrossDomainMessenger.baseGas(hex"ff", 100),
+                    gasLimit: baseGas,
                     data: xDomainCallData
                 })
             )
         );
 
         vm.prank(alice);
-        l2CrossDomainMessenger.sendMessage(recipient, hex"ff", uint32(100));
+        l2CrossDomainMessenger.sendMessage(recipient, message, minGasLimit);
     }
 
     /// @notice Tests that `sendMessage` can be called twice and that the nonce increments correctly.
@@ -120,6 +122,25 @@ contract L2CrossDomainMessenger_SendMessage_Test is L2CrossDomainMessenger_TestI
 /// @notice General tests that are not testing any function directly of the
 ///         `L2CrossDomainMessenger` contract.
 contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_TestInit {
+    uint256 internal constant l2SenderSlotIndex = 50;
+
+    function _versionedNonce(uint16 _version) internal pure returns (uint256) {
+        return Encoding.encodeVersionedNonce({ _nonce: 0, _version: _version });
+    }
+
+    function _l1MessengerAlias() internal view returns (address) {
+        return AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
+    }
+
+    function _setPortalL2Sender(address _sender) internal {
+        vm.store(address(optimismPortal2), bytes32(l2SenderSlotIndex), bytes32(abi.encode(_sender)));
+    }
+
+    function _assertMessageStatus(bytes32 _hash, bool _successful, bool _failed) internal view {
+        assertEq(l2CrossDomainMessenger.successfulMessages(_hash), _successful);
+        assertEq(l2CrossDomainMessenger.failedMessages(_hash), _failed);
+    }
+
     /// @notice Tests that `messageNonce` can be decoded correctly.
     function test_messageVersion_succeeds() external view {
         (, uint16 version) = Encoding.decodeVersionedNonce(l2CrossDomainMessenger.messageNonce());
@@ -136,28 +157,20 @@ contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_Tes
     function test_relayMessage_v2_reverts() external {
         address target = address(0xabcd);
         address sender = address(l1CrossDomainMessenger);
-        address caller = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
+        address caller = _l1MessengerAlias();
 
-        // Expect a revert.
         vm.expectRevert("CrossDomainMessenger: only version 0 or 1 messages are supported at this time");
 
-        // Try to relay a v2 message.
         vm.prank(caller);
-        l2CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce(0, 2), // nonce
-            sender,
-            target,
-            0, // value
-            0,
-            hex"1111"
-        );
+        l2CrossDomainMessenger.relayMessage(_versionedNonce(2), sender, target, 0, 0, hex"1111");
     }
 
     /// @notice Tests that `relayMessage` executes successfully.
     function test_relayMessage_succeeds() external {
         address target = address(0xabcd);
         address sender = address(l1CrossDomainMessenger);
-        address caller = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
+        address caller = _l1MessengerAlias();
+        uint256 nonce = _versionedNonce(1);
 
         vm.expectCall(target, hex"1111");
 
@@ -165,106 +178,67 @@ contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_Tes
 
         vm.expectEmit(true, true, true, true);
 
-        bytes32 hash =
-            Hashing.hashCrossDomainMessage(Encoding.encodeVersionedNonce(0, 1), sender, target, 0, 0, hex"1111");
+        bytes32 hash = Hashing.hashCrossDomainMessage(nonce, sender, target, 0, 0, hex"1111");
 
         emit RelayedMessage(hash);
 
-        l2CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce(0, 1), // nonce
-            sender,
-            target,
-            0, // value
-            0,
-            hex"1111"
-        );
+        l2CrossDomainMessenger.relayMessage(nonce, sender, target, 0, 0, hex"1111");
 
-        // the message hash is in the successfulMessages mapping
-        assert(l2CrossDomainMessenger.successfulMessages(hash));
-        // it is not in the received messages mapping
-        assertEq(l2CrossDomainMessenger.failedMessages(hash), false);
+        _assertMessageStatus(hash, true, false);
     }
 
     /// @notice Tests that `relayMessage` reverts if the value sent does not match the amount
     function test_relayMessage_fromOtherMessengerValueMismatch_reverts() external {
-        // set the target to be alice
         address target = alice;
         address sender = address(l1CrossDomainMessenger);
-        address caller = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
+        address caller = _l1MessengerAlias();
         bytes memory message = hex"1111";
 
-        // cannot send a message where the amount inputted does not match the msg.value
         vm.deal(caller, 10 ether);
         vm.prank(caller);
         vm.expectRevert(stdError.assertionError);
-        l2CrossDomainMessenger.relayMessage{ value: 10 ether }(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, target, 9 ether, 0, message
-        );
+        l2CrossDomainMessenger.relayMessage{ value: 10 ether }(_versionedNonce(1), sender, target, 9 ether, 0, message);
     }
 
     /// @notice Tests that `relayMessage` reverts if a failed message is attempted to be replayed
     ///         and the caller is the other messenger
     function test_relayMessage_fromOtherMessengerFailedMessageReplay_reverts() external {
-        // set the target to be alice
         address target = alice;
         address sender = address(l1CrossDomainMessenger);
-        address caller = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
+        address caller = _l1MessengerAlias();
+        uint256 nonce = _versionedNonce(1);
         bytes memory message = hex"1111";
 
-        // make a failed message
         vm.etch(target, hex"fe");
         vm.prank(caller);
-        l2CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, target, 0, 0, message
-        );
+        l2CrossDomainMessenger.relayMessage(nonce, sender, target, 0, 0, message);
 
-        // cannot replay messages when the caller is the other messenger
         vm.prank(caller);
         vm.expectRevert(stdError.assertionError);
-        l2CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, target, 0, 0, message
-        );
+        l2CrossDomainMessenger.relayMessage(nonce, sender, target, 0, 0, message);
     }
 
     /// @notice Tests that `relayMessage` reverts if attempting to relay a message sent to self
     function test_relayMessage_toSelf_reverts() external {
         address sender = address(l1CrossDomainMessenger);
-        address caller = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
+        address caller = _l1MessengerAlias();
         bytes memory message = hex"1111";
-
-        vm.store(address(optimismPortal2), bytes32(0), bytes32(abi.encode(sender)));
 
         vm.prank(caller);
         vm.expectRevert("CrossDomainMessenger: cannot send message to blocked system address");
-        l2CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
-            sender,
-            address(l2CrossDomainMessenger),
-            0,
-            0,
-            message
-        );
+        l2CrossDomainMessenger.relayMessage(_versionedNonce(1), sender, address(l2CrossDomainMessenger), 0, 0, message);
     }
 
     /// @notice Tests that `relayMessage` reverts if attempting to relay a message sent to the
     ///         `l2ToL1MessagePasser` address
     function test_relayMessage_toL2ToL1MessagePasser_reverts() external {
         address sender = address(l1CrossDomainMessenger);
-        address caller = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
+        address caller = _l1MessengerAlias();
         bytes memory message = hex"1111";
-
-        vm.store(address(optimismPortal2), bytes32(0), bytes32(abi.encode(sender)));
 
         vm.prank(caller);
         vm.expectRevert("CrossDomainMessenger: cannot send message to blocked system address");
-        l2CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
-            sender,
-            address(l2ToL1MessagePasser),
-            0,
-            0,
-            message
-        );
+        l2CrossDomainMessenger.relayMessage(_versionedNonce(1), sender, address(l2ToL1MessagePasser), 0, 0, message);
     }
 
     /// @notice Tests that `relayMessage` reverts if the message called by non-`optimismPortal2`
@@ -274,13 +248,9 @@ contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_Tes
         address sender = address(l1CrossDomainMessenger);
         bytes memory message = hex"1111";
 
-        vm.store(address(optimismPortal2), bytes32(0), bytes32(abi.encode(sender)));
-
         vm.prank(bob);
         vm.expectRevert("CrossDomainMessenger: message cannot be replayed");
-        l2CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, target, 0, 0, message
-        );
+        l2CrossDomainMessenger.relayMessage(_versionedNonce(1), sender, target, 0, 0, message);
     }
 
     /// @notice Tests that `relayMessage` on L2 will always succeed for any potential message,
@@ -327,7 +297,7 @@ contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_Tes
 
         // Encode the message.
         bytes memory encoded = Encoding.encodeCrossDomainMessage(
-            Encoding.encodeVersionedNonce(0, 1), // nonce
+            _versionedNonce(1),
             alice, // Sender doesn't matter
             target,
             0, // Value doesn't matter
@@ -335,40 +305,36 @@ contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_Tes
             _message
         );
 
-        // Count the number of non-zero bytes in the message.
-        uint256 zeroBytesInCalldata = 0;
+        // Count calldata bytes so the EIP-7623 floor can be checked against actual encoded data.
         uint256 nonzeroBytesInCalldata = 0;
         for (uint256 i = 0; i < encoded.length; i++) {
             if (encoded[i] != bytes1(0)) {
                 nonzeroBytesInCalldata++;
-            } else {
-                zeroBytesInCalldata++;
             }
         }
 
+        uint256 zeroBytesInCalldata = encoded.length - nonzeroBytesInCalldata;
+        uint256 calldataTokens = zeroBytesInCalldata + nonzeroBytesInCalldata * 4;
+        uint256 floorCost = l2CrossDomainMessenger.TX_BASE_GAS() + calldataTokens
+            * (l2CrossDomainMessenger.FLOOR_CALLDATA_OVERHEAD() / 4);
+
         // Base gas must always be sufficient to cover the floor cost from EIP-7623.
-        assertGt(baseGas, 21000 + ((zeroBytesInCalldata + nonzeroBytesInCalldata * 4) * 10));
+        assertGt(baseGas, floorCost);
+
+        _setPortalL2Sender(address(l2CrossDomainMessenger));
+
+        vm.prank(address(optimismPortal2));
 
         // In the L2 => L1 direction we actually get all of the base gas supplied, nothing is
         // deducted. This is an advantage over the L1 => L2 direction because it means the base
         // gas goes a lot further.
-        uint256 gasSupplied = baseGas;
-
-        // Store the value of l2Sender in the OptimismPortal2 contract.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("OptimismPortal2", "l2Sender");
-        vm.store(address(optimismPortal2), bytes32(slot.slot), bytes32(abi.encode(address(l2CrossDomainMessenger))));
-
-        // We'll trigger the L1CrossDomainMessenger as if we're the OptimismPortal2
-        vm.prank(address(optimismPortal2));
-
-        // Trigger the L1CrossDomainMessenger.
-        // Should NOT fail.
-        (bool success,) = address(l1CrossDomainMessenger).call{ gas: gasSupplied }(encoded);
+        (bool success,) = address(l1CrossDomainMessenger).call{ gas: baseGas }(encoded);
         assertTrue(success, "L1CrossDomainMessenger call should not fail");
 
         // Message should either be in the failed or successful messages mapping.
-        bool inFailedMessages = l1CrossDomainMessenger.failedMessages(keccak256(encoded));
-        bool inSuccessfulMessages = l1CrossDomainMessenger.successfulMessages(keccak256(encoded));
+        bytes32 encodedHash = keccak256(encoded);
+        bool inFailedMessages = l1CrossDomainMessenger.failedMessages(encodedHash);
+        bool inSuccessfulMessages = l1CrossDomainMessenger.successfulMessages(encodedHash);
         assertTrue(
             inFailedMessages || inSuccessfulMessages, "message should be in either failed or successful messages"
         );
@@ -380,9 +346,9 @@ contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_Tes
         vm.expectRevert("CrossDomainMessenger: xDomainMessageSender is not set");
         l2CrossDomainMessenger.xDomainMessageSender();
 
-        address caller = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
+        address caller = _l1MessengerAlias();
         vm.prank(caller);
-        l2CrossDomainMessenger.relayMessage(Encoding.encodeVersionedNonce(0, 1), address(0), address(0), 0, 0, hex"");
+        l2CrossDomainMessenger.relayMessage(_versionedNonce(1), address(0), address(0), 0, 0, hex"");
 
         vm.expectRevert("CrossDomainMessenger: xDomainMessageSender is not set");
         l2CrossDomainMessenger.xDomainMessageSender();
@@ -393,28 +359,20 @@ contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_Tes
     function test_relayMessage_retry_succeeds() external {
         address target = address(0xabcd);
         address sender = address(l1CrossDomainMessenger);
-        address caller = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
+        address caller = _l1MessengerAlias();
+        uint256 nonce = _versionedNonce(1);
         uint256 value = 100;
 
-        bytes32 hash =
-            Hashing.hashCrossDomainMessage(Encoding.encodeVersionedNonce(0, 1), sender, target, value, 0, hex"1111");
+        bytes32 hash = Hashing.hashCrossDomainMessage(nonce, sender, target, value, 0, hex"1111");
 
         vm.etch(target, address(new Reverter()).code);
         vm.deal(address(caller), value);
         vm.prank(caller);
-        l2CrossDomainMessenger.relayMessage{ value: value }(
-            Encoding.encodeVersionedNonce(0, 1), // nonce
-            sender,
-            target,
-            value,
-            0,
-            hex"1111"
-        );
+        l2CrossDomainMessenger.relayMessage{ value: value }(nonce, sender, target, value, 0, hex"1111");
 
         assertEq(address(l2CrossDomainMessenger).balance, value);
         assertEq(address(target).balance, 0);
-        assertEq(l2CrossDomainMessenger.successfulMessages(hash), false);
-        assertEq(l2CrossDomainMessenger.failedMessages(hash), true);
+        _assertMessageStatus(hash, false, true);
 
         vm.expectEmit(true, true, true, true);
 
@@ -422,18 +380,10 @@ contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_Tes
 
         vm.etch(target, address(0).code);
         vm.prank(address(sender));
-        l2CrossDomainMessenger.relayMessage(
-            Encoding.encodeVersionedNonce(0, 1), // nonce
-            sender,
-            target,
-            value,
-            0,
-            hex"1111"
-        );
+        l2CrossDomainMessenger.relayMessage(nonce, sender, target, value, 0, hex"1111");
 
         assertEq(address(l2CrossDomainMessenger).balance, 0);
         assertEq(address(target).balance, value);
-        assertEq(l2CrossDomainMessenger.successfulMessages(hash), true);
-        assertEq(l2CrossDomainMessenger.failedMessages(hash), true);
+        _assertMessageStatus(hash, true, true);
     }
 }

--- a/test/L2/L2ERC721Bridge.t.sol
+++ b/test/L2/L2ERC721Bridge.t.sol
@@ -5,22 +5,11 @@ pragma solidity 0.8.15;
 import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Contracts
-import { ERC721 } from "lib/openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
 import { OptimismMintableERC721 } from "src/L2/OptimismMintableERC721.sol";
 
 // Interfaces
 import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
-import { IL2ERC721Bridge } from "interfaces/L2/IL2ERC721Bridge.sol";
-
-/// @title TestERC721
-/// @notice A test ERC721 token used for `L2ERC721Bridge` tests.
-contract L2ERC721Bridge_TestERC721_Harness is ERC721 {
-    constructor() ERC721("Test", "TST") { }
-
-    function mint(address to, uint256 tokenId) public {
-        _mint(to, tokenId);
-    }
-}
+import { ICrossDomainMessenger } from "interfaces/universal/ICrossDomainMessenger.sol";
 
 /// @title TestMintableERC721
 /// @notice A test OptimismMintableERC721 token used for `L2ERC721Bridge` tests.
@@ -53,9 +42,7 @@ contract L2ERC721Bridge_NonCompliantERC721_Harness {
         return address(0x01);
     }
 
-    function burn(address, uint256) external {
-        // Do nothing.
-    }
+    function burn(address, uint256) external { }
 
     function supportsInterface(bytes4) external pure returns (bool) {
         return false;
@@ -65,9 +52,10 @@ contract L2ERC721Bridge_NonCompliantERC721_Harness {
 /// @title L2ERC721Bridge_TestInit
 /// @notice Reusable test initialization for `L2ERC721Bridge` tests.
 abstract contract L2ERC721Bridge_TestInit is CommonTest {
-    L2ERC721Bridge_TestMintableERC721_Harness internal localToken;
-    L2ERC721Bridge_TestERC721_Harness internal remoteToken;
     uint256 internal constant tokenId = 1;
+    uint32 internal constant DEFAULT_MIN_GAS_LIMIT = 1234;
+    bytes internal constant EXTRA_DATA = hex"5678";
+    address internal constant remoteToken = address(0x01);
 
     event ERC721BridgeInitiated(
         address indexed localToken,
@@ -86,20 +74,66 @@ abstract contract L2ERC721Bridge_TestInit is CommonTest {
         uint256 tokenId,
         bytes extraData
     );
+}
+
+abstract contract L2ERC721Bridge_Bridge_TestInit is L2ERC721Bridge_TestInit {
+    L2ERC721Bridge_TestMintableERC721_Harness internal localToken;
 
     /// @notice Sets up the test suite.
-    function setUp() public override {
+    function setUp() public virtual override {
         super.setUp();
 
-        remoteToken = new L2ERC721Bridge_TestERC721_Harness();
-        localToken = new L2ERC721Bridge_TestMintableERC721_Harness(address(l2ERC721Bridge), address(remoteToken));
+        localToken = new L2ERC721Bridge_TestMintableERC721_Harness(address(l2ERC721Bridge), remoteToken);
 
-        // Mint alice a token.
         localToken.mint(alice, tokenId);
 
-        // Approve the bridge to transfer the token.
         vm.prank(alice);
         localToken.approve(address(l2ERC721Bridge), tokenId);
+    }
+
+    function _expectBridgeMessage(address _to) internal {
+        bytes memory message = abi.encodeCall(
+            IL1ERC721Bridge.finalizeBridgeERC721, (remoteToken, address(localToken), alice, _to, tokenId, EXTRA_DATA)
+        );
+
+        vm.expectCall(
+            address(l2ERC721Bridge.messenger()),
+            abi.encodeCall(
+                ICrossDomainMessenger.sendMessage,
+                (address(l2ERC721Bridge.otherBridge()), message, DEFAULT_MIN_GAS_LIMIT)
+            )
+        );
+    }
+
+    function _expectBridgeInitiated(address _to) internal {
+        vm.expectEmit(address(l2ERC721Bridge));
+        emit ERC721BridgeInitiated(address(localToken), remoteToken, alice, _to, tokenId, EXTRA_DATA);
+    }
+
+    function _mockXDomainMessageSender(address _sender) internal {
+        vm.mockCall(
+            address(l2ERC721Bridge.messenger()),
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(_sender)
+        );
+    }
+
+    function _mockOtherBridge() internal {
+        _mockXDomainMessageSender(address(l2ERC721Bridge.otherBridge()));
+    }
+
+    function _bridgeToken() internal {
+        vm.prank(alice, alice);
+        l2ERC721Bridge.bridgeERC721(address(localToken), remoteToken, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
+    }
+
+    function _assertTokenBurned() internal {
+        vm.expectRevert("ERC721: invalid token ID");
+        localToken.ownerOf(tokenId);
+    }
+
+    function _assertTokenOwnedBy(address _owner) internal view {
+        assertEq(localToken.ownerOf(tokenId), _owner);
     }
 }
 
@@ -117,263 +151,177 @@ contract L2ERC721Bridge_Constructor_Test is L2ERC721Bridge_TestInit {
 
 /// @title L2ERC721Bridge_FinalizeBridgeERC721_Test
 /// @notice Tests the `finalizeBridgeERC721` function of the `L2ERC721Bridge` contract.
-contract L2ERC721Bridge_FinalizeBridgeERC721_Test is L2ERC721Bridge_TestInit {
+contract L2ERC721Bridge_FinalizeBridgeERC721_Test is L2ERC721Bridge_Bridge_TestInit {
     /// @notice Tests that `finalizeBridgeERC721` correctly finalizes a bridged token.
     function test_finalizeBridgeERC721_succeeds() external {
-        // Bridge the token.
-        vm.prank(alice, alice);
-        l2ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
+        _bridgeToken();
 
-        // Expect an event to be emitted.
-        vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeFinalized(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+        vm.expectEmit(address(l2ERC721Bridge));
+        emit ERC721BridgeFinalized(address(localToken), remoteToken, alice, alice, tokenId, EXTRA_DATA);
 
-        // Finalize a withdrawal.
-        vm.mockCall(
-            address(l2CrossDomainMessenger),
-            abi.encodeCall(l2CrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(l1ERC721Bridge)
-        );
-        vm.prank(address(l2CrossDomainMessenger));
-        l2ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+        _mockOtherBridge();
+        vm.prank(address(l2ERC721Bridge.messenger()));
+        l2ERC721Bridge.finalizeBridgeERC721(address(localToken), remoteToken, alice, alice, tokenId, EXTRA_DATA);
 
-        // Token is not locked in the bridge.
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenOwnedBy(alice);
     }
 
     /// @notice Tests that `finalizeBridgeERC721` reverts if the token is not compliant with the
     ///         `IOptimismMintableERC721` interface.
     function test_finalizeBridgeERC721_interfaceNotCompliant_reverts() external {
-        // Create a non-compliant token
         L2ERC721Bridge_NonCompliantERC721_Harness nonCompliantToken =
             new L2ERC721Bridge_NonCompliantERC721_Harness(alice);
 
-        // Bridge the non-compliant token.
         vm.prank(alice, alice);
-        l2ERC721Bridge.bridgeERC721(address(nonCompliantToken), address(0x01), tokenId, 1234, hex"5678");
+        l2ERC721Bridge.bridgeERC721(address(nonCompliantToken), remoteToken, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
 
-        // Attempt to finalize the withdrawal. Should revert because the token does not claim to be
-        // compliant with the `IOptimismMintableERC721` interface.
-        vm.mockCall(
-            address(l2CrossDomainMessenger),
-            abi.encodeCall(l2CrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(l1ERC721Bridge)
-        );
-        vm.prank(address(l2CrossDomainMessenger));
+        _mockOtherBridge();
+        vm.prank(address(l2ERC721Bridge.messenger()));
         vm.expectRevert("L2ERC721Bridge: local token interface is not compliant");
-        l2ERC721Bridge.finalizeBridgeERC721(
-            address(address(nonCompliantToken)), address(address(0x01)), alice, alice, tokenId, hex"5678"
-        );
+        l2ERC721Bridge.finalizeBridgeERC721(address(nonCompliantToken), remoteToken, alice, alice, tokenId, EXTRA_DATA);
     }
 
     /// @notice Tests that `finalizeBridgeERC721` reverts when not called by the remote bridge.
     function test_finalizeBridgeERC721_notViaLocalMessenger_reverts() external {
-        // Finalize a withdrawal.
         vm.prank(alice);
         vm.expectRevert("ERC721Bridge: function can only be called from the other bridge");
-        l2ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+        l2ERC721Bridge.finalizeBridgeERC721(address(localToken), remoteToken, alice, alice, tokenId, EXTRA_DATA);
     }
 
     /// @notice Tests that `finalizeBridgeERC721` reverts when not called by the remote bridge.
     function test_finalizeBridgeERC721_notFromRemoteMessenger_reverts() external {
-        // Finalize a withdrawal.
-        vm.mockCall(
-            address(l2CrossDomainMessenger),
-            abi.encodeCall(l2CrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(alice)
-        );
-        vm.prank(address(l2CrossDomainMessenger));
+        _mockXDomainMessageSender(alice);
+        vm.prank(address(l2ERC721Bridge.messenger()));
         vm.expectRevert("ERC721Bridge: function can only be called from the other bridge");
-        l2ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+        l2ERC721Bridge.finalizeBridgeERC721(address(localToken), remoteToken, alice, alice, tokenId, EXTRA_DATA);
     }
 
     /// @notice Tests that `finalizeBridgeERC721` reverts when the local token is the address of
     ///         the bridge itself.
     function test_finalizeBridgeERC721_selfToken_reverts() external {
-        // Finalize a withdrawal.
-        vm.mockCall(
-            address(l2CrossDomainMessenger),
-            abi.encodeCall(l2CrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1ERC721Bridge))
-        );
-        vm.prank(address(l2CrossDomainMessenger));
+        _mockOtherBridge();
+        vm.prank(address(l2ERC721Bridge.messenger()));
         vm.expectRevert("L2ERC721Bridge: local token cannot be self");
-        l2ERC721Bridge.finalizeBridgeERC721(
-            address(l2ERC721Bridge), address(remoteToken), alice, alice, tokenId, hex"5678"
-        );
+        l2ERC721Bridge.finalizeBridgeERC721(address(l2ERC721Bridge), remoteToken, alice, alice, tokenId, EXTRA_DATA);
     }
 
     /// @notice Tests that `finalizeBridgeERC721` reverts when already finalized.
     function test_finalizeBridgeERC721_alreadyExists_reverts() external {
-        // Finalize a withdrawal.
-        vm.mockCall(
-            address(l2CrossDomainMessenger),
-            abi.encodeCall(l2CrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1ERC721Bridge))
-        );
-        vm.prank(address(l2CrossDomainMessenger));
+        _mockOtherBridge();
+        vm.prank(address(l2ERC721Bridge.messenger()));
         vm.expectRevert("ERC721: token already minted");
-        l2ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+        l2ERC721Bridge.finalizeBridgeERC721(address(localToken), remoteToken, alice, alice, tokenId, EXTRA_DATA);
     }
 }
 
-/// @title L2ERC721Bridge_Uncategorized_Test
-/// @notice General tests that are not testing any function directly of the `L2ERC721Bridge`
-///         contract or are testing multiple functions at once.
-contract L2ERC721Bridge_Uncategorized_Test is L2ERC721Bridge_TestInit {
+/// @title L2ERC721Bridge_Paused_Test
+/// @notice Tests the `paused` function of the `L2ERC721Bridge` contract.
+contract L2ERC721Bridge_Paused_Test is L2ERC721Bridge_TestInit {
     /// @notice Ensures that the L2ERC721Bridge is always not paused. The pausability happens on L1
     ///         and not L2.
     function test_paused_succeeds() external view {
         assertFalse(l2ERC721Bridge.paused());
     }
+}
 
+/// @title L2ERC721Bridge_BridgeERC721_Test
+/// @notice Tests the `bridgeERC721` and `bridgeERC721To` functions of the `L2ERC721Bridge` contract.
+contract L2ERC721Bridge_BridgeERC721_Test is L2ERC721Bridge_Bridge_TestInit {
     /// @notice Tests that `bridgeERC721` correctly bridges a token and burns it on the origin
     ///         chain.
     function test_bridgeERC721_succeeds() public {
-        // Expect a call to the messenger.
-        vm.expectCall(
-            address(l2CrossDomainMessenger),
-            abi.encodeCall(
-                l2CrossDomainMessenger.sendMessage,
-                (
-                    address(l1ERC721Bridge),
-                    abi.encodeCall(
-                        IL2ERC721Bridge.finalizeBridgeERC721,
-                        (address(remoteToken), address(localToken), alice, alice, tokenId, hex"5678")
-                    ),
-                    1234
-                )
-            )
-        );
+        _expectBridgeMessage(alice);
+        _expectBridgeInitiated(alice);
 
-        // Expect an event to be emitted.
-        vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeInitiated(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+        _bridgeToken();
 
-        // Bridge the token.
-        vm.prank(alice, alice);
-        l2ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
-
-        // Token is burned.
-        vm.expectRevert("ERC721: invalid token ID");
-        localToken.ownerOf(tokenId);
+        _assertTokenBurned();
     }
 
     /// @notice Tests that `bridgeERC721` reverts if the owner is not an EOA.
     function test_bridgeERC721_fromContract_reverts() external {
-        // Bridge the token.
         vm.etch(alice, hex"01");
         vm.prank(alice);
         vm.expectRevert("ERC721Bridge: account is not externally owned");
-        l2ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
+        l2ERC721Bridge.bridgeERC721(address(localToken), remoteToken, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
 
-        // Token is not locked in the bridge.
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenOwnedBy(alice);
     }
 
     /// @notice Tests that `bridgeERC721` reverts if the local token is the zero address.
     function test_bridgeERC721_localTokenZeroAddress_reverts() external {
-        // Bridge the token.
         vm.prank(alice, alice);
         vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
-        l2ERC721Bridge.bridgeERC721(address(0), address(remoteToken), tokenId, 1234, hex"5678");
+        l2ERC721Bridge.bridgeERC721(address(0), remoteToken, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
 
-        // Token is not locked in the bridge.
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenOwnedBy(alice);
     }
 
     /// @notice Tests that `bridgeERC721` reverts if the remote token is the zero address.
     function test_bridgeERC721_remoteTokenZeroAddress_reverts() external {
-        // Bridge the token.
         vm.prank(alice, alice);
         vm.expectRevert("L2ERC721Bridge: remote token cannot be address(0)");
-        l2ERC721Bridge.bridgeERC721(address(localToken), address(0), tokenId, 1234, hex"5678");
+        l2ERC721Bridge.bridgeERC721(address(localToken), address(0), tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
 
-        // Token is not locked in the bridge.
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenOwnedBy(alice);
     }
 
     /// @notice Tests that `bridgeERC721` reverts if the caller is not the token owner.
     function test_bridgeERC721_wrongOwner_reverts() external {
-        // Bridge the token.
         vm.prank(bob, bob);
         vm.expectRevert("L2ERC721Bridge: Withdrawal is not being initiated by NFT owner");
-        l2ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
+        l2ERC721Bridge.bridgeERC721(address(localToken), remoteToken, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
 
-        // Token is not locked in the bridge.
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenOwnedBy(alice);
     }
 
     /// @notice Tests that `bridgeERC721To` correctly bridges a token and burns it on the origin
     ///         chain.
     function test_bridgeERC721To_succeeds() external {
-        // Expect a call to the messenger.
-        vm.expectCall(
-            address(l2CrossDomainMessenger),
-            abi.encodeCall(
-                l2CrossDomainMessenger.sendMessage,
-                (
-                    address(l1ERC721Bridge),
-                    abi.encodeCall(
-                        IL1ERC721Bridge.finalizeBridgeERC721,
-                        (address(remoteToken), address(localToken), alice, bob, tokenId, hex"5678")
-                    ),
-                    1234
-                )
-            )
-        );
+        _expectBridgeMessage(bob);
+        _expectBridgeInitiated(bob);
 
-        // Expect an event to be emitted.
-        vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeInitiated(address(localToken), address(remoteToken), alice, bob, tokenId, hex"5678");
-
-        // Bridge the token.
         vm.prank(alice);
-        l2ERC721Bridge.bridgeERC721To(address(localToken), address(remoteToken), bob, tokenId, 1234, hex"5678");
+        l2ERC721Bridge.bridgeERC721To(address(localToken), remoteToken, bob, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
 
-        // Token is burned.
-        vm.expectRevert("ERC721: invalid token ID");
-        localToken.ownerOf(tokenId);
+        _assertTokenBurned();
     }
 
     /// @notice Tests that `bridgeERC721To` reverts if the local token is the zero address.
     function test_bridgeERC721To_localTokenZeroAddress_reverts() external {
-        // Bridge the token.
         vm.prank(alice);
         vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
-        l2ERC721Bridge.bridgeERC721To(address(0), address(l1ERC721Bridge), bob, tokenId, 1234, hex"5678");
+        l2ERC721Bridge.bridgeERC721To(
+            address(0), address(l1ERC721Bridge), bob, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA
+        );
 
-        // Token is not locked in the bridge.
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenOwnedBy(alice);
     }
 
     /// @notice Tests that `bridgeERC721To` reverts if the remote token is the zero address.
     function test_bridgeERC721To_remoteTokenZeroAddress_reverts() external {
-        // Bridge the token.
         vm.prank(alice);
         vm.expectRevert("L2ERC721Bridge: remote token cannot be address(0)");
-        l2ERC721Bridge.bridgeERC721To(address(localToken), address(0), bob, tokenId, 1234, hex"5678");
+        l2ERC721Bridge.bridgeERC721To(address(localToken), address(0), bob, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
 
-        // Token is not locked in the bridge.
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenOwnedBy(alice);
     }
 
     /// @notice Tests that `bridgeERC721To` reverts if the caller is not the token owner.
     function test_bridgeERC721To_wrongOwner_reverts() external {
-        // Bridge the token.
         vm.prank(bob);
         vm.expectRevert("L2ERC721Bridge: Withdrawal is not being initiated by NFT owner");
-        l2ERC721Bridge.bridgeERC721To(address(localToken), address(remoteToken), bob, tokenId, 1234, hex"5678");
+        l2ERC721Bridge.bridgeERC721To(address(localToken), remoteToken, bob, tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA);
 
-        // Token is not locked in the bridge.
-        assertEq(localToken.ownerOf(tokenId), alice);
+        _assertTokenOwnedBy(alice);
     }
 
     /// @notice Tests that `bridgeERC721To` reverts if the to address is the zero address.
     function test_bridgeERC721To_toZeroAddress_reverts() external {
-        // Bridge the token.
         vm.prank(bob);
         vm.expectRevert("ERC721Bridge: nft recipient cannot be address(0)");
-        l2ERC721Bridge.bridgeERC721To(address(localToken), address(remoteToken), address(0), tokenId, 1234, hex"5678");
+        l2ERC721Bridge.bridgeERC721To(
+            address(localToken), remoteToken, address(0), tokenId, DEFAULT_MIN_GAS_LIMIT, EXTRA_DATA
+        );
     }
 }

--- a/test/L2/L2StandardBridge.t.sol
+++ b/test/L2/L2StandardBridge.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { stdStorage, StdStorage } from "lib/forge-std/src/Test.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 
@@ -26,8 +25,7 @@ import { IL2StandardBridge } from "interfaces/L2/IL2StandardBridge.sol";
 /// @notice Reusable test initialization for `L2StandardBridge` tests.
 abstract contract L2StandardBridge_TestInit is CommonTest {
     /// @notice Sets up expected calls and emits for a successful ERC20 withdrawal.
-    function _preBridgeERC20(bool _isLegacy, address _l2Token) internal {
-        // Alice has 100 L2Token
+    function _preBridgeERC20(address _l2Token) internal {
         deal(_l2Token, alice, 100, true);
         assertEq(ERC20(_l2Token).balanceOf(alice), 100);
         uint256 nonce = l2CrossDomainMessenger.messageNonce();
@@ -49,17 +47,6 @@ abstract contract L2StandardBridge_TestInit is CommonTest {
             })
         );
 
-        if (_isLegacy) {
-            vm.expectCall(
-                address(l2StandardBridge), abi.encodeCall(l2StandardBridge.withdraw, (_l2Token, 100, 1000, hex""))
-            );
-        } else {
-            vm.expectCall(
-                address(l2StandardBridge),
-                abi.encodeCall(l2StandardBridge.bridgeERC20, (_l2Token, address(L1Token), 100, 1000, hex""))
-            );
-        }
-
         vm.expectCall(
             address(l2CrossDomainMessenger),
             abi.encodeCall(ICrossDomainMessenger.sendMessage, (address(l1StandardBridge), message, 1000))
@@ -72,7 +59,6 @@ abstract contract L2StandardBridge_TestInit is CommonTest {
             )
         );
 
-        // The l2StandardBridge should burn the tokens
         vm.expectCall(_l2Token, abi.encodeCall(OptimismMintableERC20.burn, (alice, 100)));
 
         vm.expectEmit(true, true, true, true);
@@ -107,9 +93,9 @@ abstract contract L2StandardBridge_TestInit is CommonTest {
     ///         recipient.
     /// @dev `withdrawTo` and `bridgeERC20To` should behave the same when transferring ERC20 tokens
     ///      so they should share the same setup and expectEmit calls
-    function _preBridgeERC20To(bool _isLegacy, address _l2Token) internal {
+    function _preBridgeERC20To(address _l2Token) internal {
         deal(_l2Token, alice, 100, true);
-        assertEq(L2Token.balanceOf(alice), 100);
+        assertEq(ERC20(_l2Token).balanceOf(alice), 100);
         uint256 nonce = l2CrossDomainMessenger.messageNonce();
         bytes memory message =
             abi.encodeCall(IStandardBridge.finalizeBridgeERC20, (address(L1Token), _l2Token, alice, bob, 100, hex""));
@@ -154,18 +140,6 @@ abstract contract L2StandardBridge_TestInit is CommonTest {
         vm.expectEmit(address(l2CrossDomainMessenger));
         emit SentMessageExtension1(address(l2StandardBridge), 0);
 
-        if (_isLegacy) {
-            vm.expectCall(
-                address(l2StandardBridge),
-                abi.encodeCall(l2StandardBridge.withdrawTo, (_l2Token, bob, 100, 1000, hex""))
-            );
-        } else {
-            vm.expectCall(
-                address(l2StandardBridge),
-                abi.encodeCall(l2StandardBridge.bridgeERC20To, (_l2Token, address(L1Token), bob, 100, 1000, hex""))
-            );
-        }
-
         vm.expectCall(
             address(l2CrossDomainMessenger),
             abi.encodeCall(ICrossDomainMessenger.sendMessage, (address(l1StandardBridge), message, 1000))
@@ -178,13 +152,28 @@ abstract contract L2StandardBridge_TestInit is CommonTest {
             )
         );
 
-        // The l2StandardBridge should burn the tokens
-        vm.expectCall(address(L2Token), abi.encodeCall(OptimismMintableERC20.burn, (alice, 100)));
+        vm.expectCall(_l2Token, abi.encodeCall(OptimismMintableERC20.burn, (alice, 100)));
 
         vm.prank(alice, alice);
     }
 
-    using stdStorage for StdStorage;
+    function _mockXDomainMessageSender(address _sender) internal {
+        vm.mockCall(
+            address(l2StandardBridge.messenger()),
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(_sender)
+        );
+    }
+
+    function _mockOtherBridge() internal {
+        _mockXDomainMessageSender(address(l2StandardBridge.OTHER_BRIDGE()));
+    }
+
+    function _setupFinalizeBridgeETH() internal returns (address messenger) {
+        messenger = address(l2StandardBridge.messenger());
+        _mockOtherBridge();
+        vm.deal(messenger, 100);
+    }
 }
 
 /// @title L2StandardBridge_Version_Test
@@ -348,7 +337,7 @@ contract L2StandardBridge_Withdraw_Test is L2StandardBridge_TestInit {
     /// @notice Tests that `withdraw` burns the tokens, emits `WithdrawalInitiated`, and initiates
     ///         a withdrawal with `Withdrawer.initiateWithdrawal`.
     function test_withdraw_withdrawingERC20_succeeds() external {
-        _preBridgeERC20({ _isLegacy: true, _l2Token: address(L2Token) });
+        _preBridgeERC20(address(L2Token));
         l2StandardBridge.withdraw(address(L2Token), 100, 1000, hex"");
 
         assertEq(L2Token.balanceOf(alice), 0);
@@ -378,7 +367,7 @@ contract L2StandardBridge_WithdrawTo_Test is L2StandardBridge_TestInit {
     /// @notice Tests that `withdrawTo` burns the tokens, emits `WithdrawalInitiated`, and
     ///         initiates a withdrawal with `Withdrawer.initiateWithdrawal`.
     function test_withdrawTo_withdrawingERC20_succeeds() external {
-        _preBridgeERC20To({ _isLegacy: true, _l2Token: address(L2Token) });
+        _preBridgeERC20To(address(L2Token));
         l2StandardBridge.withdrawTo(address(L2Token), bob, 100, 1000, hex"");
 
         assertEq(L2Token.balanceOf(alice), 0);
@@ -398,7 +387,7 @@ contract L2StandardBridge_Uncategorized_Test is L2StandardBridge_TestInit {
     /// @notice Tests that `bridgeERC20` burns the tokens, emits `WithdrawalInitiated`, and
     ///         initiates a withdrawal with `Withdrawer.initiateWithdrawal`.
     function test_bridgeERC20_succeeds() external {
-        _preBridgeERC20({ _isLegacy: false, _l2Token: address(L2Token) });
+        _preBridgeERC20(address(L2Token));
         l2StandardBridge.bridgeERC20(address(L2Token), address(L1Token), 100, 1000, hex"");
 
         assertEq(L2Token.balanceOf(alice), 0);
@@ -413,35 +402,25 @@ contract L2StandardBridge_Uncategorized_Test is L2StandardBridge_TestInit {
     /// @notice Tests that `bridgeERC20To` burns the tokens, emits `WithdrawalInitiated`, and
     ///         initiates a withdrawal with `Withdrawer.initiateWithdrawal`.
     function test_bridgeERC20To_succeeds() external {
-        _preBridgeERC20To({ _isLegacy: false, _l2Token: address(L2Token) });
+        _preBridgeERC20To(address(L2Token));
         l2StandardBridge.bridgeERC20To(address(L2Token), address(L1Token), bob, 100, 1000, hex"");
         assertEq(L2Token.balanceOf(alice), 0);
     }
 
     /// @notice Tests that `finalizeBridgeETH` reverts if the recipient is the other bridge.
     function test_finalizeBridgeETH_sendToSelf_reverts() external {
-        vm.mockCall(
-            address(l2StandardBridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l2StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.deal(address(l2CrossDomainMessenger), 100);
-        vm.prank(address(l2CrossDomainMessenger));
+        address messenger = _setupFinalizeBridgeETH();
+        vm.prank(messenger);
         vm.expectRevert("StandardBridge: cannot send to self");
         l2StandardBridge.finalizeBridgeETH{ value: 100 }(alice, address(l2StandardBridge), 100, hex"");
     }
 
     /// @notice Tests that `finalizeBridgeETH` reverts if the recipient is the messenger.
     function test_finalizeBridgeETH_sendToMessenger_reverts() external {
-        vm.mockCall(
-            address(l2StandardBridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l2StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.deal(address(l2CrossDomainMessenger), 100);
-        vm.prank(address(l2CrossDomainMessenger));
+        address messenger = _setupFinalizeBridgeETH();
+        vm.prank(messenger);
         vm.expectRevert("StandardBridge: cannot send to messenger");
-        l2StandardBridge.finalizeBridgeETH{ value: 100 }(alice, address(l2CrossDomainMessenger), 100, hex"");
+        l2StandardBridge.finalizeBridgeETH{ value: 100 }(alice, messenger, 100, hex"");
     }
 
     /// @notice Tests that bridging ETH succeeds.
@@ -450,10 +429,6 @@ contract L2StandardBridge_Uncategorized_Test is L2StandardBridge_TestInit {
         uint256 nonce = l2CrossDomainMessenger.messageNonce();
 
         bytes memory message = abi.encodeCall(IStandardBridge.finalizeBridgeETH, (alice, alice, _value, _extraData));
-
-        vm.expectCall(
-            address(l2StandardBridge), _value, abi.encodeCall(l2StandardBridge.bridgeETH, (_minGasLimit, _extraData))
-        );
 
         vm.expectCall(
             address(l2CrossDomainMessenger),
@@ -483,16 +458,8 @@ contract L2StandardBridge_Uncategorized_Test is L2StandardBridge_TestInit {
         skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
         uint256 nonce = l2CrossDomainMessenger.messageNonce();
 
-        vm.expectCall(
-            address(l2StandardBridge),
-            _value,
-            abi.encodeCall(l1StandardBridge.bridgeETHTo, (bob, _minGasLimit, _extraData))
-        );
-
         bytes memory message = abi.encodeCall(IStandardBridge.finalizeBridgeETH, (alice, bob, _value, _extraData));
 
-        // the L2 bridge should call
-        // L2CrossDomainMessenger.sendMessage
         vm.expectCall(
             address(l2CrossDomainMessenger),
             abi.encodeCall(ICrossDomainMessenger.sendMessage, (address(l1StandardBridge), message, _minGasLimit))
@@ -509,7 +476,6 @@ contract L2StandardBridge_Uncategorized_Test is L2StandardBridge_TestInit {
         vm.expectEmit(address(l2CrossDomainMessenger));
         emit SentMessageExtension1(address(l2StandardBridge), _value);
 
-        // deposit eth to bob
         vm.deal(alice, _value);
         vm.prank(alice, alice);
 
@@ -518,13 +484,7 @@ contract L2StandardBridge_Uncategorized_Test is L2StandardBridge_TestInit {
 
     /// @notice Tests that `finalizeBridgeETH` succeeds.
     function test_finalizeBridgeETH_succeeds() external {
-        address messenger = address(l2StandardBridge.messenger());
-        vm.mockCall(
-            messenger,
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l2StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.deal(messenger, 100);
+        address messenger = _setupFinalizeBridgeETH();
         vm.prank(messenger);
 
         vm.expectEmit(true, true, true, true);
@@ -541,11 +501,7 @@ contract L2StandardBridge_Uncategorized_Test is L2StandardBridge_TestInit {
         address messenger = address(l2StandardBridge.messenger());
         address localToken = address(L2Token);
         address remoteToken = address(L1Token);
-        vm.mockCall(
-            messenger,
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l2StandardBridge.OTHER_BRIDGE()))
-        );
+        _mockOtherBridge();
         deal(localToken, messenger, 100, true);
         vm.prank(messenger);
 
@@ -562,11 +518,7 @@ contract L2StandardBridge_Uncategorized_Test is L2StandardBridge_TestInit {
         address messenger = address(l2StandardBridge.messenger());
         address localToken = address(L2Token);
         address remoteToken = address(BadL1Token);
-        vm.mockCall(
-            messenger,
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l2StandardBridge.OTHER_BRIDGE()))
-        );
+        _mockOtherBridge();
         deal(localToken, messenger, 100, true);
         vm.prank(messenger);
 

--- a/test/L2/L2ToL1MessagePasser.t.sol
+++ b/test/L2/L2ToL1MessagePasser.t.sol
@@ -8,11 +8,56 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Features } from "src/libraries/Features.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
 import { SemverComp } from "src/libraries/SemverComp.sol";
+
+/// @title L2ToL1MessagePasser_TestInit
+/// @notice Reusable test initialization for `L2ToL1MessagePasser` tests.
+abstract contract L2ToL1MessagePasser_TestInit is CommonTest {
+    uint256 internal constant RECEIVE_DEFAULT_GAS_LIMIT = 100_000;
+
+    function _hashWithdrawal(
+        uint256 _nonce,
+        address _sender,
+        address _target,
+        uint256 _value,
+        uint256 _gasLimit,
+        bytes memory _data
+    )
+        internal
+        pure
+        returns (bytes32)
+    {
+        return Hashing.hashWithdrawal(
+            Types.WithdrawalTransaction({
+                nonce: _nonce, sender: _sender, target: _target, value: _value, gasLimit: _gasLimit, data: _data
+            })
+        );
+    }
+
+    function _expectMessagePassed(
+        uint256 _nonce,
+        address _sender,
+        address _target,
+        uint256 _value,
+        uint256 _gasLimit,
+        bytes memory _data
+    )
+        internal
+        returns (bytes32)
+    {
+        bytes32 withdrawalHash = _hashWithdrawal(_nonce, _sender, _target, _value, _gasLimit, _data);
+
+        vm.expectEmit(address(l2ToL1MessagePasser));
+        emit MessagePassed(_nonce, _sender, _target, _value, _gasLimit, _data, withdrawalHash);
+
+        return withdrawalHash;
+    }
+}
 
 /// @title L2ToL1MessagePasser_Version_Test
 /// @notice Tests the `version` function of the `L2ToL1MessagePasser` contract.
-contract L2ToL1MessagePasser_Version_Test is CommonTest {
+contract L2ToL1MessagePasser_Version_Test is L2ToL1MessagePasser_TestInit {
     /// @notice Tests that the version follows valid semver format.
     function test_version_validFormat_succeeds() external view {
         SemverComp.parse(l2ToL1MessagePasser.version());
@@ -21,47 +66,32 @@ contract L2ToL1MessagePasser_Version_Test is CommonTest {
 
 /// @title L2ToL1MessagePasser_Receive_Test
 /// @notice Tests the `receive` function of the `L2ToL1MessagePasser` contract.
-contract L2ToL1MessagePasser_Receive_Test is CommonTest {
+contract L2ToL1MessagePasser_Receive_Test is L2ToL1MessagePasser_TestInit {
     /// @notice Tests that receive() initiates withdrawal with default gas limit.
     function testFuzz_receive_initiatesWithdrawal_succeeds(uint256 _value) external {
         skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
 
         uint256 nonce = l2ToL1MessagePasser.messageNonce();
-
-        bytes32 withdrawalHash = Hashing.hashWithdrawal(
-            Types.WithdrawalTransaction({
-                nonce: nonce,
-                sender: address(this),
-                target: address(this),
-                value: _value,
-                gasLimit: 100_000, // RECEIVE_DEFAULT_GAS_LIMIT
-                data: bytes("")
-            })
-        );
-
-        vm.expectEmit(address(l2ToL1MessagePasser));
-        emit MessagePassed(nonce, address(this), address(this), _value, 100_000, bytes(""), withdrawalHash);
+        bytes memory data = bytes("");
+        bytes32 withdrawalHash =
+            _expectMessagePassed(nonce, address(this), address(this), _value, RECEIVE_DEFAULT_GAS_LIMIT, data);
 
         vm.deal(address(this), _value);
-        (bool success,) = address(l2ToL1MessagePasser).call{ value: _value }("");
+        (bool success,) = address(l2ToL1MessagePasser).call{ value: _value }(data);
 
         assertTrue(success);
-        assertEq(l2ToL1MessagePasser.sentMessages(withdrawalHash), true);
+        assertTrue(l2ToL1MessagePasser.sentMessages(withdrawalHash));
         assertEq(l2ToL1MessagePasser.messageNonce(), nonce + 1);
     }
 }
 
 /// @title L2ToL1MessagePasser_Burn_Test
 /// @notice Tests the `burn` function of the `L2ToL1MessagePasser` contract.
-contract L2ToL1MessagePasser_Burn_Test is CommonTest {
+contract L2ToL1MessagePasser_Burn_Test is L2ToL1MessagePasser_TestInit {
     /// @notice Tests that `burn` succeeds and destroys the ETH held in the contract.
-    function testFuzz_burn_succeeds(uint256 _value, address _target, uint256 _gasLimit, bytes memory _data) external {
+    function testFuzz_burn_succeeds(uint256 _value) external {
         skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
-        vm.deal(address(this), _value);
-
-        l2ToL1MessagePasser.initiateWithdrawal{ value: _value }({
-            _target: _target, _gasLimit: _gasLimit, _data: _data
-        });
+        vm.deal(address(l2ToL1MessagePasser), _value);
 
         assertEq(address(l2ToL1MessagePasser).balance, _value);
 
@@ -69,14 +99,13 @@ contract L2ToL1MessagePasser_Burn_Test is CommonTest {
         emit WithdrawerBalanceBurnt(_value);
         l2ToL1MessagePasser.burn();
 
-        // The Withdrawer should have no balance
         assertEq(address(l2ToL1MessagePasser).balance, 0);
     }
 }
 
 /// @title L2ToL1MessagePasser_InitiateWithdrawal_Test
 /// @notice Tests the `initiateWithdrawal` function of the `L2ToL1MessagePasser` contract.
-contract L2ToL1MessagePasser_InitiateWithdrawal_Test is CommonTest {
+contract L2ToL1MessagePasser_InitiateWithdrawal_Test is L2ToL1MessagePasser_TestInit {
     /// @notice Tests that `initiateWithdrawal` succeeds and correctly sets the state of the
     ///         message passer for the withdrawal hash.
     function testFuzz_initiateWithdrawal_succeeds(
@@ -93,25 +122,14 @@ contract L2ToL1MessagePasser_InitiateWithdrawal_Test is CommonTest {
         }
         uint256 nonce = l2ToL1MessagePasser.messageNonce();
 
-        bytes32 withdrawalHash = Hashing.hashWithdrawal(
-            Types.WithdrawalTransaction({
-                nonce: nonce, sender: _sender, target: _target, value: _value, gasLimit: _gasLimit, data: _data
-            })
-        );
-
-        vm.expectEmit(address(l2ToL1MessagePasser));
-        emit MessagePassed(nonce, _sender, _target, _value, _gasLimit, _data, withdrawalHash);
+        bytes32 withdrawalHash = _expectMessagePassed(nonce, _sender, _target, _value, _gasLimit, _data);
 
         vm.deal(_sender, _value);
         vm.prank(_sender);
         l2ToL1MessagePasser.initiateWithdrawal{ value: _value }(_target, _gasLimit, _data);
 
-        assertEq(l2ToL1MessagePasser.sentMessages(withdrawalHash), true);
+        assertTrue(l2ToL1MessagePasser.sentMessages(withdrawalHash));
         assertEq(l2ToL1MessagePasser.messageNonce(), nonce + 1);
-
-        bytes32 slot = keccak256(bytes.concat(withdrawalHash, bytes32(0)));
-
-        assertEq(vm.load(address(l2ToL1MessagePasser), slot), bytes32(uint256(1)));
     }
 
     /// @notice Tests that `initiateWithdrawal` succeeds when called by a contract.
@@ -124,26 +142,13 @@ contract L2ToL1MessagePasser_InitiateWithdrawal_Test is CommonTest {
         external
     {
         skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
-        bytes32 withdrawalHash = Hashing.hashWithdrawal(
-            Types.WithdrawalTransaction({
-                nonce: l2ToL1MessagePasser.messageNonce(),
-                sender: address(this),
-                target: _target,
-                value: _value,
-                gasLimit: _gasLimit,
-                data: _data
-            })
-        );
-
-        vm.expectEmit(address(l2ToL1MessagePasser));
-        emit MessagePassed(
-            l2ToL1MessagePasser.messageNonce(), address(this), _target, _value, _gasLimit, _data, withdrawalHash
-        );
+        uint256 nonce = l2ToL1MessagePasser.messageNonce();
+        bytes32 withdrawalHash = _expectMessagePassed(nonce, address(this), _target, _value, _gasLimit, _data);
 
         vm.deal(address(this), _value);
         l2ToL1MessagePasser.initiateWithdrawal{ value: _value }(_target, _gasLimit, _data);
 
-        assertEq(l2ToL1MessagePasser.sentMessages(withdrawalHash), true);
+        assertTrue(l2ToL1MessagePasser.sentMessages(withdrawalHash));
     }
 
     /// @notice Tests that `initiateWithdrawal` succeeds when called by an EOA.
@@ -157,40 +162,25 @@ contract L2ToL1MessagePasser_InitiateWithdrawal_Test is CommonTest {
     {
         skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
         uint256 nonce = l2ToL1MessagePasser.messageNonce();
-
-        // Verify caller is an EOA (alice has no code)
-        assertEq(alice.code.length, 0);
-
-        // EOA emulation
-        vm.prank(alice, alice);
         vm.deal(alice, _value);
-        bytes32 withdrawalHash =
-            Hashing.hashWithdrawal(Types.WithdrawalTransaction(nonce, alice, _target, _value, _gasLimit, _data));
+        bytes32 withdrawalHash = _expectMessagePassed(nonce, alice, _target, _value, _gasLimit, _data);
 
-        vm.expectEmit(address(l2ToL1MessagePasser));
-        emit MessagePassed(nonce, alice, _target, _value, _gasLimit, _data, withdrawalHash);
-
+        vm.prank(alice, alice);
         l2ToL1MessagePasser.initiateWithdrawal{ value: _value }({
             _target: _target, _gasLimit: _gasLimit, _data: _data
         });
 
-        // the sent messages mapping is filled
-        assertEq(l2ToL1MessagePasser.sentMessages(withdrawalHash), true);
-        // the nonce increments
-        assertEq(nonce + 1, l2ToL1MessagePasser.messageNonce());
+        assertTrue(l2ToL1MessagePasser.sentMessages(withdrawalHash));
+        assertEq(l2ToL1MessagePasser.messageNonce(), nonce + 1);
     }
 }
 
 /// @title L2ToL1MessagePasser_MessageNonce_Test
 /// @notice Tests the `messageNonce` function of the `L2ToL1MessagePasser` contract.
-contract L2ToL1MessagePasser_MessageNonce_Test is CommonTest {
+contract L2ToL1MessagePasser_MessageNonce_Test is L2ToL1MessagePasser_TestInit {
     /// @notice Tests that messageNonce encodes version in upper bytes.
     function test_messageNonce_encodesVersion_succeeds() external view {
-        uint256 nonce = l2ToL1MessagePasser.messageNonce();
-
-        // MESSAGE_VERSION is 1, should be in upper 2 bytes
-        // Version is stored in bits 240-255 (upper 2 bytes of uint256)
-        uint256 version = nonce >> 240;
-        assertEq(version, 1);
+        (, uint16 version) = Encoding.decodeVersionedNonce(l2ToL1MessagePasser.messageNonce());
+        assertEq(version, l2ToL1MessagePasser.MESSAGE_VERSION());
     }
 }

--- a/test/L2/OperatorFeeVault.t.sol
+++ b/test/L2/OperatorFeeVault.t.sol
@@ -1,34 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Interfaces
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
-
-// Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { FeeVault_Uncategorized_Test } from "test/L2/FeeVault.t.sol";
 import { Types } from "src/libraries/Types.sol";
 import { SemverComp } from "src/libraries/SemverComp.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 
-/// @title OperatorFeeVault_Uncategorized_Test
-/// @notice Test contract for the OperatorFeeVault contract's functionality
 contract OperatorFeeVault_Uncategorized_Test is FeeVault_Uncategorized_Test {
-    /// @dev Sets up the test suite.
-    function setUp() public virtual override {
+    function setUp() public override {
         super.setUp();
         recipient = deploy.cfg().operatorFeeVaultRecipient();
-        feeVaultName = "OperatorFeeVault";
         minWithdrawalAmount = deploy.cfg().operatorFeeVaultMinimumWithdrawalAmount();
         feeVault = IFeeVault(payable(Predeploys.OPERATOR_FEE_VAULT));
         withdrawalNetwork = Types.WithdrawalNetwork(uint8(deploy.cfg().operatorFeeVaultWithdrawalNetwork()));
     }
 }
 
-/// @title OperatorFeeVault_Version_Test
-/// @notice Tests the `version` function of the `OperatorFeeVault` contract.
 contract OperatorFeeVault_Version_Test is CommonTest {
-    /// @notice Tests that version returns a valid semver string.
     function test_version_validFormat_succeeds() external view {
         SemverComp.parse(operatorFeeVault.version());
     }

--- a/test/L2/OptimismMintableERC721.t.sol
+++ b/test/L2/OptimismMintableERC721.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { ERC721, IERC721 } from "lib/openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
+import { IERC721 } from "lib/openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
 import { IERC721Enumerable } from "lib/openzeppelin-contracts/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import { IERC165 } from "lib/openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
 import { Strings } from "lib/openzeppelin-contracts/contracts/utils/Strings.sol";
@@ -11,7 +11,10 @@ import { OptimismMintableERC721, IOptimismMintableERC721 } from "src/L2/Optimism
 /// @title OptimismMintableERC721_TestInit
 /// @notice Reusable test initialization for `OptimismMintableERC721` tests.
 abstract contract OptimismMintableERC721_TestInit is CommonTest {
-    ERC721 internal L1NFT;
+    uint256 internal constant remoteChainId = 1;
+    uint256 internal constant tokenId = 1;
+
+    address internal L1NFT;
     OptimismMintableERC721 internal L2NFT;
 
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
@@ -23,13 +26,16 @@ abstract contract OptimismMintableERC721_TestInit is CommonTest {
     function setUp() public override {
         super.setUp();
 
-        // Set up the token pair.
-        L1NFT = new ERC721("L1NFT", "L1T");
-        L2NFT = new OptimismMintableERC721(address(l2ERC721Bridge), 1, address(L1NFT), "L2NFT", "L2T");
+        L1NFT = makeAddr("L1NFT");
+        L2NFT = new OptimismMintableERC721(address(l2ERC721Bridge), remoteChainId, L1NFT, "L2NFT", "L2T");
 
-        // Label the addresses for nice traces.
-        vm.label(address(L1NFT), "L1ERC721Token");
+        vm.label(L1NFT, "L1ERC721Token");
         vm.label(address(L2NFT), "L2ERC721Token");
+    }
+
+    function _bridgeMint(address _to) internal {
+        vm.prank(address(l2ERC721Bridge));
+        L2NFT.safeMint(_to, tokenId);
     }
 }
 
@@ -40,30 +46,30 @@ contract OptimismMintableERC721_Constructor_Test is OptimismMintableERC721_TestI
     function test_constructor_succeeds() external view {
         assertEq(L2NFT.name(), "L2NFT");
         assertEq(L2NFT.symbol(), "L2T");
-        assertEq(L2NFT.remoteToken(), address(L1NFT));
+        assertEq(L2NFT.remoteToken(), L1NFT);
         assertEq(L2NFT.bridge(), address(l2ERC721Bridge));
-        assertEq(L2NFT.remoteChainId(), 1);
-        assertEq(L2NFT.REMOTE_TOKEN(), address(L1NFT));
+        assertEq(L2NFT.remoteChainId(), remoteChainId);
+        assertEq(L2NFT.REMOTE_TOKEN(), L1NFT);
         assertEq(L2NFT.BRIDGE(), address(l2ERC721Bridge));
-        assertEq(L2NFT.REMOTE_CHAIN_ID(), 1);
+        assertEq(L2NFT.REMOTE_CHAIN_ID(), remoteChainId);
     }
 
     /// @notice Tests that the constructor reverts when the bridge address is zero.
     function test_constructor_bridgeAsAddress0_reverts() external {
         vm.expectRevert("OptimismMintableERC721: bridge cannot be address(0)");
-        L2NFT = new OptimismMintableERC721(address(0), 1, address(L1NFT), "L2NFT", "L2T");
+        L2NFT = new OptimismMintableERC721(address(0), remoteChainId, L1NFT, "L2NFT", "L2T");
     }
 
     /// @notice Tests that the constructor reverts when the remote chain ID is zero.
     function test_constructor_remoteChainId0_reverts() external {
         vm.expectRevert("OptimismMintableERC721: remote chain id cannot be zero");
-        L2NFT = new OptimismMintableERC721(address(l2ERC721Bridge), 0, address(L1NFT), "L2NFT", "L2T");
+        L2NFT = new OptimismMintableERC721(address(l2ERC721Bridge), 0, L1NFT, "L2NFT", "L2T");
     }
 
     /// @notice Tests that the constructor reverts when the remote token address is zero.
     function test_constructor_remoteTokenAsAddress0_reverts() external {
         vm.expectRevert("OptimismMintableERC721: remote token cannot be address(0)");
-        L2NFT = new OptimismMintableERC721(address(l2ERC721Bridge), 1, address(0), "L2NFT", "L2T");
+        L2NFT = new OptimismMintableERC721(address(l2ERC721Bridge), remoteChainId, address(0), "L2NFT", "L2T");
     }
 }
 
@@ -73,28 +79,22 @@ contract OptimismMintableERC721_SafeMint_Test is OptimismMintableERC721_TestInit
     /// @notice Tests that the `safeMint` function successfully mints a token when called by the
     ///         bridge.
     function test_safeMint_succeeds() external {
-        // Expect a transfer event.
-        vm.expectEmit(true, true, true, true);
-        emit Transfer(address(0), alice, 1);
+        vm.expectEmit(address(L2NFT));
+        emit Transfer(address(0), alice, tokenId);
 
-        // Expect a mint event.
-        vm.expectEmit(true, true, true, true);
-        emit Mint(alice, 1);
+        vm.expectEmit(address(L2NFT));
+        emit Mint(alice, tokenId);
 
-        // Mint the token.
-        vm.prank(address(l2ERC721Bridge));
-        L2NFT.safeMint(alice, 1);
+        _bridgeMint(alice);
 
-        // Token should be owned by alice.
-        assertEq(L2NFT.ownerOf(1), alice);
+        assertEq(L2NFT.ownerOf(tokenId), alice);
     }
 
     /// @notice Tests that the `safeMint` function reverts when called by an address other than the bridge.
     function test_safeMint_notBridge_reverts() external {
-        // Try to mint the token.
         vm.expectRevert("OptimismMintableERC721: only bridge can call this function");
         vm.prank(address(alice));
-        L2NFT.safeMint(alice, 1);
+        L2NFT.safeMint(alice, tokenId);
     }
 }
 
@@ -104,38 +104,29 @@ contract OptimismMintableERC721_Burn_Test is OptimismMintableERC721_TestInit {
     /// @notice Tests that the `burn` function successfully burns a token when called by the
     ///         bridge.
     function test_burn_succeeds() external {
-        // Mint the token first.
+        _bridgeMint(alice);
+
+        vm.expectEmit(address(L2NFT));
+        emit Transfer(alice, address(0), tokenId);
+
+        vm.expectEmit(address(L2NFT));
+        emit Burn(alice, tokenId);
+
         vm.prank(address(l2ERC721Bridge));
-        L2NFT.safeMint(alice, 1);
+        L2NFT.burn(alice, tokenId);
 
-        // Expect a transfer event.
-        vm.expectEmit(true, true, true, true);
-        emit Transfer(alice, address(0), 1);
-
-        // Expect a burn event.
-        vm.expectEmit(true, true, true, true);
-        emit Burn(alice, 1);
-
-        // Burn the token.
-        vm.prank(address(l2ERC721Bridge));
-        L2NFT.burn(alice, 1);
-
-        // Token should be owned by address(0).
         vm.expectRevert("ERC721: invalid token ID");
-        L2NFT.ownerOf(1);
+        L2NFT.ownerOf(tokenId);
     }
 
     /// @notice Tests that the `burn` function reverts when called by an address other than the
     ///         bridge.
     function test_burn_notBridge_reverts() external {
-        // Mint the token first.
-        vm.prank(address(l2ERC721Bridge));
-        L2NFT.safeMint(alice, 1);
+        _bridgeMint(alice);
 
-        // Try to burn the token.
         vm.expectRevert("OptimismMintableERC721: only bridge can call this function");
         vm.prank(address(alice));
-        L2NFT.burn(alice, 1);
+        L2NFT.burn(alice, tokenId);
     }
 }
 
@@ -145,13 +136,9 @@ contract OptimismMintableERC721_SupportsInterface_Test is OptimismMintableERC721
     /// @notice Tests that the `supportsInterface` function returns true for
     ///         IOptimismMintableERC721, IERC721Enumerable, IERC721 and IERC165 interfaces.
     function test_supportsInterface_succeeds() external view {
-        // Checks if the contract supports the IOptimismMintableERC721 interface.
         assertTrue(L2NFT.supportsInterface(type(IOptimismMintableERC721).interfaceId));
-        // Checks if the contract supports the IERC721Enumerable interface.
         assertTrue(L2NFT.supportsInterface(type(IERC721Enumerable).interfaceId));
-        // Checks if the contract supports the IERC721 interface.
         assertTrue(L2NFT.supportsInterface(type(IERC721).interfaceId));
-        // Checks if the contract supports the IERC165 interface.
         assertTrue(L2NFT.supportsInterface(type(IERC165).interfaceId));
     }
 }
@@ -162,22 +149,17 @@ contract OptimismMintableERC721_SupportsInterface_Test is OptimismMintableERC721
 contract OptimismMintableERC721_Uncategorized_Test is OptimismMintableERC721_TestInit {
     /// @notice Tests that the `tokenURI` function returns the correct URI for a minted token.
     function test_tokenURI_succeeds() external {
-        // Mint the token first.
-        vm.prank(address(l2ERC721Bridge));
-        L2NFT.safeMint(alice, 1);
+        _bridgeMint(alice);
 
-        // Token URI should be correct.
         assertEq(
-            L2NFT.tokenURI(1),
-            string(
-                abi.encodePacked(
-                    "ethereum:",
-                    Strings.toHexString(uint160(address(L1NFT)), 20),
-                    "@",
-                    Strings.toString(1),
-                    "/tokenURI?uint256=",
-                    Strings.toString(1)
-                )
+            L2NFT.tokenURI(tokenId),
+            string.concat(
+                "ethereum:",
+                Strings.toHexString(uint160(L1NFT), 20),
+                "@",
+                Strings.toString(remoteChainId),
+                "/tokenURI?uint256=",
+                Strings.toString(tokenId)
             )
         );
     }

--- a/test/L2/OptimismMintableERC721Factory.t.sol
+++ b/test/L2/OptimismMintableERC721Factory.t.sol
@@ -7,9 +7,14 @@ import { OptimismMintableERC721 } from "src/L2/OptimismMintableERC721.sol";
 /// @title OptimismMintableERC721Factory_TestInit
 /// @notice Reusable test initialization for `OptimismMintableERC721Factory` tests.
 abstract contract OptimismMintableERC721Factory_TestInit is CommonTest {
+    address internal constant REMOTE_TOKEN = address(1234);
+    string internal constant TOKEN_NAME = "L2Token";
+    string internal constant TOKEN_SYMBOL = "L2T";
+
     event OptimismMintableERC721Created(address indexed localToken, address indexed remoteToken, address deployer);
 
-    function calculateTokenAddress(
+    /// @notice Precalculates the address of the token contract.
+    function _calculateTokenAddress(
         address _remote,
         string memory _name,
         string memory _symbol
@@ -47,29 +52,22 @@ contract OptimismMintableERC721Factory_Constructor_Test is OptimismMintableERC72
 contract OptimismMintableERC721Factory_CreateOptimismMintableERC721_Test is OptimismMintableERC721Factory_TestInit {
     /// @notice Tests that the `createOptimismMintableERC721` function succeeds.
     function test_createOptimismMintableERC721_succeeds() external {
-        address remote = address(1234);
-        address local = calculateTokenAddress(address(1234), "L2Token", "L2T");
+        address local = _calculateTokenAddress(REMOTE_TOKEN, TOKEN_NAME, TOKEN_SYMBOL);
 
-        // Expect a token creation event.
         vm.expectEmit(address(l2OptimismMintableERC721Factory));
-        emit OptimismMintableERC721Created(local, remote, alice);
+        emit OptimismMintableERC721Created(local, REMOTE_TOKEN, alice);
 
-        // Create the token.
         vm.prank(alice);
         OptimismMintableERC721 created = OptimismMintableERC721(
-            l2OptimismMintableERC721Factory.createOptimismMintableERC721(remote, "L2Token", "L2T")
+            l2OptimismMintableERC721Factory.createOptimismMintableERC721(REMOTE_TOKEN, TOKEN_NAME, TOKEN_SYMBOL)
         );
 
-        // Token address should be correct.
         assertEq(address(created), local);
-
-        // Should be marked as created by the factory.
         assertTrue(l2OptimismMintableERC721Factory.isOptimismMintableERC721(address(created)));
 
-        // Token should've been constructed correctly.
-        assertEq(created.name(), "L2Token");
-        assertEq(created.symbol(), "L2T");
-        assertEq(created.REMOTE_TOKEN(), remote);
+        assertEq(created.name(), TOKEN_NAME);
+        assertEq(created.symbol(), TOKEN_SYMBOL);
+        assertEq(created.REMOTE_TOKEN(), REMOTE_TOKEN);
         assertEq(created.BRIDGE(), address(l2ERC721Bridge));
         assertEq(created.REMOTE_CHAIN_ID(), deploy.cfg().l1ChainId());
     }
@@ -77,22 +75,19 @@ contract OptimismMintableERC721Factory_CreateOptimismMintableERC721_Test is Opti
     /// @notice Tests that the `createOptimismMintableERC721` function reverts if the same token is
     ///         created twice.
     function test_createOptimismMintableERC721_sameTwice_reverts() external {
-        address remote = address(1234);
-
         vm.prank(alice);
-        l2OptimismMintableERC721Factory.createOptimismMintableERC721(remote, "L2Token", "L2T");
+        l2OptimismMintableERC721Factory.createOptimismMintableERC721(REMOTE_TOKEN, TOKEN_NAME, TOKEN_SYMBOL);
 
         vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
 
         vm.prank(alice);
-        l2OptimismMintableERC721Factory.createOptimismMintableERC721(remote, "L2Token", "L2T");
+        l2OptimismMintableERC721Factory.createOptimismMintableERC721(REMOTE_TOKEN, TOKEN_NAME, TOKEN_SYMBOL);
     }
 
     /// @notice Tests that the `createOptimismMintableERC721` function reverts if the remote token
     ///         address is zero.
     function test_createOptimismMintableERC721_zeroRemoteToken_reverts() external {
-        // Try to create a token with a zero remote token address.
         vm.expectRevert("OptimismMintableERC721Factory: L1 token address cannot be address(0)");
-        l2OptimismMintableERC721Factory.createOptimismMintableERC721(address(0), "L2Token", "L2T");
+        l2OptimismMintableERC721Factory.createOptimismMintableERC721(address(0), TOKEN_NAME, TOKEN_SYMBOL);
     }
 }

--- a/test/L2/SequencerFeeVault.t.sol
+++ b/test/L2/SequencerFeeVault.t.sol
@@ -1,29 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Interfaces
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
-import { ISequencerFeeVault } from "interfaces/L2/ISequencerFeeVault.sol";
 
-// Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { FeeVault_Uncategorized_Test } from "test/L2/FeeVault.t.sol";
 import { Types } from "src/libraries/Types.sol";
 
-/// @title SequencerFeeVault_Uncategorized_Test
-/// @notice Test contract for the SequencerFeeVault contract's functionality
 contract SequencerFeeVault_Uncategorized_Test is FeeVault_Uncategorized_Test {
-    /// @dev Sets up the test suite.
     function setUp() public virtual override {
         super.setUp();
         recipient = deploy.cfg().sequencerFeeVaultRecipient();
-        feeVaultName = "SequencerFeeVault";
         minWithdrawalAmount = deploy.cfg().sequencerFeeVaultMinimumWithdrawalAmount();
         feeVault = IFeeVault(payable(Predeploys.SEQUENCER_FEE_WALLET));
-        withdrawalNetwork = Types.WithdrawalNetwork(uint8(deploy.cfg().sequencerFeeVaultWithdrawalNetwork()));
+        withdrawalNetwork = Types.WithdrawalNetwork(deploy.cfg().sequencerFeeVaultWithdrawalNetwork());
     }
 
-    function test_constructor_l1FeeWallet_succeeds() external view {
-        assertEq(ISequencerFeeVault(payable(address(feeVault))).l1FeeWallet(), recipient);
+    function test_l1FeeWallet_matchesRecipient_succeeds() external view {
+        assertEq(sequencerFeeVault.l1FeeWallet(), recipient);
     }
 }

--- a/test/L2/WETH.t.sol
+++ b/test/L2/WETH.t.sol
@@ -1,54 +1,40 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";
-
-// Libraries
 import { SemverComp } from "src/libraries/SemverComp.sol";
-
-// Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
-/// @title WETH_Version_Test
-/// @notice Tests the `version` function of the `WETH` contract.
 contract WETH_Version_Test is CommonTest {
-    /// @notice Tests that the version returns a valid semver string.
-    function test_version_succeeds() external view {
+    function test_version_validFormat_succeeds() external view {
         SemverComp.parse(ISemver(address(weth)).version());
     }
 }
 
-/// @title WETH_Name_Test
-/// @notice Tests the `name` function of the `WETH` contract.
 contract WETH_Name_Test is CommonTest {
-    /// @notice Tests that the `name` function returns the correct value.
     function testFuzz_name_succeeds(string memory _gasPayingTokenName) external {
+        vm.assume(bytes(_gasPayingTokenName).length <= 128);
         vm.mockCall(address(l1Block), abi.encodeCall(l1Block.gasPayingTokenName, ()), abi.encode(_gasPayingTokenName));
 
-        assertEq(string.concat("Wrapped ", _gasPayingTokenName), weth.name());
+        assertEq(weth.name(), string.concat("Wrapped ", _gasPayingTokenName));
     }
 
-    /// @notice Tests that the `name` function returns 'Wrapped Ether' by default.
-    function test_name_ether_succeeds() external view {
-        assertEq(string.concat("Wrapped ", l1Block.gasPayingTokenName()), weth.name());
+    function test_name_defaultGasPayingToken_succeeds() external view {
+        assertEq(weth.name(), string.concat("Wrapped ", l1Block.gasPayingTokenName()));
     }
 }
 
-/// @title WETH_Symbol_Test
-/// @notice Tests the `symbol` function of the `WETH` contract.
 contract WETH_Symbol_Test is CommonTest {
-    /// @notice Tests that the `symbol` function returns the correct value.
     function testFuzz_symbol_succeeds(string memory _gasPayingTokenSymbol) external {
+        vm.assume(bytes(_gasPayingTokenSymbol).length <= 128);
         vm.mockCall(
             address(l1Block), abi.encodeCall(l1Block.gasPayingTokenSymbol, ()), abi.encode(_gasPayingTokenSymbol)
         );
 
-        assertEq(string.concat("W", _gasPayingTokenSymbol), weth.symbol());
+        assertEq(weth.symbol(), string.concat("W", _gasPayingTokenSymbol));
     }
 
-    /// @notice Tests that the `symbol` function returns 'WETH' by default.
-    function test_symbol_ether_succeeds() external view {
-        assertEq(string.concat("W", l1Block.gasPayingTokenSymbol()), weth.symbol());
+    function test_symbol_defaultGasPayingToken_succeeds() external view {
+        assertEq(weth.symbol(), string.concat("W", l1Block.gasPayingTokenSymbol()));
     }
 }


### PR DESCRIPTION
## Summary
- Clean up L2 tests with shared helpers and constants.
- Remove duplicated expectations and redundant setup/comments.