### PR TITLE
chore: simplify lib tests

### DIFF
--- a/test/libraries/Bytes.t.sol
+++ b/test/libraries/Bytes.t.sol
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
 import { Test } from "lib/forge-std/src/Test.sol";
-
-// Target contract
 import { Bytes } from "src/libraries/Bytes.sol";
 
 contract Bytes_Harness {
@@ -16,34 +13,38 @@ contract Bytes_Harness {
 /// @title Bytes_TestInit
 /// @notice Reusable test initialization for `Bytes` tests.
 abstract contract Bytes_TestInit is Test {
-    Bytes_Harness harness;
-
-    /// @notice Manually checks equality of two dynamic `bytes` arrays in memory.
-    /// @param _a The first `bytes` array to compare.
-    /// @param _b The second `bytes` array to compare.
-    /// @return True if the two `bytes` arrays are equal in memory.
     function manualEq(bytes memory _a, bytes memory _b) internal pure returns (bool) {
-        bool _eq;
-        assembly {
-            _eq := and(
-                // Check if the contents of the two bytes arrays are equal in memory.
-                eq(keccak256(add(0x20, _a), mload(_a)), keccak256(add(0x20, _b), mload(_b))),
-                // Check if the length of the two bytes arrays are equal in memory.
-                // This is redundant given the above check, but included for completeness.
-                eq(mload(_a), mload(_b))
-            )
-        }
-        return _eq;
+        return _a.length == _b.length && keccak256(_a) == keccak256(_b);
     }
 
-    function setUp() public {
-        harness = new Bytes_Harness();
+    function freeMemoryPtr() internal pure returns (uint64 ptr_) {
+        assembly {
+            ptr_ := mload(0x40)
+        }
+    }
+
+    function nextSliceMemoryPtr(uint64 _ptr, uint256 _length) internal pure returns (uint64) {
+        if (_length == 0) {
+            return _ptr + 0x20;
+        }
+
+        return uint64((_ptr + 0x20 + _length + 0x1f) & ~uint256(0x1f));
+    }
+
+    function nextBytesMemoryPtr(uint64 _ptr, uint256 _length) internal pure returns (uint64) {
+        return uint64(_ptr + 0x20 + ((_length + 0x1f) & ~uint256(0x1f)));
     }
 }
 
 /// @title Bytes_Slice_Test
 /// @notice Tests the `slice` function of the `Bytes` library.
 contract Bytes_Slice_Test is Bytes_TestInit {
+    Bytes_Harness harness;
+
+    function setUp() public {
+        harness = new Bytes_Harness();
+    }
+
     /// @notice Tests that the `slice` function works as expected when starting from index 0.
     function test_slice_fromZeroIdx_works() public pure {
         bytes memory input = hex"11223344556677889900";
@@ -107,54 +108,17 @@ contract Bytes_Slice_Test is Bytes_TestInit {
     function testFuzz_slice_memorySafety_succeeds(bytes memory _input, uint256 _start, uint256 _length) public {
         vm.assume(_input.length > 0);
 
-        // The start should never be more than the length of the input bytes array - 1
         _start = bound(_start, 0, _input.length - 1);
-
-        // The length should never be more than the length of the input bytes array - the starting
-        // slice index.
         _length = bound(_length, 0, _input.length - _start);
 
-        // Grab the free memory pointer before the slice operation
-        uint64 initPtr;
-        assembly {
-            initPtr := mload(0x40)
-        }
-        uint64 expectedPtr = uint64((initPtr + 0x20 + _length + 0x1f) & ~uint256(0x1f));
+        uint64 initPtr = freeMemoryPtr();
+        uint64 expectedPtr = nextSliceMemoryPtr(initPtr, _length);
 
-        // Ensure that all memory outside of the expected range is safe.
         vm.expectSafeMemory(initPtr, expectedPtr);
-
-        // Slice the input bytes array from `_start` to `_start + _length`
         bytes memory slice = Bytes.slice(_input, _start, _length);
-
         vm.stopExpectSafeMemory();
 
-        // Grab the free memory pointer after the slice operation
-        uint64 finalPtr;
-        assembly {
-            finalPtr := mload(0x40)
-        }
-
-        // The free memory pointer should have been updated properly
-        if (_length == 0) {
-            // If the slice length is zero, only 32 bytes of memory should have been allocated.
-            assertEq(finalPtr, initPtr + 0x20);
-        } else {
-            // If the slice length is greater than zero, the memory allocated should be the length
-            // of the slice rounded up to the next 32 byte word + 32 bytes for the length of the
-            // byte array.
-            //
-            // Note that we use a slightly less efficient, but equivalent method of rounding up
-            // `_length` to the next multiple of 32 than is used in the `slice` function. This is
-            // to diff test the method used in `slice`.
-            uint64 _expectedPtr = uint64(((initPtr + 0x20 + _length + 0x1F) >> 5) << 5);
-            assertEq(finalPtr, _expectedPtr);
-
-            // Sanity check for equivalence of the rounding methods.
-            assertEq(_expectedPtr, expectedPtr);
-        }
-
-        // The slice length should be equal to `_length`
+        assertEq(freeMemoryPtr(), expectedPtr);
         assertEq(slice.length, _length);
     }
 
@@ -181,26 +145,25 @@ contract Bytes_Slice_Test is Bytes_TestInit {
 
     /// @notice Tests that, when given a length `n` that is greater than `type(uint256).max - 31`,
     ///         the `slice` function reverts.
-    function testFuzz_slice_lengthOverflows_reverts(bytes memory _input, uint256 _start, uint256 _length) public {
+    function testFuzz_slice_lengthOverflows_reverts(uint256 _length) public {
         // Ensure that the `_length` will overflow if a number >= 31 is added to it.
         _length = uint256(bound(_length, type(uint256).max - 30, type(uint256).max));
 
         vm.expectRevert("slice_overflow");
-        harness.exposed_slice(_input, _start, _length);
+        harness.exposed_slice(hex"", 0, _length);
     }
 
     /// @notice Tests that, when given a start index `n` that is greater than
     ///         `type(uint256).max - n`, the `slice` function reverts.
     ///         The calls to `bound` are to reduce the number of times that `assume` is triggered.
     function testFuzz_slice_rangeOverflows_reverts(bytes memory _input, uint256 _start, uint256 _length) public {
+        vm.assume(_input.length > 1);
+
         // Ensure that `_length` is a realistic length of a slice. This is to make sure we revert
         // on the correct require statement.
-        _length = bound(_length, 0, _input.length == 0 ? 0 : _input.length - 1);
-        vm.assume(_length < _input.length);
+        _length = bound(_length, 1, _input.length - 1);
 
-        // Ensure that `_start` will overflow if `_length` is added to it.
-        _start = bound(_start, type(uint256).max - _length, type(uint256).max);
-        vm.assume(_start > type(uint256).max - _length);
+        _start = bound(_start, type(uint256).max - _length + 1, type(uint256).max);
 
         vm.expectRevert("slice_overflow");
         harness.exposed_slice(_input, _start, _length);
@@ -240,60 +203,22 @@ contract Bytes_ToNibbles_Test is Bytes_TestInit {
     /// @notice Tests that, given an input of 0 bytes, the `toNibbles` function returns a zero
     ///         length array.
     function test_toNibbles_zeroLengthInput_works() public pure {
-        bytes memory input = hex"";
-        bytes memory expected = hex"";
-        bytes memory actual = Bytes.toNibbles(input);
-
-        assertEq(input.length, 0);
-        assertEq(expected.length, 0);
-        assertEq(actual.length, 0);
-        assertEq(actual, expected);
+        assertEq(Bytes.toNibbles(hex""), hex"");
     }
 
     /// @notice Tests that the `toNibbles` function correctly updates the free memory pointer
     ///         depending on the length of the resulting array.
     function testFuzz_toNibbles_memorySafety_succeeds(bytes memory _input) public {
-        // Grab the free memory pointer before the `toNibbles` operation
-        uint64 initPtr;
-        assembly {
-            initPtr := mload(0x40)
-        }
-        uint64 expectedPtr = uint64(initPtr + 0x20 + ((_input.length * 2 + 0x1F) & ~uint256(0x1F)));
+        uint256 nibblesLength = _input.length * 2;
+        uint64 initPtr = freeMemoryPtr();
+        uint64 expectedPtr = nextBytesMemoryPtr(initPtr, nibblesLength);
 
-        // Ensure that all memory outside of the expected range is safe.
         vm.expectSafeMemory(initPtr, expectedPtr);
-
-        // Pull out each individual nibble from the input bytes array
         bytes memory nibbles = Bytes.toNibbles(_input);
-
         vm.stopExpectSafeMemory();
 
-        // Grab the free memory pointer after the `toNibbles` operation
-        uint64 finalPtr;
-        assembly {
-            finalPtr := mload(0x40)
-        }
-
-        // The free memory pointer should have been updated properly
-        if (_input.length == 0) {
-            // If the input length is zero, only 32 bytes of memory should have been allocated.
-            assertEq(finalPtr, initPtr + 0x20);
-        } else {
-            // If the input length is greater than zero, the memory allocated should be the length
-            // of the input * 2 + 32 bytes for the length field.
-            //
-            // Note that we use a slightly less efficient, but equivalent method of rounding up
-            // `_length` to the next multiple of 32 than is used in the `toNibbles` function. This
-            // is to diff test the method used in `toNibbles`.
-            uint64 _expectedPtr = uint64(initPtr + 0x20 + (((_input.length * 2 + 0x1F) >> 5) << 5));
-            assertEq(finalPtr, _expectedPtr);
-
-            // Sanity check for equivalence of the rounding methods.
-            assertEq(_expectedPtr, expectedPtr);
-        }
-
-        // The nibbles length should be equal to `_length * 2`
-        assertEq(nibbles.length, _input.length << 1);
+        assertEq(freeMemoryPtr(), expectedPtr);
+        assertEq(nibbles.length, nibblesLength);
     }
 }
 

--- a/test/libraries/Constants.t.sol
+++ b/test/libraries/Constants.t.sol
@@ -5,47 +5,37 @@ import { Test } from "lib/forge-std/src/Test.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 
-/// @title Constants_Test
-/// @notice Tests the constant values defined in the `Constants` library.
 contract Constants_Test is Test {
-    /// @notice Verify ESTIMATION_ADDRESS constant value.
     function test_estimationAddress_succeeds() external pure {
         assertEq(Constants.ESTIMATION_ADDRESS, address(1));
     }
 
-    /// @notice Verify DEFAULT_L2_SENDER constant value.
     function test_defaultL2Sender_succeeds() external pure {
         assertEq(Constants.DEFAULT_L2_SENDER, 0x000000000000000000000000000000000000dEaD);
     }
 
-    /// @notice Verify EIP1967 proxy implementation storage slot.
     function test_proxyImplementationAddress_succeeds() external pure {
         assertEq(
             bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1), Constants.PROXY_IMPLEMENTATION_ADDRESS
         );
     }
 
-    /// @notice Verify EIP1967 proxy admin storage slot.
     function test_proxyOwnerAddress_succeeds() external pure {
         assertEq(bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1), Constants.PROXY_OWNER_ADDRESS);
     }
 
-    /// @notice Verify GUARD_STORAGE_SLOT constant value.
     function test_guardStorageSlot_succeeds() external pure {
         assertEq(keccak256("guard_manager.guard.address"), Constants.GUARD_STORAGE_SLOT);
     }
 
-    /// @notice Verify ETHER constant value.
     function test_ether_succeeds() external pure {
         assertEq(Constants.ETHER, 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
     }
 
-    /// @notice Verify DEPOSITOR_ACCOUNT constant value.
     function test_depositorAccount_succeeds() external pure {
         assertEq(Constants.DEPOSITOR_ACCOUNT, 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001);
     }
 
-    /// @notice Verify DEFAULT_RESOURCE_CONFIG returns expected values.
     function test_defaultResourceConfig_succeeds() external pure {
         IResourceMetering.ResourceConfig memory config = Constants.DEFAULT_RESOURCE_CONFIG();
         assertEq(config.maxResourceLimit, 20_000_000);

--- a/test/libraries/EOA.t.sol
+++ b/test/libraries/EOA.t.sol
@@ -17,99 +17,74 @@ contract EOA_Harness {
     }
 }
 
-/// @title EOA_TestInit
-/// @notice Reusable test initialization for `EOA` tests.
-abstract contract EOA_TestInit is Test {
+/// @title EOA_isSenderEOA_Test
+/// @notice Tests the `isSenderEOA` function of the `EOA` library.
+contract EOA_isSenderEOA_Test is Test {
     EOA_Harness harness;
 
     /// @notice Sets up the test.
     function setUp() public {
         harness = new EOA_Harness();
     }
-}
 
-/// @title EOA_isSenderEOA_Test
-/// @notice Tests the `isSenderEOA` function of the `EOA` library.
-contract EOA_isSenderEOA_Test is EOA_TestInit {
     /// @notice Tests that a standard EOA is detected as an EOA.
     /// @param _privateKey The private key of the sender.
     function testFuzz_isSenderEOA_isStandardEOA_succeeds(uint256 _privateKey) external {
-        // Make sure that the private key is in the range of a valid secp256k1 private key.
-        _privateKey = boundPrivateKey(_privateKey);
-
-        // Make sure that the sender is a standard EOA with no code.
-        address sender = vm.addr(_privateKey);
+        address sender = _senderFromPrivateKey(_privateKey);
         vm.assume(sender.code.length == 0);
 
-        // Should be considered an EOA
         vm.prank(sender, sender);
-        assertEq(harness.isSenderEOA(), true);
+        assertTrue(harness.isSenderEOA());
     }
 
     /// @notice Tests that a 7702 EOA is detected as an EOA.
     /// @param _privateKey The private key of the sender.
     /// @param _7702Target The target of the 7702 EOA.
     function testFuzz_isSenderEOA_is7702EOA_succeeds(uint256 _privateKey, address _7702Target) external {
-        // Make sure that the private key is in the range of a valid secp256k1 private key.
-        _privateKey = boundPrivateKey(_privateKey);
-
         // Delegating to address(0) revokes the delegation per EIP-7702, so exclude it.
         vm.assume(_7702Target != address(0));
 
-        // Make sure that the sender is a 7702 EOA.
-        address sender = vm.addr(_privateKey);
+        address sender = _senderFromPrivateKey(_privateKey);
         vm.etch(sender, abi.encodePacked(hex"EF0100", _7702Target));
 
-        // Should be considered a 7702 EOA.
         vm.prank(sender, sender);
-        assertEq(harness.isSenderEOA(), true);
+        assertTrue(harness.isSenderEOA());
 
         // Should still be considered an EOA even if origin is different.
         vm.prank(sender, address(0x0420));
-        assertEq(harness.isSenderEOA(), true);
+        assertTrue(harness.isSenderEOA());
     }
 
     /// @notice Tests that a contract is not detected as an EOA.
     /// @param _privateKey The private key of the sender.
     /// @param _code The code of the sender.
     function testFuzz_isSenderEOA_isContract_succeeds(uint256 _privateKey, bytes memory _code) external {
-        // Make sure that the private key is in the range of a valid secp256k1 private key.
-        _privateKey = boundPrivateKey(_privateKey);
-
-        // If code is empty or starts with EF, change it.
+        // Avoid empty code and the 0xEF prefix space, which includes 7702 delegation code.
         if (_code.length == 0 || _code[0] == 0xEF) {
             _code = bytes.concat(hex"FFFFFF", _code);
         }
 
-        // Make sure that the sender is a contract.
-        address sender = vm.addr(_privateKey);
+        address sender = _senderFromPrivateKey(_privateKey);
         vm.etch(sender, _code);
 
-        // Should not be considered an EOA.
         vm.prank(sender);
-        assertEq(harness.isSenderEOA(), false);
+        assertFalse(harness.isSenderEOA());
     }
 
     /// @notice Tests that a contract with 23 bytes of code is not detected as an EOA.
     /// @param _privateKey The private key of the sender.
     function testFuzz_isSenderEOA_isContract23BytesNot7702_succeeds(uint256 _privateKey) external {
-        // Make sure that the private key is in the range of a valid secp256k1 private key.
-        _privateKey = boundPrivateKey(_privateKey);
+        address sender = _senderFromPrivateKey(_privateKey);
+        vm.etch(sender, abi.encodePacked(hex"FE", bytes22(0)));
 
-        // Generate a random 23 byte code.
-        bytes memory code = vm.randomBytes(23);
-
-        // If the code happens to be EOF code, change it!
-        if (code[0] == 0xEF) {
-            code[0] = 0xFE; // Anything but EF!
-        }
-
-        // Make sure that the sender is a contract.
-        address sender = vm.addr(_privateKey);
-        vm.etch(sender, code);
-
-        // Should not be considered an EOA.
         vm.prank(sender);
-        assertEq(harness.isSenderEOA(), false);
+        assertFalse(harness.isSenderEOA());
+    }
+
+    /// @notice Returns the sender for a valid secp256k1 private key.
+    /// @param _privateKey The private key of the sender.
+    /// @return sender_ The sender address.
+    function _senderFromPrivateKey(uint256 _privateKey) internal pure returns (address sender_) {
+        sender_ = vm.addr(boundPrivateKey(_privateKey));
     }
 }

--- a/test/libraries/Encoding.t.sol
+++ b/test/libraries/Encoding.t.sol
@@ -30,13 +30,45 @@ contract Encoding_Harness {
 }
 
 /// @title Encoding_TestInit
-/// @notice Reusable test initialization for `Encoding` tests.
+/// @notice Reusable helpers for `Encoding` tests.
 abstract contract Encoding_TestInit is CommonTest {
-    Encoding_Harness encoding;
+    bytes1 internal constant SUPER_ROOT_VERSION = 0x01;
+    uint256 internal constant MAX_OUTPUT_ROOTS = 50;
 
-    function setUp() public override {
-        super.setUp();
-        encoding = new Encoding_Harness();
+    function _outputRoot(uint256 _chainId, bytes32 _root) internal pure returns (Types.OutputRootWithChainId memory) {
+        return Types.OutputRootWithChainId({ chainId: _chainId, root: _root });
+    }
+
+    function _superRootProof(
+        uint64 _timestamp,
+        uint256 _length,
+        uint256 _seed
+    )
+        internal
+        pure
+        returns (Types.SuperRootProof memory proof)
+    {
+        _length = bound(_length, 1, MAX_OUTPUT_ROOTS);
+
+        Types.OutputRootWithChainId[] memory outputRoots = new Types.OutputRootWithChainId[](_length);
+        for (uint256 i = 0; i < _length; i++) {
+            outputRoots[i] = _outputRoot(
+                uint256(keccak256(abi.encode(_seed, uint8(0), i))), keccak256(abi.encode(_seed, uint8(1), i))
+            );
+        }
+
+        proof = Types.SuperRootProof({ version: SUPER_ROOT_VERSION, timestamp: _timestamp, outputRoots: outputRoots });
+    }
+
+    function _expectedSuperRootProofEncoding(Types.SuperRootProof memory _proof)
+        internal
+        pure
+        returns (bytes memory expected)
+    {
+        expected = bytes.concat(_proof.version, bytes8(_proof.timestamp));
+        for (uint256 i = 0; i < _proof.outputRoots.length; i++) {
+            expected = bytes.concat(expected, bytes32(_proof.outputRoots[i].chainId), _proof.outputRoots[i].root);
+        }
     }
 }
 
@@ -56,14 +88,14 @@ contract Encoding_EncodeDepositTransaction_Test is Encoding_TestInit {
     )
         external
     {
-        Types.UserDepositTransaction memory t = Types.UserDepositTransaction(
+        Types.UserDepositTransaction memory depositTx = Types.UserDepositTransaction(
             _from, _to, isCreate, _value, _mint, _gas, _data, bytes32(uint256(0)), _logIndex
         );
 
-        bytes memory txn = Encoding.encodeDepositTransaction(t);
-        bytes memory _txn = ffi.encodeDepositTransaction(t);
+        bytes memory actual = Encoding.encodeDepositTransaction(depositTx);
+        bytes memory expected = ffi.encodeDepositTransaction(depositTx);
 
-        assertEq(txn, _txn);
+        assertEq(actual, expected);
     }
 }
 
@@ -82,24 +114,23 @@ contract Encoding_EncodeCrossDomainMessage_Test is Encoding_TestInit {
     )
         external
     {
-        uint8 version = _version % 2;
+        uint8 version = uint8(bound(uint256(_version), 0, 1));
         uint256 nonce = Encoding.encodeVersionedNonce(_nonce, version);
 
-        bytes memory encoding = Encoding.encodeCrossDomainMessage(nonce, _sender, _target, _value, _gasLimit, _data);
+        bytes memory actual = Encoding.encodeCrossDomainMessage(nonce, _sender, _target, _value, _gasLimit, _data);
+        bytes memory expected = ffi.encodeCrossDomainMessage(nonce, _sender, _target, _value, _gasLimit, _data);
 
-        bytes memory _encoding = ffi.encodeCrossDomainMessage(nonce, _sender, _target, _value, _gasLimit, _data);
-
-        assertEq(encoding, _encoding);
+        assertEq(actual, expected);
     }
 
     /// @notice Tests that encodeCrossDomainMessage reverts if version is greater than 1.
-    function testFuzz_encodeCrossDomainMessage_versionGreaterThanOne_reverts(uint256 nonce) external {
-        // nonce >> 240 must be greater than 1
-        uint256 minInvalidNonce = (uint256(type(uint240).max) + 1) * 2;
-        nonce = bound(nonce, minInvalidNonce, type(uint256).max);
+    function testFuzz_encodeCrossDomainMessage_versionGreaterThanOne_reverts(uint240 _nonce, uint16 _version) external {
+        uint16 invalidVersion = uint16(bound(uint256(_version), 2, type(uint16).max));
+        uint256 nonce = Encoding.encodeVersionedNonce(_nonce, invalidVersion);
+        Encoding_Harness harness = new Encoding_Harness();
 
         vm.expectRevert(bytes("Encoding: unknown cross domain message version"));
-        encoding.encodeCrossDomainMessage(nonce, address(this), address(this), 1, 100, hex"");
+        harness.encodeCrossDomainMessage(nonce, address(this), address(this), 1, 100, hex"");
     }
 }
 
@@ -111,99 +142,33 @@ contract Encoding_EncodeSuperRootProof_Test is Encoding_TestInit {
     /// @param _length The number of output roots in the super root proof
     /// @param _seed The seed used to generate the output roots
     function testFuzz_encodeSuperRootProof_succeeds(uint64 _timestamp, uint256 _length, uint256 _seed) external pure {
-        // Ensure at least 1 element and cap at a reasonable maximum to avoid gas issues
-        _length = uint256(bound(_length, 1, 50));
+        Types.SuperRootProof memory proof = _superRootProof(_timestamp, _length, _seed);
 
-        // Create output roots array
-        Types.OutputRootWithChainId[] memory outputRoots = new Types.OutputRootWithChainId[](_length);
-
-        // Generate deterministic chain IDs and roots based on the seed
-        for (uint256 i = 0; i < _length; i++) {
-            // Use different derivations of the seed for each value
-            uint256 chainId = uint256(keccak256(abi.encode(_seed, "chainId", i)));
-            bytes32 root = keccak256(abi.encode(_seed, "root", i));
-
-            outputRoots[i] = Types.OutputRootWithChainId({ chainId: chainId, root: root });
-        }
-
-        // Create the super root proof
-        Types.SuperRootProof memory proof =
-            Types.SuperRootProof({ version: 0x01, timestamp: _timestamp, outputRoots: outputRoots });
-
-        // Encode the proof
-        bytes memory encoded = Encoding.encodeSuperRootProof(proof);
-
-        // Verify encoding structure
-        assertEq(encoded[0], bytes1(0x01), "Version byte should be 0x01");
-
-        // Verify timestamp (bytes 1-8)
-        bytes8 encodedTimestamp;
-        for (uint256 i = 0; i < 8; i++) {
-            encodedTimestamp |= bytes8(encoded[i + 1]) >> (i * 8);
-        }
-        assertEq(uint64(encodedTimestamp), _timestamp, "Timestamp should match");
-
-        // Verify each chain ID and root is encoded correctly
-        uint256 offset = 9; // 1 byte version + 8 bytes timestamp
-        for (uint256 i = 0; i < _length; i++) {
-            // Extract chain ID (32 bytes)
-            uint256 encodedChainId;
-            assembly {
-                // Load 32 bytes from encoded at position offset
-                encodedChainId := mload(add(add(encoded, 32), offset))
-            }
-            assertEq(encodedChainId, outputRoots[i].chainId, "Chain ID should match");
-            offset += 32;
-
-            // Extract root (32 bytes)
-            bytes32 encodedRoot;
-            assembly {
-                // Load 32 bytes from encoded at position offset
-                encodedRoot := mload(add(add(encoded, 32), offset))
-            }
-            assertEq(encodedRoot, outputRoots[i].root, "Root should match");
-            offset += 32;
-        }
-
-        // Verify total length
-        assertEq(encoded.length, 9 + (_length * 64), "Encoded length should match expected");
+        assertEq(Encoding.encodeSuperRootProof(proof), _expectedSuperRootProofEncoding(proof));
     }
 
     /// @notice Tests encoding with a single output root
     function test_encodeSuperRootProof_singleOutputRoot_succeeds() external pure {
-        // Create a single output root
         Types.OutputRootWithChainId[] memory outputRoots = new Types.OutputRootWithChainId[](1);
-        outputRoots[0] = Types.OutputRootWithChainId({ chainId: 10, root: bytes32(uint256(0xdeadbeef)) });
+        outputRoots[0] = _outputRoot(10, bytes32(uint256(0xdeadbeef)));
 
-        // Create the super root proof
         Types.SuperRootProof memory proof =
-            Types.SuperRootProof({ version: 0x01, timestamp: 1234567890, outputRoots: outputRoots });
+            Types.SuperRootProof({ version: SUPER_ROOT_VERSION, timestamp: 1234567890, outputRoots: outputRoots });
 
-        // Encode the proof
-        bytes memory encoded = Encoding.encodeSuperRootProof(proof);
-
-        // Expected: 1 byte version + 8 bytes timestamp + (32 bytes chainId + 32 bytes root)
-        assertEq(encoded.length, 1 + 8 + 64, "Encoded length should be 73 bytes");
-        assertEq(encoded[0], bytes1(0x01), "First byte should be version 0x01");
+        assertEq(Encoding.encodeSuperRootProof(proof), _expectedSuperRootProofEncoding(proof));
     }
 
     /// @notice Tests encoding with multiple output roots
     function test_encodeSuperRootProof_multipleOutputRoots_succeeds() external pure {
-        // Create multiple output roots
         Types.OutputRootWithChainId[] memory outputRoots = new Types.OutputRootWithChainId[](3);
-        outputRoots[0] = Types.OutputRootWithChainId({ chainId: 10, root: bytes32(uint256(0xdeadbeef)) });
-        outputRoots[1] = Types.OutputRootWithChainId({ chainId: 20, root: bytes32(uint256(0xbeefcafe)) });
-        outputRoots[2] = Types.OutputRootWithChainId({ chainId: 30, root: bytes32(uint256(0xcafebabe)) });
+        outputRoots[0] = _outputRoot(10, bytes32(uint256(0xdeadbeef)));
+        outputRoots[1] = _outputRoot(20, bytes32(uint256(0xbeefcafe)));
+        outputRoots[2] = _outputRoot(30, bytes32(uint256(0xcafebabe)));
 
-        // Create the super root proof
         Types.SuperRootProof memory proof =
-            Types.SuperRootProof({ version: 0x01, timestamp: 1234567890, outputRoots: outputRoots });
+            Types.SuperRootProof({ version: SUPER_ROOT_VERSION, timestamp: 1234567890, outputRoots: outputRoots });
 
-        // Encode the proof
-        bytes memory encoded = Encoding.encodeSuperRootProof(proof);
-
-        // Expected: 1 byte version + 8 bytes timestamp + 3 * (32 bytes chainId + 32 bytes root)
-        assertEq(encoded.length, 1 + 8 + (3 * 64), "Encoded length should be 201 bytes");
+        assertEq(Encoding.encodeSuperRootProof(proof), _expectedSuperRootProofEncoding(proof));
     }
 
     /// @notice Tests that the Solidity impl of encodeSuperRootProof matches the FFI impl
@@ -211,70 +176,40 @@ contract Encoding_EncodeSuperRootProof_Test is Encoding_TestInit {
     /// @param _length The number of output roots in the super root proof
     /// @param _seed The seed used to generate the output roots
     function testDiff_encodeSuperRootProof_succeeds(uint64 _timestamp, uint256 _length, uint256 _seed) external {
-        // Ensure at least 1 element and cap at a reasonable maximum to avoid gas issues
-        _length = uint256(bound(_length, 1, 50));
+        Types.SuperRootProof memory proof = _superRootProof(_timestamp, _length, _seed);
 
-        // Create output roots array
-        Types.OutputRootWithChainId[] memory outputRoots = new Types.OutputRootWithChainId[](_length);
-
-        // Generate deterministic chain IDs and roots based on the seed
-        for (uint256 i = 0; i < _length; i++) {
-            // Use different derivations of the seed for each value
-            uint256 chainId = uint256(keccak256(abi.encode(_seed, "chainId", i)));
-            bytes32 root = keccak256(abi.encode(_seed, "root", i));
-
-            outputRoots[i] = Types.OutputRootWithChainId({ chainId: chainId, root: root });
-        }
-
-        // Create the super root proof
-        Types.SuperRootProof memory proof =
-            Types.SuperRootProof({ version: 0x01, timestamp: _timestamp, outputRoots: outputRoots });
-
-        // Encode using the Solidity implementation
-        bytes memory encoding1 = Encoding.encodeSuperRootProof(proof);
-
-        // Encode using the FFI implementation
-        bytes memory encoding2 = ffi.encodeSuperRootProof(proof);
-
-        // Compare the results
-        assertEq(encoding1, encoding2, "Solidity and FFI implementations should match");
+        assertEq(Encoding.encodeSuperRootProof(proof), ffi.encodeSuperRootProof(proof));
     }
 
     /// @notice Tests that encoding fails when version is not 0x01
     /// @param _version The version to use for the super root proof
     /// @param _timestamp The timestamp of the super root proof
     function testFuzz_encodeSuperRootProof_invalidVersion_reverts(bytes1 _version, uint64 _timestamp) external {
-        // Ensure version is not 0x01
-        if (_version == 0x01) {
+        if (_version == SUPER_ROOT_VERSION) {
             _version = 0x02;
         }
 
-        // Create a minimal valid output roots array
         Types.OutputRootWithChainId[] memory outputRoots = new Types.OutputRootWithChainId[](1);
-        outputRoots[0] = Types.OutputRootWithChainId({ chainId: 1, root: bytes32(uint256(1)) });
+        outputRoots[0] = _outputRoot(1, bytes32(uint256(1)));
 
-        // Create the super root proof with invalid version
         Types.SuperRootProof memory proof =
             Types.SuperRootProof({ version: _version, timestamp: _timestamp, outputRoots: outputRoots });
+        Encoding_Harness harness = new Encoding_Harness();
 
-        // Expect revert when encoding
         vm.expectRevert(Encoding.Encoding_InvalidSuperRootVersion.selector);
-        encoding.encodeSuperRootProof(proof);
+        harness.encodeSuperRootProof(proof);
     }
 
     /// @notice Tests that encoding fails when output roots array is empty
     /// @param _timestamp The timestamp of the super root proof
     function testFuzz_encodeSuperRootProof_emptyOutputRoots_reverts(uint64 _timestamp) external {
-        // Create an empty output roots array
         Types.OutputRootWithChainId[] memory outputRoots = new Types.OutputRootWithChainId[](0);
-
-        // Create the super root proof with empty output roots
         Types.SuperRootProof memory proof =
-            Types.SuperRootProof({ version: 0x01, timestamp: _timestamp, outputRoots: outputRoots });
+            Types.SuperRootProof({ version: SUPER_ROOT_VERSION, timestamp: _timestamp, outputRoots: outputRoots });
+        Encoding_Harness harness = new Encoding_Harness();
 
-        // Expect revert when encoding
         vm.expectRevert(Encoding.Encoding_EmptySuperRoot.selector);
-        encoding.encodeSuperRootProof(proof);
+        harness.encodeSuperRootProof(proof);
     }
 }
 

--- a/test/libraries/Hashing.t.sol
+++ b/test/libraries/Hashing.t.sol
@@ -32,6 +32,36 @@ contract Hashing_Harness {
     }
 }
 
+abstract contract Hashing_TestInit is CommonTest {
+    bytes1 internal constant SUPER_ROOT_VERSION = 0x01;
+    uint256 internal constant MAX_OUTPUT_ROOTS = 50;
+
+    function _outputRoot(uint256 _chainId, bytes32 _root) internal pure returns (Types.OutputRootWithChainId memory) {
+        return Types.OutputRootWithChainId({ chainId: _chainId, root: _root });
+    }
+
+    function _superRootProof(
+        uint64 _timestamp,
+        uint256 _length,
+        uint256 _seed
+    )
+        internal
+        pure
+        returns (Types.SuperRootProof memory proof)
+    {
+        _length = bound(_length, 1, MAX_OUTPUT_ROOTS);
+
+        Types.OutputRootWithChainId[] memory outputRoots = new Types.OutputRootWithChainId[](_length);
+        for (uint256 i = 0; i < _length; i++) {
+            outputRoots[i] = _outputRoot(
+                uint256(keccak256(abi.encode(_seed, uint8(0), i))), keccak256(abi.encode(_seed, uint8(1), i))
+            );
+        }
+
+        proof = Types.SuperRootProof({ version: SUPER_ROOT_VERSION, timestamp: _timestamp, outputRoots: outputRoots });
+    }
+}
+
 /// @title Hashing_hashDepositTransaction_Test
 /// @notice Tests the `hashDepositTransaction` function of the `Hashing` library.
 contract Hashing_hashDepositTransaction_Test is CommonTest {
@@ -57,7 +87,7 @@ contract Hashing_hashDepositTransaction_Test is CommonTest {
                     _mint,
                     _gas,
                     _data,
-                    bytes32(uint256(0)),
+                    bytes32(0),
                     _logIndex
                 )
             ),
@@ -90,15 +120,7 @@ contract Hashing_hashDepositSource_Test is CommonTest {
 /// @title Hashing_hashCrossDomainMessage_Test
 /// @notice Tests the `hashCrossDomainMessage` function of the `Hashing` library.
 contract Hashing_hashCrossDomainMessage_Test is CommonTest {
-    Hashing_Harness internal harness;
-
-    /// @notice Sets up the test.
-    function setUp() public override {
-        super.setUp();
-        harness = new Hashing_Harness();
-    }
     /// @notice Tests that hashCrossDomainMessage returns the correct hash in a simple case.
-
     function testDiff_hashCrossDomainMessage_succeeds(
         uint240 _nonce,
         uint16 _version,
@@ -110,7 +132,6 @@ contract Hashing_hashCrossDomainMessage_Test is CommonTest {
     )
         external
     {
-        // Ensure the version is valid.
         uint16 version = uint16(bound(uint256(_version), 0, 1));
         uint256 nonce = Encoding.encodeVersionedNonce(_nonce, version);
 
@@ -123,28 +144,13 @@ contract Hashing_hashCrossDomainMessage_Test is CommonTest {
     /// @notice Tests that hashCrossDomainMessage reverts with unknown version.
     /// @param _nonce Message nonce base value.
     /// @param _version Invalid version number (will be bounded to 2+).
-    /// @param _sender Address of the sender of the message.
-    /// @param _target Address of the target of the message.
-    /// @param _value ETH value to send to the target.
-    /// @param _gasLimit Gas limit to use for the message.
-    /// @param _data Data to send with the message.
-    function testFuzz_hashCrossDomainMessage_unknownVersion_reverts(
-        uint240 _nonce,
-        uint16 _version,
-        address _sender,
-        address _target,
-        uint256 _value,
-        uint256 _gasLimit,
-        bytes memory _data
-    )
-        external
-    {
-        // Use version 2 or higher (invalid versions)
+    function testFuzz_hashCrossDomainMessage_unknownVersion_reverts(uint240 _nonce, uint16 _version) external {
         uint16 invalidVersion = uint16(bound(uint256(_version), 2, type(uint16).max));
         uint256 nonce = Encoding.encodeVersionedNonce(_nonce, invalidVersion);
+        Hashing_Harness harness = new Hashing_Harness();
 
         vm.expectRevert(bytes("Hashing: unknown cross domain message version"));
-        harness.hashCrossDomainMessage(nonce, _sender, _target, _value, _gasLimit, _data);
+        harness.hashCrossDomainMessage(nonce, address(this), address(this), 1, 100, hex"");
     }
 }
 
@@ -225,49 +231,33 @@ contract Hashing_hashL2toL2CrossDomainMessage_Test is CommonTest {
 
 /// @title Hashing_hashSuperRootProof_Test
 /// @notice Tests the `hashSuperRootProof` function of the `Hashing` library.
-contract Hashing_hashSuperRootProof_Test is CommonTest {
-    Hashing_Harness internal harness;
-
-    /// @notice Sets up the test.
-    function setUp() public override {
-        super.setUp();
-        harness = new Hashing_Harness();
-    }
-
+contract Hashing_hashSuperRootProof_Test is Hashing_TestInit {
     /// @notice Tests that the Solidity impl of hashSuperRootProof matches the FFI impl
-    /// @param _proof The super root proof to test.
-    function testDiff_hashSuperRootProof_succeeds(Types.SuperRootProof memory _proof) external {
-        // Make sure the proof has the right version.
-        _proof.version = 0x01;
+    /// @param _timestamp The timestamp of the super root proof.
+    /// @param _length The number of output roots in the super root proof.
+    /// @param _seed The seed used to generate the output roots.
+    function testDiff_hashSuperRootProof_succeeds(uint64 _timestamp, uint256 _length, uint256 _seed) external {
+        Types.SuperRootProof memory proof = _superRootProof(_timestamp, _length, _seed);
 
-        // Make sure the proof has at least one output root.
-        if (_proof.outputRoots.length == 0) {
-            _proof.outputRoots = new Types.OutputRootWithChainId[](1);
-            _proof.outputRoots[0] = Types.OutputRootWithChainId({
-                chainId: vm.randomUint(0, type(uint64).max), root: bytes32(vm.randomUint())
-            });
-        }
-
-        // Encode using the Solidity implementation
-        bytes32 hash1 = harness.hashSuperRootProof(_proof);
-
-        // Encode using the FFI implementation
-        bytes32 hash2 = ffi.hashSuperRootProof(_proof);
-
-        // Compare the results
-        assertEq(hash1, hash2, "Solidity and FFI implementations should match");
+        assertEq(Hashing.hashSuperRootProof(proof), ffi.hashSuperRootProof(proof), "hash mismatch");
     }
 
     /// @notice Tests that hashSuperRootProof reverts when the version is incorrect.
-    /// @param _proof The super root proof to test.
-    function testFuzz_hashSuperRootProof_wrongVersion_reverts(Types.SuperRootProof memory _proof) external {
-        // 0x01 is the correct version, so we need any other version.
-        if (_proof.version == 0x01) {
-            _proof.version = 0x00;
+    /// @param _version The version to use for the super root proof.
+    /// @param _timestamp The timestamp of the super root proof.
+    function testFuzz_hashSuperRootProof_wrongVersion_reverts(bytes1 _version, uint64 _timestamp) external {
+        if (_version == SUPER_ROOT_VERSION) {
+            _version = 0x00;
         }
 
-        // Should always revert when the version is incorrect.
+        Types.OutputRootWithChainId[] memory outputRoots = new Types.OutputRootWithChainId[](1);
+        outputRoots[0] = _outputRoot(1, bytes32(uint256(1)));
+
+        Types.SuperRootProof memory proof =
+            Types.SuperRootProof({ version: _version, timestamp: _timestamp, outputRoots: outputRoots });
+        Hashing_Harness harness = new Hashing_Harness();
+
         vm.expectRevert(Encoding.Encoding_InvalidSuperRootVersion.selector);
-        harness.hashSuperRootProof(_proof);
+        harness.hashSuperRootProof(proof);
     }
 }

--- a/test/libraries/Predeploys.t.sol
+++ b/test/libraries/Predeploys.t.sol
@@ -22,11 +22,6 @@ abstract contract Predeploys_TestInit is CommonTest {
         return _addr == Predeploys.L1_BLOCK_ATTRIBUTES || _addr == Predeploys.L2_STANDARD_BRIDGE;
     }
 
-    /// @notice Returns true if the account is not meant to be in the L2 genesis anymore.
-    function _isOmitted(address _addr) internal pure returns (bool) {
-        return _addr == Predeploys.L1_MESSAGE_SENDER;
-    }
-
     /// @notice Returns true if the predeploy is initializable and uses OpenZeppelin v4 storage pattern.
     ///         These contracts have _initialized in the regular storage layout.
     function _isInitializableV4(address _addr) internal pure returns (bool) {
@@ -48,26 +43,20 @@ abstract contract Predeploys_TestInit is CommonTest {
 
     /// @notice Internal test function for predeploys validation across different forks.
     function _test_predeploys() internal view {
-        uint256 count = 2048;
         uint160 prefix = uint160(0x420) << 148;
 
         bytes memory proxyCode = vm.getDeployedCode("src/universal/Proxy.sol:Proxy");
 
-        for (uint256 i = 0; i < count; i++) {
+        for (uint256 i = 0; i < Predeploys.PREDEPLOY_COUNT; i++) {
             address addr = address(prefix | uint160(i));
-            address implAddr = Predeploys.predeployToCodeNamespace(addr);
 
-            if (_isOmitted(addr)) {
-                assertEq(implAddr.code.length, 0, "must have no code");
+            if (addr == Predeploys.L1_MESSAGE_SENDER) {
+                assertEq(Predeploys.predeployToCodeNamespace(addr).code.length, 0, "must have no code");
                 continue;
             }
 
             bool isPredeploy = Predeploys.isSupportedPredeploy(addr);
-
-            bytes memory code = addr.code;
-            if (isPredeploy) assertTrue(code.length > 0);
-
-            bool proxied = Predeploys.notProxied(addr) == false;
+            bool proxied = !Predeploys.notProxied(addr);
 
             if (!isPredeploy) {
                 // All of the predeploys, even if inactive, have their admin set to the proxy admin
@@ -75,13 +64,17 @@ abstract contract Predeploys_TestInit is CommonTest {
                 continue;
             }
 
+            address implAddr = Predeploys.predeployToCodeNamespace(addr);
+            bytes memory code = addr.code;
+            assertTrue(code.length > 0);
+
             string memory cname = Predeploys.getName(addr);
             assertNotEq(cname, "", "must have a name");
 
             bytes memory supposedCode = vm.getDeployedCode(string.concat(cname, ".sol:", cname));
             assertNotEq(supposedCode.length, 0, "must have supposed code");
 
-            if (proxied == false) {
+            if (!proxied) {
                 // can't check bytecode if it's modified with immutables in genesis.
                 if (!_usesImmutables(addr)) {
                     assertEq(code, supposedCode, "non-proxy contract should be deployed in-place");

--- a/test/libraries/Preinstalls.t.sol
+++ b/test/libraries/Preinstalls.t.sol
@@ -9,15 +9,43 @@ import { IEIP712 } from "interfaces/universal/IEIP712.sol";
 /// @title Preinstalls_TestInit
 /// @notice Reusable test initialization for `Preinstalls` tests.
 abstract contract Preinstalls_TestInit is CommonTest {
+    uint256 internal constant PERMIT2_CHAIN_ID_OFFSET = 6945;
+    uint256 internal constant PERMIT2_DOMAIN_SEPARATOR_OFFSET = 6983;
+    uint256 internal constant PERMIT2_DEPLOYMENT_CHAIN_ID = 901;
+
     function assertPreinstall(address _addr, bytes memory _code) internal view {
+        assertPreinstall(_addr, _code, block.chainid);
+    }
+
+    function assertPreinstall(address _addr, bytes memory _code, uint256 _chainId) internal view {
+        bytes memory deployedCode = _addr.code;
+
         assertNotEq(_code.length, 0, "must have code");
-        assertNotEq(_addr.code.length, 0, "deployed preinstall account must have code");
-        assertEq(_addr.code, _code, "equal code must be deployed");
-        assertEq(Preinstalls.getDeployedCode(_addr, block.chainid), _code, "deployed-code getter must match");
+        assertNotEq(deployedCode.length, 0, "deployed preinstall account must have code");
+        assertEq(deployedCode, _code, "equal code must be deployed");
+        assertEq(Preinstalls.getDeployedCode(_addr, _chainId), _code, "deployed-code getter must match");
         assertNotEq(Preinstalls.getName(_addr), "", "must have a name");
         if (_addr != Preinstalls.DeterministicDeploymentProxy) {
             assertEq(vm.getNonce(_addr), 1, "preinstall account must have 1 nonce");
         }
+    }
+
+    function assertPermit2Code(
+        uint256 _chainId,
+        bytes32 _expectedDomainSeparator
+    )
+        internal
+        pure
+        returns (bytes memory code_)
+    {
+        code_ = Preinstalls.getPermit2Code(_chainId);
+        assertNotEq(code_.length, 0, "must have code");
+        assertEq(uint256(bytes32(Bytes.slice(code_, PERMIT2_CHAIN_ID_OFFSET, 32))), _chainId, "expecting chain ID");
+        assertEq(
+            bytes32(Bytes.slice(code_, PERMIT2_DOMAIN_SEPARATOR_OFFSET, 32)),
+            _expectedDomainSeparator,
+            "expecting domain separator"
+        );
     }
 }
 
@@ -25,23 +53,10 @@ abstract contract Preinstalls_TestInit is CommonTest {
 /// @notice Tests the `getPermit2Code` function of the `Preinstalls` library.
 contract Preinstalls_GetPermit2Code_Test is Preinstalls_TestInit {
     function test_getPermit2Code_templating_works() external pure {
-        bytes memory customCode = Preinstalls.getPermit2Code(1234);
-        assertNotEq(customCode.length, 0, "must have code");
-        assertEq(uint256(bytes32(Bytes.slice(customCode, 6945, 32))), uint256(1234), "expecting custom chain ID");
-        assertEq(
-            bytes32(Bytes.slice(customCode, 6983, 32)),
-            bytes32(0x6cda538cafce36292a6ef27740629597f85f6716f5694d26d5c59fc1d07cfd95),
-            "expecting custom domain separator"
-        );
+        assertPermit2Code(1234, bytes32(0x6cda538cafce36292a6ef27740629597f85f6716f5694d26d5c59fc1d07cfd95));
 
-        bytes memory defaultCode = Preinstalls.getPermit2Code(1);
-        assertNotEq(defaultCode.length, 0, "must have code");
-        assertEq(uint256(bytes32(Bytes.slice(defaultCode, 6945, 32))), uint256(1), "expecting default chain ID");
-        assertEq(
-            bytes32(Bytes.slice(defaultCode, 6983, 32)),
-            bytes32(0x866a5aba21966af95d6c7ab78eb2b2fc913915c28be3b9aa07cc04ff903e3f28),
-            "expecting default domain separator"
-        );
+        bytes memory defaultCode =
+            assertPermit2Code(1, bytes32(0x866a5aba21966af95d6c7ab78eb2b2fc913915c28be3b9aa07cc04ff903e3f28));
         assertEq(defaultCode, Preinstalls.Permit2TemplateCode, "template is using chain ID 1");
     }
 }
@@ -57,10 +72,9 @@ contract Preinstalls_Uncategorized_Test is Preinstalls_TestInit {
             keccak256(abi.encodePacked("EIP712Domain(string name,uint256 chainId,address verifyingContract)"));
         bytes32 nameHash = keccak256(abi.encodePacked("Permit2"));
         uint256 chainId = block.chainid;
-        bytes memory encoded = abi.encode(typeHash, nameHash, chainId, Preinstalls.Permit2);
-        bytes32 expectedDomainSeparator = keccak256(encoded);
+        bytes32 expectedDomainSeparator = keccak256(abi.encode(typeHash, nameHash, chainId, Preinstalls.Permit2));
         assertEq(domainSeparator, expectedDomainSeparator, "Domain separator mismatch");
-        assertEq(chainId, uint256(901)); // uses devnet config
+        assertEq(chainId, PERMIT2_DEPLOYMENT_CHAIN_ID); // uses devnet config
         assertEq(domainSeparator, bytes32(0x48deb34b39fb4b41f5c195008940d5ef510cdd7853eba5807b2fa08dfd586475));
         // Warning the Permit2 domain separator as cached in the DeployPermit2.sol bytecode is
         // incorrect.
@@ -98,11 +112,10 @@ contract Preinstalls_Uncategorized_Test is Preinstalls_TestInit {
         assertPreinstall(Preinstalls.MultiSend_v130, Preinstalls.MultiSend_v130Code);
     }
 
-    function test_preinstall_permit2_succeeds() external {
-        uint256 pre = block.chainid;
-        vm.chainId(901); // TODO legacy deployment does not use same chainID as tests run with
-        assertPreinstall(Preinstalls.Permit2, Preinstalls.getPermit2Code(block.chainid));
-        vm.chainId(pre);
+    function test_preinstall_permit2_succeeds() external view {
+        assertPreinstall(
+            Preinstalls.Permit2, Preinstalls.getPermit2Code(PERMIT2_DEPLOYMENT_CHAIN_ID), PERMIT2_DEPLOYMENT_CHAIN_ID
+        );
     }
 
     function test_preinstall_senderCreatorv060_succeeds() external view {

--- a/test/libraries/SafeCall.t.sol
+++ b/test/libraries/SafeCall.t.sol
@@ -32,16 +32,26 @@ contract SimpleSafeCaller {
 /// @title SafeCall_TestInit
 /// @notice Reusable test initialization for `SafeCall` tests.
 abstract contract SafeCall_TestInit is Test {
-    /// @notice Helper function to deduplicate code. Makes all assumptions required for these
-    ///         tests.
-    function assumeNot(address _addr) internal {
-        vm.deal(_addr, 0);
-        vm.assume(_addr != address(this));
-        assumeAddressIsNot(_addr, StdCheatsSafe.AddressType.ForgeAddress, StdCheatsSafe.AddressType.Precompile);
+    struct CallBalances {
+        uint256 from;
+        uint256 to;
     }
 
-    /// @notice Internal helper function for `send` tests
-    function sendTest(address _from, address _to, uint64 _gas, uint256 _value) internal {
+    /// @notice Makes all assumptions required for these tests.
+    function assumeNot(address _addr) internal {
+        vm.assume(_addr != address(this));
+        assumeAddressIsNot(_addr, StdCheatsSafe.AddressType.ForgeAddress, StdCheatsSafe.AddressType.Precompile);
+        vm.deal(_addr, 0);
+    }
+
+    function prepareCall(
+        address _from,
+        address _to,
+        uint256 _value
+    )
+        internal
+        returns (CallBalances memory balancesBefore)
+    {
         assumeNot(_from);
         assumeNot(_to);
 
@@ -49,7 +59,29 @@ abstract contract SafeCall_TestInit is Test {
         vm.deal(_from, _value);
         assertEq(_from.balance, _value, "from balance not dealt");
 
-        uint256[2] memory balancesBefore = [_from.balance, _to.balance];
+        balancesBefore = CallBalances({ from: _from.balance, to: _to.balance });
+    }
+
+    function assertCallBalances(
+        address _from,
+        address _to,
+        uint256 _value,
+        CallBalances memory _balancesBefore
+    )
+        internal
+        view
+    {
+        if (_from == _to) {
+            assertEq(_from.balance, _balancesBefore.from, "self-transfer did not preserve balance");
+        } else {
+            assertEq(_from.balance, _balancesBefore.from - _value, "from balance not drained");
+            assertEq(_to.balance, _balancesBefore.to + _value, "to balance received");
+        }
+    }
+
+    /// @notice Internal helper function for `send` tests
+    function sendTest(address _from, address _to, uint64 _gas, uint256 _value) internal {
+        CallBalances memory balancesBefore = prepareCall(_from, _to, _value);
 
         vm.expectCall(_to, _value, bytes(""));
         vm.prank(_from);
@@ -61,12 +93,7 @@ abstract contract SafeCall_TestInit is Test {
         }
 
         assertTrue(success, "send not successful");
-        if (_from == _to) {
-            assertEq(_from.balance, balancesBefore[0], "Self-send did not change balance");
-        } else {
-            assertEq(_from.balance, balancesBefore[0] - _value, "from balance not drained");
-            assertEq(_to.balance, balancesBefore[1] + _value, "to balance received");
-        }
+        assertCallBalances(_from, _to, _value, balancesBefore);
     }
 }
 
@@ -90,26 +117,14 @@ contract SafeCall_Send_Test is SafeCall_TestInit {
 contract SafeCall_Call_Test is SafeCall_TestInit {
     /// @notice Tests that `call` succeeds.
     function testFuzz_call_succeeds(address from, address to, uint256 gas, uint64 value, bytes memory data) external {
-        assumeNot(from);
-        assumeNot(to);
-
-        assertEq(from.balance, 0, "from balance is 0");
-        vm.deal(from, value);
-        assertEq(from.balance, value, "from balance not dealt");
-
-        uint256[2] memory balancesBefore = [from.balance, to.balance];
+        CallBalances memory balancesBefore = prepareCall(from, to, value);
 
         vm.expectCall(to, value, data);
         vm.prank(from);
         bool success = SafeCall.call(to, gas, value, data);
 
         assertTrue(success, "call not successful");
-        if (from == to) {
-            assertEq(from.balance, balancesBefore[0], "Self-send did not change balance");
-        } else {
-            assertEq(from.balance, balancesBefore[0] - value, "from balance not drained");
-            assertEq(to.balance, balancesBefore[1] + value, "to balance received");
-        }
+        assertCallBalances(from, to, value, balancesBefore);
     }
 }
 
@@ -126,110 +141,80 @@ contract SafeCall_CallWithMinGas_Test is SafeCall_TestInit {
     )
         external
     {
-        assumeNot(from);
-        assumeNot(to);
-
-        assertEq(from.balance, 0, "from balance is 0");
-        vm.deal(from, value);
-        assertEq(from.balance, value, "from balance not dealt");
+        CallBalances memory balancesBefore = prepareCall(from, to, value);
 
         // Bound minGas to [0, l1_block_gas_limit]
         minGas = uint64(bound(minGas, 0, 30_000_000));
-
-        uint256[2] memory balancesBefore = [from.balance, to.balance];
 
         vm.expectCallMinGas(to, value, minGas, data);
         vm.prank(from);
         bool success = SafeCall.callWithMinGas(to, minGas, value, data);
 
         assertTrue(success, "call not successful");
-        if (from == to) {
-            assertEq(from.balance, balancesBefore[0], "Self-send did not change balance");
-        } else {
-            assertEq(from.balance, balancesBefore[0] - value, "from balance not drained");
-            assertEq(to.balance, balancesBefore[1] + value, "to balance received");
-        }
+        assertCallBalances(from, to, value, balancesBefore);
     }
 
     /// @notice Tests that `callWithMinGas` succeeds for the lower gas bounds.
     function test_callWithMinGas_noLeakageLow_succeeds() external {
         SimpleSafeCaller caller = new SimpleSafeCaller();
 
-        for (uint64 i = 40_000; i < 100_000; i++) {
-            uint256 snapshot = vm.snapshot();
-
-            // The values below are best gotten by setting the value to a high number and running
-            // the test with a verbosity of `-vvv` then setting the value to the value (gas arg) of
-            // the failed assertion. A faster way to do this for forge coverage cases, is to
-            // comment out the optimizer and optimizer runs in the foundry.toml file and then run
-            // forge test. This is faster because forge test only compiles modified contracts
-            // unlike forge coverage.
-            uint256 expected;
-
-            // Because forge coverage always runs with the optimizer disabled, if forge coverage is
-            // run before testing this with forge test or forge snapshot, forge clean should be run
-            // first so that it recompiles the contracts using the foundry.toml optimizer settings.
-            if (vm.isContext(VmSafe.ForgeContext.Coverage) || LibString.eq(Config.foundryProfile(), "lite")) {
-                // 66_290 is the exact amount of gas required to make the safe call
-                // successfully with the optimizer disabled (ran via forge coverage)
-                expected = 66_290;
-            } else if (vm.isContext(VmSafe.ForgeContext.Test) || vm.isContext(VmSafe.ForgeContext.Snapshot)) {
-                // 65_922 is the exact amount of gas required to make the safe call
-                // successfully with the foundry.toml optimizer settings.
-                expected = 65_922;
-            } else {
-                revert("SafeCall_Test: unknown context");
-            }
-
-            if (i < expected) {
-                assertFalse(caller.makeSafeCall(i, 25_000));
-            } else {
-                vm.expectCallMinGas(address(caller), 0, 25_000, abi.encodeCall(caller.setA, (1)));
-                assertTrue(caller.makeSafeCall(i, 25_000));
-            }
-
-            assertTrue(vm.revertTo(snapshot));
-        }
+        checkNoGasLeakage({
+            _caller: caller,
+            _startGas: 40_000,
+            _endGas: 100_000,
+            _minGas: 25_000,
+            _expected: expectedSafeCallGas({ _coverageOrLiteGas: 66_290, _testGas: 65_922 }),
+            _setACall: abi.encodeCall(caller.setA, (1))
+        });
     }
 
     /// @notice Tests that `callWithMinGas` succeeds on the upper gas bounds.
     function test_callWithMinGas_noLeakageHigh_succeeds() external {
         SimpleSafeCaller caller = new SimpleSafeCaller();
 
-        for (uint64 i = 15_200_000; i < 15_300_000; i++) {
-            uint256 snapshot = vm.snapshot();
+        checkNoGasLeakage({
+            _caller: caller,
+            _startGas: 15_200_000,
+            _endGas: 15_300_000,
+            _minGas: 15_000_000,
+            _expected: expectedSafeCallGas({ _coverageOrLiteGas: 15_278_989, _testGas: 15_278_621 }),
+            _setACall: abi.encodeCall(caller.setA, (1))
+        });
+    }
 
-            // The values below are best gotten by setting the value to a high number and running
-            // the test with a verbosity of `-vvv` then setting the value to the value (gas arg) of
-            // the failed assertion. A faster way to do this for forge coverage cases, is to
-            // comment out the optimizer and optimizer runs in the foundry.toml file and then run
-            // forge test. This is faster because forge test only compiles modified contracts
-            // unlike forge coverage.
-            uint256 expected;
+    /// @notice Returns the gas threshold calibrated for the current forge context.
+    /// @dev Thresholds are calibrated from the failing gas arg when running these tests with `-vvv`.
+    function expectedSafeCallGas(uint256 _coverageOrLiteGas, uint256 _testGas) internal view returns (uint256) {
+        if (vm.isContext(VmSafe.ForgeContext.Coverage) || LibString.eq(Config.foundryProfile(), "lite")) {
+            return _coverageOrLiteGas;
+        } else if (vm.isContext(VmSafe.ForgeContext.Test) || vm.isContext(VmSafe.ForgeContext.Snapshot)) {
+            return _testGas;
+        } else {
+            revert("SafeCall_Test: unknown context");
+        }
+    }
 
-            // Because forge coverage always runs with the optimizer disabled, if forge coverage is
-            // run before testing this with forge test or forge snapshot, forge clean should be run
-            // first so that it recompiles the contracts using the foundry.toml optimizer settings.
-            if (vm.isContext(VmSafe.ForgeContext.Coverage) || LibString.eq(Config.foundryProfile(), "lite")) {
-                // 15_278_989 is the exact amount of gas required to make the safe call
-                // successfully with the optimizer disabled (ran via forge coverage)
-                expected = 15_278_989;
-            } else if (vm.isContext(VmSafe.ForgeContext.Test) || vm.isContext(VmSafe.ForgeContext.Snapshot)) {
-                // 15_278_621 is the exact amount of gas required to make the safe call
-                // successfully with the foundry.toml optimizer settings.
-                expected = 15_278_621;
+    function checkNoGasLeakage(
+        SimpleSafeCaller _caller,
+        uint64 _startGas,
+        uint64 _endGas,
+        uint64 _minGas,
+        uint256 _expected,
+        bytes memory _setACall
+    )
+        internal
+    {
+        for (uint64 i = _startGas; i < _endGas; i++) {
+            uint256 snapshot = vm.snapshotState();
+
+            if (i < _expected) {
+                assertFalse(_caller.makeSafeCall(i, _minGas));
             } else {
-                revert("SafeCall_Test: unknown context");
+                vm.expectCallMinGas(address(_caller), 0, _minGas, _setACall);
+                assertTrue(_caller.makeSafeCall(i, _minGas));
             }
 
-            if (i < expected) {
-                assertFalse(caller.makeSafeCall(i, 15_000_000));
-            } else {
-                vm.expectCallMinGas(address(caller), 0, 15_000_000, abi.encodeCall(caller.setA, (1)));
-                assertTrue(caller.makeSafeCall(i, 15_000_000));
-            }
-
-            assertTrue(vm.revertTo(snapshot));
+            assertTrue(vm.revertToState(snapshot));
         }
     }
 }

--- a/test/libraries/SemverComp.t.sol
+++ b/test/libraries/SemverComp.t.sol
@@ -1,131 +1,88 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Forge
 import { Test } from "lib/forge-std/src/Test.sol";
 
-// Libraries
 import { JSONParserLib } from "lib/solady/src/utils/JSONParserLib.sol";
 import { SemverComp } from "src/libraries/SemverComp.sol";
 
-/// @title SemverComp_Harness
-/// @notice Exposes internal functions of `SemverComp` for testing.
 contract SemverComp_Harness {
-    /// @notice Parses a semver string into a Semver struct. This is a wrapper around
-    ///         `SemverComp.parse` that returns the major, minor, and patch components as
-    ///         separate values.
-    /// @param _semver The semver string to parse.
-    /// @return major_ The major version.
-    /// @return minor_ The minor version.
-    /// @return patch_ The patch version.
     function parse(string memory _semver) external pure returns (uint256 major_, uint256 minor_, uint256 patch_) {
         SemverComp.Semver memory v = SemverComp.parse(_semver);
         return (v.major, v.minor, v.patch);
     }
 }
 
-/// @title SemverComp_TestInit
-/// @notice Reusable test initialization for `SemverComp` tests.
 abstract contract SemverComp_TestInit is Test {
     SemverComp_Harness internal harness;
 
-    /// @notice Sets up the test environment.
     function setUp() public {
         harness = new SemverComp_Harness();
     }
 
-    /// @notice Asserts that the parsed semver components match the expected values.
-    /// @param _semver The semver string to parse.
-    /// @param _major The expected major version.
-    /// @param _minor The expected minor version.
-    /// @param _patch The expected patch version.
     function assertParsedEq(string memory _semver, uint256 _major, uint256 _minor, uint256 _patch) internal view {
         (uint256 major, uint256 minor, uint256 patch) = harness.parse(_semver);
         assertEq(major, _major, "major mismatch");
         assertEq(minor, _minor, "minor mismatch");
         assertEq(patch, _patch, "patch mismatch");
     }
+
+    function assertParseReverts(string memory _semver, bytes4 _selector) internal {
+        vm.expectRevert(_selector);
+        harness.parse(_semver);
+    }
 }
 
-/// @title SemverComp_parse_Test
-/// @notice Tests the `parse` function behavior.
 contract SemverComp_parse_Test is SemverComp_TestInit {
-    /// @notice Parses the minimal version.
     function test_parse_basicZero_succeeds() external view {
         assertParsedEq("0.0.0", 0, 0, 0);
     }
 
-    /// @notice Parses a standard version.
     function test_parse_basic123_succeeds() external view {
         assertParsedEq("1.2.3", 1, 2, 3);
     }
 
-    /// @notice Ignores prerelease identifiers.
     function test_parse_withPrerelease_succeeds() external view {
         assertParsedEq("1.2.3-alpha", 1, 2, 3);
         assertParsedEq("1.2.3-alpha.1", 1, 2, 3);
         assertParsedEq("10.20.30-rc.1", 10, 20, 30);
     }
 
-    /// @notice Ignores build metadata.
     function test_parse_withBuildMetadataOnly_succeeds() external view {
         assertParsedEq("1.2.3+build.5", 1, 2, 3);
         assertParsedEq("1.2.3+20240101", 1, 2, 3);
     }
 
-    /// @notice Ignores prerelease and build metadata together.
     function test_parse_withPrereleaseAndBuild_succeeds() external view {
         assertParsedEq("1.2.3-rc.1+build.5", 1, 2, 3);
         assertParsedEq("2.0.0-beta+exp.sha.5114f85", 2, 0, 0);
     }
 
-    /// @notice Reverts when fewer than 3 dot-separated core parts are present.
     function test_parse_lessThanThreeParts_reverts() external {
-        vm.expectRevert(SemverComp.SemverComp_InvalidSemverParts.selector);
-        harness.parse("1.2");
-
-        vm.expectRevert(SemverComp.SemverComp_InvalidSemverParts.selector);
-        harness.parse("1");
-
-        vm.expectRevert(SemverComp.SemverComp_InvalidSemverParts.selector);
-        harness.parse("");
+        assertParseReverts("1.2", SemverComp.SemverComp_InvalidSemverParts.selector);
+        assertParseReverts("1", SemverComp.SemverComp_InvalidSemverParts.selector);
+        assertParseReverts("", SemverComp.SemverComp_InvalidSemverParts.selector);
     }
 
-    /// @notice Current behavior: extra dot-components beyond the core 3 are ignored.
     function test_parse_extraDotComponents_succeeds() external view {
         assertParsedEq("1.2.3.4", 1, 2, 3);
         assertParsedEq("1.2.3.4.5", 1, 2, 3);
     }
 
-    /// @notice Reverts on non-numeric core parts.
     function test_parse_nonNumeric_reverts() external {
-        vm.expectRevert(JSONParserLib.ParsingFailed.selector);
-        harness.parse("a.b.c");
-
-        vm.expectRevert(JSONParserLib.ParsingFailed.selector);
-        harness.parse("1.b.3");
-
-        vm.expectRevert(JSONParserLib.ParsingFailed.selector);
-        harness.parse("1.2.c");
+        assertParseReverts("a.b.c", JSONParserLib.ParsingFailed.selector);
+        assertParseReverts("1.b.3", JSONParserLib.ParsingFailed.selector);
+        assertParseReverts("1.2.c", JSONParserLib.ParsingFailed.selector);
     }
 
-    /// @notice Reverts on certain commonly malformed inputs.
     function test_parse_malformedInputs_reverts() external {
-        // Leading/trailing whitespace
-        vm.expectRevert(JSONParserLib.ParsingFailed.selector);
-        harness.parse(" 1.2.3");
-        vm.expectRevert(JSONParserLib.ParsingFailed.selector);
-        harness.parse("1.2.3 ");
-
-        // "v" prefix
-        vm.expectRevert(JSONParserLib.ParsingFailed.selector);
-        harness.parse("v1.2.3");
+        assertParseReverts(" 1.2.3", JSONParserLib.ParsingFailed.selector);
+        assertParseReverts("1.2.3 ", JSONParserLib.ParsingFailed.selector);
+        assertParseReverts("v1.2.3", JSONParserLib.ParsingFailed.selector);
     }
 }
 
-/// @title SemverComp_Eq_Test
-/// @notice Tests the `eq` function behavior.
-contract SemverComp_Eq_Test is SemverComp_TestInit {
+contract SemverComp_Eq_Test is Test {
     function test_eq_succeeds() external pure {
         assertTrue(SemverComp.eq("1.2.3", "1.2.3"));
 
@@ -135,9 +92,7 @@ contract SemverComp_Eq_Test is SemverComp_TestInit {
     }
 }
 
-/// @title SemverComp_Lt_Test
-/// @notice Tests the `lt` function behavior.
-contract SemverComp_Lt_Test is SemverComp_TestInit {
+contract SemverComp_Lt_Test is Test {
     function test_lt_succeeds() external pure {
         assertTrue(SemverComp.lt("1.2.3", "1.2.4"));
         assertTrue(SemverComp.lt("1.2.3", "1.3.0"));
@@ -149,9 +104,7 @@ contract SemverComp_Lt_Test is SemverComp_TestInit {
     }
 }
 
-/// @title SemverComp_Lte_Test
-/// @notice Tests the `lte` function behavior.
-contract SemverComp_Lte_Test is SemverComp_TestInit {
+contract SemverComp_Lte_Test is Test {
     function test_lte_succeeds() external pure {
         assertTrue(SemverComp.lte("1.2.3", "1.2.3"));
         assertTrue(SemverComp.lte("1.2.3", "1.2.4"));
@@ -163,9 +116,7 @@ contract SemverComp_Lte_Test is SemverComp_TestInit {
     }
 }
 
-/// @title SemverComp_Gt_Test
-/// @notice Tests the `gt` function behavior.
-contract SemverComp_Gt_Test is SemverComp_TestInit {
+contract SemverComp_Gt_Test is Test {
     function test_gt_succeeds() external pure {
         assertTrue(SemverComp.gt("1.2.4", "1.2.3"));
         assertTrue(SemverComp.gt("1.3.0", "1.2.3"));
@@ -177,9 +128,7 @@ contract SemverComp_Gt_Test is SemverComp_TestInit {
     }
 }
 
-/// @title SemverComp_Gte_Test
-/// @notice Tests the `gte` function behavior.
-contract SemverComp_Gte_Test is SemverComp_TestInit {
+contract SemverComp_Gte_Test is Test {
     function test_gte_succeeds() external pure {
         assertTrue(SemverComp.gte("1.2.3", "1.2.3"));
         assertTrue(SemverComp.gte("1.2.4", "1.2.3"));


### PR DESCRIPTION
## Summary

Simplifies and cleans up tests under `test/libraries/`, removing redundancy and reducing test file sizes.