### PR TITLE
fix(multiproof): update finalization delay constants

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -232,8 +232,8 @@
     "sourceCodeHash": "0x955bd0c9b47e43219865e4e92abf28d916c96de20cbdf2f94c8ab14d02083759"
   },
   "src/multiproof/AggregateVerifier.sol:AggregateVerifier": {
-    "initCodeHash": "0x10bb6a60f21de103d1da9ff310a38f571c53a8113d04a029087648debf3f0341",
-    "sourceCodeHash": "0xcd4c508223b9b461ec230bde03c1630fe68cd00b82ee84c39b93d9f3c0d71d37"
+    "initCodeHash": "0x90629c679e821a70553d899a68e818bcddb672a004a0d2e09078d17028a2f082",
+    "sourceCodeHash": "0xb9584e6e70462410b1d42a866c9d71e4f4259a46f2da32853498b8e14380c196"
   },
   "src/multiproof/tee/NitroEnclaveVerifier.sol:NitroEnclaveVerifier": {
     "initCodeHash": "0x100364f9b0c63a61538386ba91e73dcffba22d3f6dfe8efdbbf5ff347b6fce47",

--- a/src/multiproof/AggregateVerifier.sol
+++ b/src/multiproof/AggregateVerifier.sol
@@ -47,7 +47,7 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
     //                         Constants                          //
     ////////////////////////////////////////////////////////////////
     /// @notice The slow finalization delay.
-    uint64 public constant SLOW_FINALIZATION_DELAY = 7 days;
+    uint64 public constant SLOW_FINALIZATION_DELAY = 5 days;
 
     /// @notice The fast finalization delay.
     uint64 public constant FAST_FINALIZATION_DELAY = 1 days;

--- a/test/multiproof/AggregateVerifier.t.sol
+++ b/test/multiproof/AggregateVerifier.t.sol
@@ -96,8 +96,8 @@ contract AggregateVerifierTest is BaseTest {
         vm.expectRevert(GameNotResolved.selector);
         game.claimCredit();
 
-        // Resolve after 7 days
-        vm.warp(block.timestamp + 7 days);
+        // Resolve after SLOW_FINALIZATION_DELAY
+        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
         game.resolve();
         assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
 
@@ -126,8 +126,8 @@ contract AggregateVerifierTest is BaseTest {
             ZK_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proof
         );
 
-        // Resolve after 7 days
-        vm.warp(block.timestamp + 7 days);
+        // Resolve after SLOW_FINALIZATION_DELAY
+        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
         game.resolve();
         assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
 
@@ -160,8 +160,8 @@ contract AggregateVerifierTest is BaseTest {
         _provideProof(game, ZK_PROVER, zkProof);
         assertEq(game.proofCount(), 2);
 
-        // Resolve after 1 day (FAST_FINALIZATION_DELAY with 2 proofs)
-        vm.warp(block.timestamp + 1 days);
+        // Resolve after FAST_FINALIZATION_DELAY (2 proofs)
+        vm.warp(block.timestamp + FAST_FINALIZATION_DELAY);
         game.resolve();
         assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
 
@@ -192,9 +192,9 @@ contract AggregateVerifierTest is BaseTest {
         );
 
         Timestamp originalExpectedResolution = game.expectedResolution();
-        assertEq(originalExpectedResolution.raw(), block.timestamp + 7 days);
+        assertEq(originalExpectedResolution.raw(), block.timestamp + SLOW_FINALIZATION_DELAY);
 
-        vm.warp(block.timestamp + 7 days - 1);
+        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY - 1);
         // Cannot resolve yet
         vm.expectRevert(AggregateVerifier.GameNotOver.selector);
         game.resolve();

--- a/test/multiproof/BaseTest.t.sol
+++ b/test/multiproof/BaseTest.t.sol
@@ -40,6 +40,8 @@ contract BaseTest is Test {
     uint256 public constant DELAYED_WETH_DELAY = 1 days;
     // Finality delay handled by the AggregateVerifier
     uint256 public constant FINALITY_DELAY = 0 days;
+    uint256 public SLOW_FINALIZATION_DELAY;
+    uint256 public FAST_FINALIZATION_DELAY;
 
     uint256 public currentL2BlockNumber = 0;
 
@@ -68,6 +70,11 @@ contract BaseTest is Test {
 
         // Deploy the implementations
         _deployAndSetAggregateVerifier();
+
+        AggregateVerifier aggregateVerifierImpl =
+            AggregateVerifier(address(factory.gameImpls(AGGREGATE_VERIFIER_GAME_TYPE)));
+        SLOW_FINALIZATION_DELAY = aggregateVerifierImpl.SLOW_FINALIZATION_DELAY();
+        FAST_FINALIZATION_DELAY = aggregateVerifierImpl.FAST_FINALIZATION_DELAY();
 
         anchorStateRegistry.setRespectedGameType(AGGREGATE_VERIFIER_GAME_TYPE);
 

--- a/test/multiproof/Challenge.t.sol
+++ b/test/multiproof/Challenge.t.sol
@@ -35,7 +35,7 @@ contract ChallengeTest is BaseTest {
         assertEq(game.proofCount(), 2);
 
         // Resolve after SLOW_FINALIZATION_DELAY
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
         game.resolve();
 
         assertEq(uint8(game.status()), uint8(GameStatus.CHALLENGER_WINS));
@@ -97,7 +97,7 @@ contract ChallengeTest is BaseTest {
         );
 
         // Resolve game1
-        vm.warp(block.timestamp + 7 days + 1);
+        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY + 1);
         game1.resolve();
 
         // Try to challenge game1
@@ -245,7 +245,7 @@ contract ChallengeTest is BaseTest {
         assertEq(gameA.counteredByIntermediateRootIndexPlusOne(), 0);
         assertEq(address(gameA.zkProver()), address(0));
 
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
         assertEq(uint8(gameA.resolve()), uint8(GameStatus.DEFENDER_WINS));
         assertEq(gameA.bondRecipient(), TEE_PROVER);
 
@@ -295,7 +295,7 @@ contract ChallengeTest is BaseTest {
         assertEq(address(gameA.teeProver()), address(0));
         assertEq(gameA.zkProver(), ZK_PROVER);
 
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
         assertEq(uint8(gameA.resolve()), uint8(GameStatus.CHALLENGER_WINS));
         assertEq(gameA.bondRecipient(), ZK_PROVER);
 

--- a/test/multiproof/Nullify.t.sol
+++ b/test/multiproof/Nullify.t.sol
@@ -84,7 +84,7 @@ contract NullifyTest is BaseTest {
         bytes memory zkProof = _generateProof("zk-proof-2", AggregateVerifier.ProofType.ZK);
         game.verifyProposalProof(zkProof);
 
-        assertEq(game.expectedResolution().raw(), block.timestamp + 1 days);
+        assertEq(game.expectedResolution().raw(), block.timestamp + FAST_FINALIZATION_DELAY);
 
         Claim rootClaim2 = Claim.wrap(keccak256(abi.encode(currentL2BlockNumber, "tee2")));
         bytes memory teeProof2 = _generateProof("tee-proof-2", AggregateVerifier.ProofType.TEE);
@@ -93,7 +93,7 @@ contract NullifyTest is BaseTest {
         assertEq(uint8(game.status()), uint8(GameStatus.IN_PROGRESS));
         assertEq(game.bondRecipient(), TEE_PROVER);
         assertEq(game.proofCount(), 1);
-        assertEq(game.expectedResolution().raw(), block.timestamp + 7 days);
+        assertEq(game.expectedResolution().raw(), block.timestamp + SLOW_FINALIZATION_DELAY);
     }
 
     function testZKNullifyFailsIfNoZKProof() public {
@@ -124,7 +124,7 @@ contract NullifyTest is BaseTest {
         );
 
         // Resolve game1
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
         game1.resolve();
 
         // Try to nullify game1
@@ -158,8 +158,8 @@ contract NullifyTest is BaseTest {
 
         assertEq(game1.bondRecipient(), TEE_PROVER);
 
-        // After nullify, only TEE proof remains; expectedResolution = now + 7 days
-        vm.warp(block.timestamp + 7 days);
+        // After nullify, only TEE proof remains; expectedResolution = now + SLOW_FINALIZATION_DELAY
+        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
         game1.resolve();
 
         uint256 balanceBefore = game1.gameCreator().balance;
@@ -190,7 +190,7 @@ contract NullifyTest is BaseTest {
         AggregateVerifier gameB =
             _createAggregateVerifierGame(TEE_PROVER, rootClaimB, currentL2BlockNumber, address(gameA), teeProofB);
 
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
         assertTrue(gameA.gameOver());
         assertEq(gameA.proofCount(), 1);
 
@@ -228,7 +228,7 @@ contract NullifyTest is BaseTest {
         AggregateVerifier gameB =
             _createAggregateVerifierGame(ZK_PROVER, rootClaimB, currentL2BlockNumber, address(gameA), zkProofB);
 
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
         assertTrue(gameA.gameOver());
         assertEq(gameA.proofCount(), 1);
 
@@ -248,9 +248,9 @@ contract NullifyTest is BaseTest {
         gameA.resolve();
     }
 
-    /// @notice With TEE + ZK, the fast window is 1 day. Another game nullifies the shared ZK verifier; the first
-    ///         `resolve` persists the ZK refutation and returns `IN_PROGRESS`. After `SLOW_FINALIZATION_DELAY`
-    ///         (7 days) from that moment, a second `resolve` finalizes with only the TEE proof.
+    /// @notice With TEE + ZK, the fast window is `FAST_FINALIZATION_DELAY`. Another game nullifies the shared ZK
+    ///         verifier; the first `resolve` persists the ZK refutation and returns `IN_PROGRESS`. After
+    ///         `SLOW_FINALIZATION_DELAY` from that moment, a second `resolve` finalizes with only the TEE proof.
     function testTwoProofsResolveDelayedAfterExternalVerifierNullify() public {
         currentL2BlockNumber += BLOCK_INTERVAL;
 
@@ -265,9 +265,9 @@ contract NullifyTest is BaseTest {
         gameA.verifyProposalProof(zkProofA);
 
         assertEq(gameA.proofCount(), 2);
-        assertEq(gameA.expectedResolution().raw(), block.timestamp + 1 days);
+        assertEq(gameA.expectedResolution().raw(), block.timestamp + FAST_FINALIZATION_DELAY);
 
-        vm.warp(block.timestamp + 1 days);
+        vm.warp(block.timestamp + FAST_FINALIZATION_DELAY);
         assertTrue(gameA.gameOver());
 
         currentL2BlockNumber += BLOCK_INTERVAL;
@@ -284,9 +284,9 @@ contract NullifyTest is BaseTest {
 
         assertEq(uint8(gameA.resolve()), uint8(GameStatus.IN_PROGRESS));
         assertEq(gameA.proofCount(), 1);
-        assertEq(gameA.expectedResolution().raw(), block.timestamp + 7 days);
+        assertEq(gameA.expectedResolution().raw(), block.timestamp + SLOW_FINALIZATION_DELAY);
 
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + SLOW_FINALIZATION_DELAY);
         assertEq(uint8(gameA.resolve()), uint8(GameStatus.DEFENDER_WINS));
         assertEq(uint8(gameA.status()), uint8(GameStatus.DEFENDER_WINS));
     }


### PR DESCRIPTION
### What changed? Why?

Backports #293 onto the v8.2.0 release branch. This updates the AggregateVerifier slow finalization delay from 7 days to 5 days and updates the related tests to use the finalization constants.