### PR TITLE
chore: clean up legacy tests

### DIFF
--- a/test/legacy/L1ChugSplashProxy.t.sol
+++ b/test/legacy/L1ChugSplashProxy.t.sol
@@ -16,11 +16,7 @@ import { LibString } from "lib/solady/src/utils/LibString.sol";
 import { IL1ChugSplashProxy } from "interfaces/legacy/IL1ChugSplashProxy.sol";
 
 contract L1ChugSplashProxy_Owner_Harness {
-    bool public isUpgrading;
-
-    function setIsUpgrading(bool _isUpgrading) public {
-        isUpgrading = _isUpgrading;
-    }
+    bool public isUpgrading = true;
 }
 
 contract L1ChugSplashProxy_Implementation_Harness {
@@ -48,20 +44,37 @@ contract L1ChugSplashProxy_Implementation_Harness {
 /// @title L1ChugSplashProxy_TestInit
 /// @notice Reusable test initialization for `L1ChugSplashProxy` tests.
 abstract contract L1ChugSplashProxy_TestInit is Test {
+    bytes internal constant RETURN_42_BYTECODE = hex"604260005260206000f3";
+
     IL1ChugSplashProxy proxy;
-    address impl;
     address owner = makeAddr("owner");
     address alice = makeAddr("alice");
 
-    function setUp() public {
-        proxy = IL1ChugSplashProxy(
+    function setUp() public virtual {
+        proxy = _deployProxy();
+        vm.prank(owner);
+        assertEq(proxy.getOwner(), owner);
+    }
+
+    function _deployProxy() internal returns (IL1ChugSplashProxy) {
+        return IL1ChugSplashProxy(
             DeployUtils.create1({
                 _name: "L1ChugSplashProxy",
                 _args: DeployUtils.encodeConstructor(abi.encodeCall(IL1ChugSplashProxy.__constructor__, (owner)))
             })
         );
-        vm.prank(owner);
-        assertEq(proxy.getOwner(), owner);
+    }
+
+    function _proxyAsImplementation() internal view returns (L1ChugSplashProxy_Implementation_Harness) {
+        return L1ChugSplashProxy_Implementation_Harness(address(proxy));
+    }
+}
+
+abstract contract L1ChugSplashProxy_WithImplementation_TestInit is L1ChugSplashProxy_TestInit {
+    address impl;
+
+    function setUp() public virtual override {
+        super.setUp();
 
         vm.prank(owner);
         proxy.setCode(type(L1ChugSplashProxy_Implementation_Harness).runtimeCode);
@@ -73,11 +86,11 @@ abstract contract L1ChugSplashProxy_TestInit is Test {
 
 /// @title L1ChugSplashProxy_SetCode_Test
 /// @notice Tests the `setCode` function of the `L1ChugSplashProxy` contract.
-contract L1ChugSplashProxy_SetCode_Test is L1ChugSplashProxy_TestInit {
+contract L1ChugSplashProxy_SetCode_Test is L1ChugSplashProxy_WithImplementation_TestInit {
     /// @notice Tests that the owner can deploy a new implementation with a given runtime code.
     function test_setCode_whenOwner_succeeds() public {
         vm.prank(owner);
-        proxy.setCode(hex"604260005260206000f3");
+        proxy.setCode(RETURN_42_BYTECODE);
 
         vm.prank(owner);
         assertNotEq(proxy.getImplementation(), impl);
@@ -85,7 +98,7 @@ contract L1ChugSplashProxy_SetCode_Test is L1ChugSplashProxy_TestInit {
 
     /// @notice Tests that when not the owner, `setCode` delegatecalls the implementation.
     function test_setCode_whenNotOwner_works() public view {
-        uint256 ret = L1ChugSplashProxy_Implementation_Harness(address(proxy)).setCode(hex"604260005260206000f3");
+        uint256 ret = _proxyAsImplementation().setCode(RETURN_42_BYTECODE);
         assertEq(ret, 1);
     }
 
@@ -95,7 +108,6 @@ contract L1ChugSplashProxy_SetCode_Test is L1ChugSplashProxy_TestInit {
         vm.prank(owner);
         proxy.setCode(type(L1ChugSplashProxy_Implementation_Harness).runtimeCode);
 
-        // does not deploy new implementation
         vm.prank(owner);
         assertEq(proxy.getImplementation(), impl);
     }
@@ -135,7 +147,7 @@ contract L1ChugSplashProxy_SetCode_Test is L1ChugSplashProxy_TestInit {
 
 /// @title L1ChugSplashProxy_SetStorage_Test
 /// @notice Tests the `setStorage` function of the `L1ChugSplashProxy` contract.
-contract L1ChugSplashProxy_SetStorage_Test is L1ChugSplashProxy_TestInit {
+contract L1ChugSplashProxy_SetStorage_Test is L1ChugSplashProxy_WithImplementation_TestInit {
     /// @notice Tests that the owner can set storage of the proxy
     function test_setStorage_whenOwner_works() public {
         vm.prank(owner);
@@ -145,8 +157,7 @@ contract L1ChugSplashProxy_SetStorage_Test is L1ChugSplashProxy_TestInit {
 
     /// @notice Tests that when not the owner, `setStorage` delegatecalls the implementation
     function test_setStorage_whenNotOwner_works() public view {
-        uint256 ret =
-            L1ChugSplashProxy_Implementation_Harness(address(proxy)).setStorage(bytes32(0), bytes32(uint256(42)));
+        uint256 ret = _proxyAsImplementation().setStorage(bytes32(0), bytes32(uint256(42)));
         assertEq(ret, 2);
         assertEq(vm.load(address(proxy), bytes32(0)), bytes32(uint256(0)));
     }
@@ -154,7 +165,7 @@ contract L1ChugSplashProxy_SetStorage_Test is L1ChugSplashProxy_TestInit {
 
 /// @title L1ChugSplashProxy_SetOwner_Test
 /// @notice Tests the `setOwner` function of the `L1ChugSplashProxy` contract.
-contract L1ChugSplashProxy_SetOwner_Test is L1ChugSplashProxy_TestInit {
+contract L1ChugSplashProxy_SetOwner_Test is L1ChugSplashProxy_WithImplementation_TestInit {
     /// @notice Tests that the owner can set the owner of the proxy
     function test_setOwner_whenOwner_works() public {
         vm.prank(owner);
@@ -166,7 +177,7 @@ contract L1ChugSplashProxy_SetOwner_Test is L1ChugSplashProxy_TestInit {
 
     /// @notice Tests that when not the owner, `setOwner` delegatecalls the implementation
     function test_setOwner_whenNotOwner_works() public {
-        uint256 ret = L1ChugSplashProxy_Implementation_Harness(address(proxy)).setOwner(alice);
+        uint256 ret = _proxyAsImplementation().setOwner(alice);
         assertEq(ret, 3);
 
         vm.prank(owner);
@@ -176,7 +187,7 @@ contract L1ChugSplashProxy_SetOwner_Test is L1ChugSplashProxy_TestInit {
 
 /// @title L1ChugSplashProxy_GetOwner_Test
 /// @notice Tests the `getOwner` function of the `L1ChugSplashProxy` contract.
-contract L1ChugSplashProxy_GetOwner_Test is L1ChugSplashProxy_TestInit {
+contract L1ChugSplashProxy_GetOwner_Test is L1ChugSplashProxy_WithImplementation_TestInit {
     /// @notice Tests that the owner can get the owner of the proxy
     function test_getOwner_whenOwner_works() public {
         vm.prank(owner);
@@ -185,14 +196,14 @@ contract L1ChugSplashProxy_GetOwner_Test is L1ChugSplashProxy_TestInit {
 
     /// @notice Tests that when not the owner, `getOwner` delegatecalls the implementation
     function test_getOwner_whenNotOwner_works() public view {
-        uint256 ret = L1ChugSplashProxy_Implementation_Harness(address(proxy)).getOwner();
+        uint256 ret = _proxyAsImplementation().getOwner();
         assertEq(ret, 4);
     }
 }
 
 /// @title L1ChugSplashProxy_GetImplementation_Test
 /// @notice Tests the `getImplementation` function of the `L1ChugSplashProxy` contract.
-contract L1ChugSplashProxy_GetImplementation_Test is L1ChugSplashProxy_TestInit {
+contract L1ChugSplashProxy_GetImplementation_Test is L1ChugSplashProxy_WithImplementation_TestInit {
     /// @notice Tests that the owner can get the implementation of the proxy
     function test_getImplementation_whenOwner_works() public {
         vm.prank(owner);
@@ -201,29 +212,25 @@ contract L1ChugSplashProxy_GetImplementation_Test is L1ChugSplashProxy_TestInit 
 
     /// @notice Tests that when not the owner, `getImplementation` delegatecalls the implementation
     function test_getImplementation_whenNotOwner_works() public view {
-        uint256 ret = L1ChugSplashProxy_Implementation_Harness(address(proxy)).getImplementation();
+        uint256 ret = _proxyAsImplementation().getImplementation();
         assertEq(ret, 5);
     }
 }
 
-/// @title L1ChugSplashProxy_Uncategorized_Test
-/// @notice General tests that are not testing any function directly of the `L1ChugSplashProxy`
-///         contract or are testing multiple functions at once.
-contract L1ChugSplashProxy_Uncategorized_Test is L1ChugSplashProxy_TestInit {
+/// @title L1ChugSplashProxy_NoImplementation_Test
+/// @notice Tests calls against a proxy before its implementation has been set.
+contract L1ChugSplashProxy_NoImplementation_Test is L1ChugSplashProxy_TestInit {
     /// @notice Tests that when the caller is not the owner and the implementation is not set, all
     ///         calls reverts.
     function test_calls_whenNotOwnerNoImplementation_reverts() public {
-        proxy = IL1ChugSplashProxy(
-            DeployUtils.create1({
-                _name: "L1ChugSplashProxy",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(IL1ChugSplashProxy.__constructor__, (owner)))
-            })
-        );
-
         vm.expectRevert(bytes("L1ChugSplashProxy: implementation is not set yet"));
-        L1ChugSplashProxy_Implementation_Harness(address(proxy)).setCode(hex"604260005260206000f3");
+        _proxyAsImplementation().setCode(RETURN_42_BYTECODE);
     }
+}
 
+/// @title L1ChugSplashProxy_Upgrading_Test
+/// @notice Tests calls against a proxy while its owner reports an active upgrade.
+contract L1ChugSplashProxy_Upgrading_Test is L1ChugSplashProxy_WithImplementation_TestInit {
     /// @notice Tests that when the caller is not the owner but the owner has marked `isUpgrading`
     ///         as true, the call reverts.
     function test_calls_whenUpgrading_reverts() public {
@@ -231,9 +238,7 @@ contract L1ChugSplashProxy_Uncategorized_Test is L1ChugSplashProxy_TestInit {
         vm.prank(owner);
         proxy.setOwner(address(ownerContract));
 
-        ownerContract.setIsUpgrading(true);
-
         vm.expectRevert(bytes("L1ChugSplashProxy: system is currently being upgraded"));
-        L1ChugSplashProxy_Implementation_Harness(address(proxy)).setCode(hex"604260005260206000f3");
+        _proxyAsImplementation().setCode(RETURN_42_BYTECODE);
     }
 }

--- a/test/legacy/ResolvedDelegateProxy.t.sol
+++ b/test/legacy/ResolvedDelegateProxy.t.sol
@@ -1,13 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
 import { Test } from "lib/forge-std/src/Test.sol";
-
-// Target contract dependencies
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
-
-// Target contract
 import { IResolvedDelegateProxy } from "interfaces/legacy/IResolvedDelegateProxy.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
@@ -21,76 +16,68 @@ contract ResolvedDelegateProxy_SimpleImplementation_Harness {
     }
 }
 
-/// @title ResolvedDelegateProxy_TestInit
-/// @notice Reusable test initialization for `ResolvedDelegateProxy` tests.
-abstract contract ResolvedDelegateProxy_TestInit is Test {
-    IAddressManager internal addressManager;
-    ResolvedDelegateProxy_SimpleImplementation_Harness internal impl;
-    ResolvedDelegateProxy_SimpleImplementation_Harness internal proxy;
+abstract contract ResolvedDelegateProxy_TestBase is Test {
+    string internal constant IMPLEMENTATION_NAME = "SimpleImplementation";
 
-    /// @notice Sets up the test suite.
-    function setUp() public {
-        // Set up the address manager.
-        addressManager = IAddressManager(
+    function _deployAddressManager() internal returns (IAddressManager) {
+        return IAddressManager(
             DeployUtils.create1({
                 _name: "AddressManager",
                 _args: DeployUtils.encodeConstructor(abi.encodeCall(IAddressManager.__constructor__, ()))
             })
         );
-        impl = new ResolvedDelegateProxy_SimpleImplementation_Harness();
-        addressManager.setAddress("SimpleImplementation", address(impl));
+    }
 
-        // Set up the proxy.
-        proxy = ResolvedDelegateProxy_SimpleImplementation_Harness(
-            address(
-                DeployUtils.create1({
-                    _name: "ResolvedDelegateProxy",
-                    _args: DeployUtils.encodeConstructor(
-                        abi.encodeCall(IResolvedDelegateProxy.__constructor__, (addressManager, "SimpleImplementation"))
-                    )
-                })
-            )
+    function _deployProxy(IAddressManager _addressManager) internal returns (IResolvedDelegateProxy) {
+        return IResolvedDelegateProxy(
+            DeployUtils.create1({
+                _name: "ResolvedDelegateProxy",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IResolvedDelegateProxy.__constructor__, (_addressManager, IMPLEMENTATION_NAME))
+                )
+            })
         );
+    }
+
+    function _proxyAsImplementation(IResolvedDelegateProxy _proxy)
+        internal
+        pure
+        returns (ResolvedDelegateProxy_SimpleImplementation_Harness)
+    {
+        return ResolvedDelegateProxy_SimpleImplementation_Harness(address(_proxy));
     }
 }
 
-/// @title ResolvedDelegateProxy_Fallback_Test
-/// @notice Tests the `fallback` function of the `ResolvedDelegateProxy` contract.
-contract ResolvedDelegateProxy_Fallback_Test is ResolvedDelegateProxy_TestInit {
-    /// @notice Tests that the proxy properly bubbles up returndata when the delegatecall succeeds.
-    function testFuzz_fallback_delegateCallFoo_succeeds(uint256 x) public {
-        vm.expectCall(address(impl), abi.encodeCall(impl.foo, (x)));
-        assertEq(proxy.foo(x), x);
+contract ResolvedDelegateProxy_Fallback_Test is ResolvedDelegateProxy_TestBase {
+    IAddressManager internal addressManager;
+    ResolvedDelegateProxy_SimpleImplementation_Harness internal impl;
+    IResolvedDelegateProxy internal proxy;
+
+    function setUp() public {
+        addressManager = _deployAddressManager();
+        impl = new ResolvedDelegateProxy_SimpleImplementation_Harness();
+        addressManager.setAddress(IMPLEMENTATION_NAME, address(impl));
+
+        proxy = _deployProxy(addressManager);
     }
 
-    /// @notice Tests that the proxy properly bubbles up returndata when the delegatecall reverts.
+    function testFuzz_fallback_delegateCallFoo_succeeds(uint256 x) public {
+        vm.expectCall(address(impl), abi.encodeCall(impl.foo, (x)));
+        assertEq(_proxyAsImplementation(proxy).foo(x), x);
+    }
+
     function test_fallback_delegateCallBar_reverts() public {
         vm.expectRevert("SimpleImplementation: revert");
         vm.expectCall(address(impl), abi.encodeCall(impl.bar, ()));
-        proxy.bar();
+        _proxyAsImplementation(proxy).bar();
     }
+}
 
-    /// @notice Tests that the proxy fallback reverts as expected if the implementation within the
-    ///         address manager is not set.
+contract ResolvedDelegateProxy_FallbackNoImplementation_Test is ResolvedDelegateProxy_TestBase {
     function test_fallback_addressManagerNotSet_reverts() public {
-        IAddressManager am = IAddressManager(
-            DeployUtils.create1({
-                _name: "AddressManager",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(IAddressManager.__constructor__, ()))
-            })
-        );
-        ResolvedDelegateProxy_SimpleImplementation_Harness p = ResolvedDelegateProxy_SimpleImplementation_Harness(
-            address(
-                DeployUtils.create1({
-                    _name: "ResolvedDelegateProxy",
-                    _args: DeployUtils.encodeConstructor(
-                        abi.encodeCall(IResolvedDelegateProxy.__constructor__, (am, "SimpleImplementation"))
-                    )
-                })
-            )
-        );
+        IResolvedDelegateProxy proxy = _deployProxy(_deployAddressManager());
 
         vm.expectRevert("ResolvedDelegateProxy: target address must be initialized");
-        p.foo(0);
+        _proxyAsImplementation(proxy).foo(0);
     }
 }


### PR DESCRIPTION
## Summary
- Clean up legacy proxy tests with shared helpers and constants.
- Split `L1ChugSplashProxy` test init into a base contract and a `WithImplementation` variant so no-implementation and upgrading scenarios get focused fixtures.
- Refactor `ResolvedDelegateProxy` tests around a shared `TestBase` with `_deployAddressManager`/`_deployProxy` helpers and an `IMPLEMENTATION_NAME` constant.