### PR TITLE
chore: simplify lib tests

### DIFF
--- a/test/libraries/bridge/LibGameId.t.sol
+++ b/test/libraries/bridge/LibGameId.t.sol
@@ -3,14 +3,9 @@ pragma solidity ^0.8.15;
 
 import { Test } from "lib/forge-std/src/Test.sol";
 
-import { Timestamp, GameId, LibGameId } from "src/libraries/bridge/LibUDT.sol";
-import "src/libraries/bridge/Types.sol";
+import { Timestamp, GameId, GameType, LibGameId } from "src/libraries/bridge/LibUDT.sol";
 
-/// @title LibGameId_Pack_Test
-/// @notice Tests the `pack` and `unpack` functions of the `LibGameId` library.
 contract LibGameId_Pack_Test is Test {
-    /// @notice Tests that a round trip of packing and unpacking a `GameId` maintains the same
-    ///         values.
     function testFuzz_pack_roundTrip_succeeds(
         GameType _gameType,
         Timestamp _timestamp,
@@ -22,8 +17,8 @@ contract LibGameId_Pack_Test is Test {
         GameId gameId = LibGameId.pack(_gameType, _timestamp, _gameProxy);
         (GameType gameType_, Timestamp timestamp_, address gameProxy_) = LibGameId.unpack(gameId);
 
-        assertEq(GameType.unwrap(gameType_), GameType.unwrap(_gameType));
-        assertEq(Timestamp.unwrap(timestamp_), Timestamp.unwrap(_timestamp));
+        assertEq(gameType_.raw(), _gameType.raw());
+        assertEq(timestamp_.raw(), _timestamp.raw());
         assertEq(gameProxy_, _gameProxy);
     }
 }

--- a/test/libraries/rlp/RLPReader.t.sol
+++ b/test/libraries/rlp/RLPReader.t.sol
@@ -8,8 +8,6 @@ import "src/libraries/rlp/RLPErrors.sol";
 
 /// @title RLPReader_readBytes_Test
 /// @notice Tests the `readBytes` function of the `RLPReader` library.
-/// @dev Here we allow internal reverts as readRawBytes uses memory allocations and can only be
-///      tested internally.
 contract RLPReader_readBytes_Test is Test {
     /// @notice Tests that the `readBytes` function returns the correct bytes when given a null
     ///         byte.
@@ -66,9 +64,19 @@ contract RLPReader_readBytes_Test is Test {
     }
 }
 
+/// @title RLPReader_TestInit
+/// @notice Reusable helpers for `RLPReader` tests.
+abstract contract RLPReader_TestInit is Test {
+    function assertRepeatedRawBytes(RLPReader.RLPItem[] memory _list, bytes memory _expected) internal pure {
+        for (uint256 i = 0; i < _list.length; i++) {
+            assertEq(RLPReader.readRawBytes(_list[i]), _expected);
+        }
+    }
+}
+
 /// @title RLPReader_readList_Test
 /// @notice Tests the `readList` function of the `RLPReader` library.
-contract RLPReader_readList_Test is Test {
+contract RLPReader_readList_Test is RLPReader_TestInit {
     /// @notice Tests that the `readList` function returns an empty array when given an empty list.
     function test_readList_empty_succeeds() external pure {
         RLPReader.RLPItem[] memory list = RLPReader.readList(hex"c0");
@@ -114,10 +122,7 @@ contract RLPReader_readList_Test is Test {
         );
 
         assertEq(list.length, 4);
-        assertEq(RLPReader.readRawBytes(list[0]), hex"cf84617364668471776572847a786376");
-        assertEq(RLPReader.readRawBytes(list[1]), hex"cf84617364668471776572847a786376");
-        assertEq(RLPReader.readRawBytes(list[2]), hex"cf84617364668471776572847a786376");
-        assertEq(RLPReader.readRawBytes(list[3]), hex"cf84617364668471776572847a786376");
+        assertRepeatedRawBytes(list, hex"cf84617364668471776572847a786376");
     }
 
     /// @notice Tests that the `readList` function correctly parses a very long list with 32 nested
@@ -127,10 +132,7 @@ contract RLPReader_readList_Test is Test {
             hex"f90200cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376cf84617364668471776572847a786376"
         );
         assertEq(list.length, 32);
-
-        for (uint256 i = 0; i < 32; i++) {
-            assertEq(RLPReader.readRawBytes(list[i]), hex"cf84617364668471776572847a786376");
-        }
+        assertRepeatedRawBytes(list, hex"cf84617364668471776572847a786376");
     }
 
     /// @notice Tests that the `readList` function reverts when given a list longer than 32
@@ -196,18 +198,18 @@ contract RLPReader_readList_Test is Test {
         RLPReader.readList(hex"efdebdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     }
 
-    /// @notice Tests that the `readList` function reverts when given data that causes int32
-    ///         overflow.
+    /// @notice Tests that the `readList` function reverts when the declared string length exceeds
+    ///         the available payload.
     /// forge-config: default.allow_internal_expect_revert = true
-    function test_readList_int32Overflow_reverts() external {
+    function test_readList_declaredStringLengthExceedsPayload_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
         RLPReader.readList(hex"bf0f000000000000021111");
     }
 
-    /// @notice Tests that the `readList` function reverts when given data that causes int32
-    ///         overflow with a different prefix.
+    /// @notice Tests that the `readList` function reverts when the declared list length exceeds
+    ///         the available payload.
     /// forge-config: default.allow_internal_expect_revert = true
-    function test_readList_int32Overflow2_reverts() external {
+    function test_readList_declaredListLengthExceedsPayload_reverts() external {
         vm.expectRevert(ContentLengthMismatch.selector);
         RLPReader.readList(hex"ff0f000000000000021111");
     }

--- a/test/libraries/rlp/RLPWriter.t.sol
+++ b/test/libraries/rlp/RLPWriter.t.sol
@@ -125,10 +125,22 @@ contract RLPWriter_writeUint_Test is Test {
         assertGt(encoded.length, 0);
     }
 }
+
+/// @title RLPWriter_TestInit
+/// @notice Reusable helpers for `RLPWriter` tests.
+abstract contract RLPWriter_TestInit is Test {
+    function encodedThreeStringList() internal pure returns (bytes[] memory list_) {
+        list_ = new bytes[](3);
+        list_[0] = RLPWriter.writeString("asdf");
+        list_[1] = RLPWriter.writeString("qwer");
+        list_[2] = RLPWriter.writeString("zxcv");
+    }
+}
+
 /// @title RLPWriter_writeList_Test
 /// @notice Tests the `writeList` function of the `RLPWriter` library.
 
-contract RLPWriter_writeList_Test is Test {
+contract RLPWriter_writeList_Test is RLPWriter_TestInit {
     /// @notice Tests that the `writeList` function returns the correct RLP encoding when given an
     ///         empty list.
     function test_writeList_empty_succeeds() external pure {
@@ -186,16 +198,11 @@ contract RLPWriter_writeList_Test is Test {
     ///         long list containing nested lists.
     function test_writeList_longlist1_succeeds() external pure {
         bytes[] memory list = new bytes[](4);
-        bytes[] memory list2 = new bytes[](3);
+        bytes memory nestedList = RLPWriter.writeList(encodedThreeStringList());
 
-        list2[0] = RLPWriter.writeString("asdf");
-        list2[1] = RLPWriter.writeString("qwer");
-        list2[2] = RLPWriter.writeString("zxcv");
-
-        list[0] = RLPWriter.writeList(list2);
-        list[1] = RLPWriter.writeList(list2);
-        list[2] = RLPWriter.writeList(list2);
-        list[3] = RLPWriter.writeList(list2);
+        for (uint256 i = 0; i < list.length; i++) {
+            list[i] = nestedList;
+        }
 
         assertEq(
             RLPWriter.writeList(list),
@@ -207,14 +214,10 @@ contract RLPWriter_writeList_Test is Test {
     ///         very long list with 32 nested lists.
     function test_writeList_longlist2_succeeds() external pure {
         bytes[] memory list = new bytes[](32);
-        bytes[] memory list2 = new bytes[](3);
-
-        list2[0] = RLPWriter.writeString("asdf");
-        list2[1] = RLPWriter.writeString("qwer");
-        list2[2] = RLPWriter.writeString("zxcv");
+        bytes memory nestedList = RLPWriter.writeList(encodedThreeStringList());
 
         for (uint256 i = 0; i < 32; i++) {
-            list[i] = RLPWriter.writeList(list2);
+            list[i] = nestedList;
         }
 
         assertEq(
@@ -229,12 +232,13 @@ contract RLPWriter_writeList_Test is Test {
         // [ [ [], [] ], [] ]
         bytes[] memory list = new bytes[](2);
         bytes[] memory list2 = new bytes[](2);
+        bytes memory emptyList = RLPWriter.writeList(new bytes[](0));
 
-        list2[0] = RLPWriter.writeList(new bytes[](0));
-        list2[1] = RLPWriter.writeList(new bytes[](0));
+        list2[0] = emptyList;
+        list2[1] = emptyList;
 
         list[0] = RLPWriter.writeList(list2);
-        list[1] = RLPWriter.writeList(new bytes[](0));
+        list[1] = emptyList;
 
         assertEq(RLPWriter.writeList(list), hex"c4c2c0c0c0");
     }
@@ -243,16 +247,17 @@ contract RLPWriter_writeList_Test is Test {
     ///         complex nested list structure.
     function test_writeList_listoflists2_succeeds() external pure {
         // [ [], [[]], [ [], [[]] ] ]
+        bytes memory emptyList = RLPWriter.writeList(new bytes[](0));
         bytes[] memory list = new bytes[](3);
-        list[0] = RLPWriter.writeList(new bytes[](0));
+        list[0] = emptyList;
 
         bytes[] memory list2 = new bytes[](1);
-        list2[0] = RLPWriter.writeList(new bytes[](0));
+        list2[0] = emptyList;
 
         list[1] = RLPWriter.writeList(list2);
 
         bytes[] memory list3 = new bytes[](2);
-        list3[0] = RLPWriter.writeList(new bytes[](0));
+        list3[0] = emptyList;
         list3[1] = RLPWriter.writeList(list2);
 
         list[2] = RLPWriter.writeList(list3);
@@ -316,7 +321,7 @@ contract RLPWriter_writeAddress_Test is Test {
     function testFuzz_writeAddress_anyAddress_succeeds(address _addr) external pure {
         bytes memory encoded = RLPWriter.writeAddress(_addr);
         assertEq(encoded.length, 21);
-        assertEq(uint8(encoded[0]), 0x94);
+        assertEq(encoded[0], bytes1(0x94));
     }
 }
 

--- a/test/libraries/trie/MerkleTrie.t.sol
+++ b/test/libraries/trie/MerkleTrie.t.sol
@@ -5,7 +5,7 @@ import { Test } from "lib/forge-std/src/Test.sol";
 import { MerkleTrie } from "src/libraries/trie/MerkleTrie.sol";
 import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
 import { FFIInterface } from "test/setup/FFIInterface.sol";
-import "src/libraries/rlp/RLPErrors.sol";
+import { InvalidDataRemainder, UnexpectedString } from "src/libraries/rlp/RLPErrors.sol";
 
 contract MerkleTrie_Harness {
     function exposed_get(bytes memory _key, bytes[] memory _proof, bytes32 _root) public pure returns (bytes memory) {
@@ -417,31 +417,18 @@ contract MerkleTrie_Get_Test is MerkleTrie_TestInit {
 
     /// @notice Tests that `get` reverts if a proof node has an unknown prefix
     function test_get_unknownNodePrefix_reverts(uint8 prefix) external {
-        // bound it to only have prefixes where the first nibble is >= 4
         prefix = uint8(bound(prefix, 0x40, 0xff));
-        // if the first nibble of the prefix is odd, make it even by adding 16
         if (((prefix / 16) % 2) == 1) {
             unchecked {
                 prefix += 16;
             }
-            // bound it again in case it overflowed
             prefix = uint8(bound(prefix, 0x40, 0xff));
         }
-
-        MerkleTrie_Harness wrapper = new MerkleTrie_Harness();
 
         bytes memory key = abi.encodePacked(
             keccak256(abi.encodePacked(bytes32(0xa15bc60c955c405d20d9149c709e2460f1c2d9a497496a7f46004d1772c3054c)))
         );
         bytes[] memory proof = new bytes[](5);
-        proof[0] =
-            hex"f90211a085ed702d58e6a962ad0e785e5c9036e06d878fd065eb9669122447f6aee7957da05badb8cfd5a7493d928614730af6e14eabe2c93fbac93c853dde3270c446309da01de85a57c524ac56a5bd4bed0b0aa7d963e364ad930ea964d0a42631a77ded4da0fe3143892366faeb9fae1117b888263afe0f74e6c73555fee53a604bf7188431a0af2c79f0dddd15d6f62e3fa60d515c44d58444ad3915c7ca4bddb31c8f148d0ca08f37a2f9093a4aee39519f3a06fe4674cc670fbbbd7a5f4eb096310b7bc1fdc9a086bd12d2031d9714130c687e6822250fa24b3147824780bea96cf8a7406c8966a03e42538ba2da8adaa0eca4550ef62de4dabde8ca06b71ac1b276ff31b67a7655a04a439f7eb6a62c77ec921139925af3359f61d16e083076e0e425583289107d7da0c453a51991b5a4c6174ddff77c0b7d9cc86f05ffda6ff523e2365f19797c7a00a06f43b7b9a118264ab4b6c24d7d3de77f39071a298426bfc27180adfca57d590da0032e0db4dcf122d4bdb1d4ec3c5df5fabd3127bcefe412cb046b7f0d80d11c9fa0560c2b8c9466b8cb5ffd600f24ea0ed9838bfdab7870d505d4387c2468d3c498a0597996e939ff8c29c9e59dc47c111e760450a9c4fe2b065825762da2a1f32495a0e3411c9af104364230c49de5a4d0802c84df18beee9778673364e1747a875622a02a6928825356d8280f361a02285af30e73889f4e55ecb63ed85c8581e07061d680";
-        proof[1] =
-            hex"f90211a0db246208c4cef45e9aeb9f1df1baa8572675bc453f7da538165a2bb9e6a4c416a0d26d82a9ddff901d2a1f9e18506120dec0e5b3c95549c5bff0efc355061ea73fa04f1cedbb5c7df7ee5cc3210980baf5537affb29c661c6a4eeb193bc42e7fbc74a0acea389e0cf577d0e13483d98b15c82618ac18b7cc4a479981e3e672ddd16867a0ef59a06aeea1eb5ba1313bbe1fa74ff264d84d7319ab6178213734b5b5efa9c1a08f85dc6001713d77aa4e12982dfdb28fd1c7dcc290d46f2749e8a7d67ba2a694a0f6698ff794881edc50340b75311de64ce3da5f97debcfdfd4d20de57ef3ba7eba0680071ce05e9c7915f731bac8b9673332d1d77ea1f7dadab36d9b233eea32ba4a035ad3686f436232360c2aa364c9f2aa2081318b9fb33cd1050d69ee46f791d62a03b495b3d65d9ae39680a0f835c1d1378d218f7b1fb88d2b2c6ac6ef916f09172a0a808d1e8c632d9a6cfeb3c2c123a58b5b3e1998d4bd02c5fb0f7c5d4ba1338e6a0369376e9152831135ff3a902c9740cf22951d67edd51bf0541565e379d7efc25a0cc26d7fa1c326bc14950e92d9de78e4ed8372ff9727dec34602f24057b3a9b30a0278081783022e748dc70874a72377038935c00c1f0a24bbb8cd0fc208d8b68f4a06c4e83593571b94d08cb78ece0de4920b02a650a47a16583f94c8fe35f724707a0cd7eb9d730e5138fd943200b577e7bbb827d010a50d19af2f4b19ef19658156d80";
-        proof[2] =
-            hex"f90211a0065f58fbe63e8e3387e91047d5b7a4532e7d9de0abc47f04791aef27a140fdb5a0858beea29778551c01b0d3e542d707675856da9c3f1d065c845e55c24d77be89a0e90a410489eff6f4f8d70b0cce1fb1339117ec0f6f1db195a6cc410509a2ebaea078ba7fe504e8d01d57f6bee52c4938d779108e500b5923272441ed2964b8c45da0f0430ed9fa807e5fb6ace75f8766ea60009d8539e00006e359f5f7bc38a76596a0a98a7938db99a2d80abea6349de42bf2576c9e51cc715c85fbacab365ec16f5ba026fadc7d124a456c62ada928eaede3e80611e3e6f99041f7393f062e9e788c8ca0ca48cad1e00d22d6146173341a6060378e738be727a7265a923cf6bfd1f8b610a0f8a4aae21a78ac28e2a61f50396f9a80f6c8232fe4afa203160361c0962242baa09a1029479959fb29b4da7239393fd6ca20bc376d860324f429a51b0e0565a158a0eefb84d3943d680e176258dffe0104ac48c171a8574a811535256a2d8ba531dea062a3d709a2f70ba1970842c4f20a602291273d1f6022e7a14cde2afdcd51e795a0397e6b9b87012cd79cbd0bb7daa4cc43830a673d80b65fb88c0449140175d89ca0f8a4c73c0078cbd32961227910e3f9315bc587716062e39f66be19747ccf9b67a0ea4bdd1b187fdba273a8625f88f284994d19c38ec58651839852665717d953d9a0319ebf356f45da83c7f106f1fd3decbf15f651fad3389a0d279602cdea8ee11480";
-        proof[3] =
-            hex"f8f1a069a092c7a950214e7e45b99012dc8ad112eab0fc94ae5ca9efbd6949068384f280a0b25c46db67ef7cf0c47bb400c31c85a26c5a204431527c964c8ecaf3d63e52cc80a01911a2a74db0d8d182447176e23f25556d1a1eaa0afad96453f2d64876ad88e480808080a04a0ca9e3bed1bc3e3c819384d19b6d5e523164a6520c4eb42e828a63ef730ae38080a03b598ed1b9269d4b05e2e75cfb54298d25437669870c919a59a147d2d256fdba80a0db2d655057c83107a73d086cfdd8fcc74739bb48c652eb0ce597178ecf96b39aa05c66ac392a761341b9c22b773ea19af311f34ef537640b9bb96842ec6ace913280";
 
         proof[4] = bytes.concat(
             hex"f69f",
@@ -453,7 +440,7 @@ contract MerkleTrie_Get_Test is MerkleTrie_TestInit {
         (proof[0], proof[1], proof[2], proof[3], root) = rehashOtherElements(proof[4]);
 
         vm.expectRevert("MerkleTrie: received a node with an unknown prefix");
-        wrapper.exposed_get(key, proof, root);
+        harness.exposed_get(key, proof, root);
     }
 
     /// @notice Tests that `get` reverts if a proof node is unparsable i.e list length is not 2 or 17
@@ -462,8 +449,6 @@ contract MerkleTrie_Get_Test is MerkleTrie_TestInit {
         if (listLen == 2 || listLen == 17) {
             listLen++;
         }
-
-        MerkleTrie_Harness wrapper = new MerkleTrie_Harness();
 
         bytes memory key = abi.encodePacked(
             keccak256(abi.encodePacked(bytes32(0xa15bc60c955c405d20d9149c709e2460f1c2d9a497496a7f46004d1772c3054c)))
@@ -478,44 +463,36 @@ contract MerkleTrie_Get_Test is MerkleTrie_TestInit {
         proof[3] =
             hex"f8f1a069a092c7a950214e7e45b99012dc8ad112eab0fc94ae5ca9efbd6949068384f280a0b25c46db67ef7cf0c47bb400c31c85a26c5a204431527c964c8ecaf3d63e52cc80a01911a2a74db0d8d182447176e23f25556d1a1eaa0afad96453f2d64876ad88e480808080a04a0ca9e3bed1bc3e3c819384d19b6d5e523164a6520c4eb42e828a63ef730ae38080a03b598ed1b9269d4b05e2e75cfb54298d25437669870c919a59a147d2d256fdba80a0db2d655057c83107a73d086cfdd8fcc74739bb48c652eb0ce597178ecf96b39aa05c66ac392a761341b9c22b773ea19af311f34ef537640b9bb96842ec6ace913280";
         proof[4] =
-            hex"f69f204dcf44e265ba93879b2da89e1b16ab48fc5eb8e31bc16b0612d6da8463f195942536c09e5f5691498805884fa37811be3b2bddb4"; // Correct
-        // leaf node
+            hex"f69f204dcf44e265ba93879b2da89e1b16ab48fc5eb8e31bc16b0612d6da8463f195942536c09e5f5691498805884fa37811be3b2bddb4";
 
         bytes32 root = keccak256(proof[0]);
 
-        // Should not revert
-        wrapper.exposed_get(key, proof, root);
+        harness.exposed_get(key, proof, root);
 
         if (listLen > 3) {
-            // Node with list > 3
             proof[4] =
                 hex"f8379f204dcf44e265ba93879b2da89e1b16ab48fc5eb8e31bc16b0612d6da8463f195942536c09e5f5691498805884fa37811be3b2bddb480";
             for (uint256 i; i < listLen - 3; i++) {
                 proof[4] = bytes.concat(proof[4], hex"80");
             }
             proof[4][1] = bytes1(uint8(proof[4][1]) + (listLen - 3));
-            // rehash all proof elements and insert it into the proof element above it
             (proof[0], proof[1], proof[2], proof[3], root) = rehashOtherElements(proof[4]);
 
             vm.expectRevert("MerkleTrie: received an unparseable node");
-            wrapper.exposed_get(key, proof, root);
+            harness.exposed_get(key, proof, root);
         } else if (listLen == 1) {
-            // Node with list of 1
             proof[4] = hex"e09f204dcf44e265ba93879b2da89e1b16ab48fc5eb8e31bc16b0612d6da8463f1";
-            // rehash all proof elements and insert it into the proof element above it
             (proof[0], proof[1], proof[2], proof[3], root) = rehashOtherElements(proof[4]);
 
             vm.expectRevert("MerkleTrie: received an unparseable node");
-            wrapper.exposed_get(key, proof, root);
+            harness.exposed_get(key, proof, root);
         } else if (listLen == 3) {
-            // Node with list of 3
             proof[4] =
                 hex"f79f204dcf44e265ba93879b2da89e1b16ab48fc5eb8e31bc16b0612d6da8463f195942536c09e5f5691498805884fa37811be3b2bddb480";
-            // rehash all proof elements and insert it into the proof element above it
             (proof[0], proof[1], proof[2], proof[3], root) = rehashOtherElements(proof[4]);
 
             vm.expectRevert("MerkleTrie: received an unparseable node");
-            wrapper.exposed_get(key, proof, root);
+            harness.exposed_get(key, proof, root);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Clean up library tests with shared helpers and reduced duplication.
- `LibGameId`: drop the redundant `Types.sol` wildcard import, explicitly import `GameType`, and use `.raw()` instead of `*.unwrap(...)` for user-defined value type comparisons.
- `RLPReader`: introduce a `RLPReader_TestInit` base contract with an `assertRepeatedRawBytes` helper, replacing repeated per-index `assertEq` calls in the long-list tests. Rename the two `int32Overflow` revert tests to describe what they actually exercise (declared string/list length exceeding the payload).
- `RLPWriter`: introduce a `RLPWriter_TestInit` base with an `encodedThreeStringList` helper and hoist repeated `writeList(new bytes[](0))` calls into a local `emptyList`, deduplicating the long-list and list-of-lists tests. Tighten the `writeAddress` prefix assertion to compare `bytes1` directly.
- `MerkleTrie`: use the shared `harness` from `MerkleTrie_TestInit` instead of constructing a new `MerkleTrie_Harness` per test, narrow the `RLPErrors` import to the symbols actually used, and strip stale inline comments.