### PR TITLE
chore(test): simplify test setup

### DIFF
--- a/test/scripts/L2Genesis.t.sol
+++ b/test/scripts/L2Genesis.t.sol
@@ -6,10 +6,6 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { L2Genesis } from "scripts/L2Genesis.s.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { LATEST_FORK } from "scripts/libraries/Config.sol";
-import { ISequencerFeeVault } from "interfaces/L2/ISequencerFeeVault.sol";
-import { IBaseFeeVault } from "interfaces/L2/IBaseFeeVault.sol";
-import { IL1FeeVault } from "interfaces/L2/IL1FeeVault.sol";
-import { IOperatorFeeVault } from "interfaces/L2/IOperatorFeeVault.sol";
 import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
 import { IOptimismMintableERC721Factory } from "interfaces/L2/IOptimismMintableERC721Factory.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
@@ -28,12 +24,9 @@ abstract contract L2Genesis_TestInit is Test {
         genesis = new L2Genesis();
     }
 
-    function testProxyAdmin() internal view {
-        // Verify owner in the proxy
+    function _assertProxyAdmin() internal view {
         assertEq(input.opChainProxyAdminOwner, IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
 
-        // Verify owner in the implementation to catch storage shifting issues
-        // The implementation is stored in the code namespace
         address proxyAdminImpl = Predeploys.predeployToCodeNamespace(Predeploys.PROXY_ADMIN);
         assertEq(
             input.opChainProxyAdminOwner,
@@ -42,71 +35,77 @@ abstract contract L2Genesis_TestInit is Test {
         );
     }
 
-    function testPredeploys() internal view {
+    function _assertPredeploys() internal view {
         uint160 prefix = uint160(0x420) << 148;
 
         for (uint256 i = 0; i < Predeploys.PREDEPLOY_COUNT; i++) {
             address addr = address(prefix | uint160(i));
-            // If it's not proxied, skip next checks.
             if (Predeploys.notProxied(addr)) {
                 continue;
             }
 
-            // All predeploys should have code
             assertGt(addr.code.length, 0);
-            // All proxied predeploys should have the 1967 admin slot set to the ProxyAdmin
             assertEq(Predeploys.PROXY_ADMIN, EIP1967Helper.getAdmin(addr));
 
-            // If it's not a supported predeploy, skip next checks.
             if (!Predeploys.isSupportedPredeploy(addr)) {
                 continue;
             }
 
-            // All proxied predeploys should have the 1967 admin slot set to the ProxyAdmin
-            // predeploy
             address impl = Predeploys.predeployToCodeNamespace(addr);
+            assertEq(impl, EIP1967Helper.getImplementation(addr));
             assertGt(impl.code.length, 0);
         }
 
         assertGt(Predeploys.WETH.code.length, 0);
     }
 
-    function testVaultsWithoutRevenueShare() internal view {
-        IBaseFeeVault baseFeeVault = IBaseFeeVault(payable(Predeploys.BASE_FEE_VAULT));
-        IL1FeeVault l1FeeVault = IL1FeeVault(payable(Predeploys.L1_FEE_VAULT));
-        ISequencerFeeVault sequencerFeeVault = ISequencerFeeVault(payable(Predeploys.SEQUENCER_FEE_WALLET));
-        IOperatorFeeVault operatorFeeVault = IOperatorFeeVault(payable(Predeploys.OPERATOR_FEE_VAULT));
-
-        assertEq(baseFeeVault.RECIPIENT(), input.baseFeeVaultRecipient);
-        assertEq(baseFeeVault.recipient(), input.baseFeeVaultRecipient);
-        assertEq(baseFeeVault.MIN_WITHDRAWAL_AMOUNT(), input.baseFeeVaultMinimumWithdrawalAmount);
-        assertEq(baseFeeVault.minWithdrawalAmount(), input.baseFeeVaultMinimumWithdrawalAmount);
-        assertEq(uint8(baseFeeVault.WITHDRAWAL_NETWORK()), uint8(input.baseFeeVaultWithdrawalNetwork));
-        assertEq(uint8(baseFeeVault.withdrawalNetwork()), uint8(input.baseFeeVaultWithdrawalNetwork));
-
-        assertEq(l1FeeVault.RECIPIENT(), input.l1FeeVaultRecipient);
-        assertEq(l1FeeVault.recipient(), input.l1FeeVaultRecipient);
-        assertEq(l1FeeVault.MIN_WITHDRAWAL_AMOUNT(), input.l1FeeVaultMinimumWithdrawalAmount);
-        assertEq(l1FeeVault.minWithdrawalAmount(), input.l1FeeVaultMinimumWithdrawalAmount);
-        assertEq(uint8(l1FeeVault.WITHDRAWAL_NETWORK()), uint8(input.l1FeeVaultWithdrawalNetwork));
-        assertEq(uint8(l1FeeVault.withdrawalNetwork()), uint8(input.l1FeeVaultWithdrawalNetwork));
-
-        assertEq(sequencerFeeVault.RECIPIENT(), input.sequencerFeeVaultRecipient);
-        assertEq(sequencerFeeVault.recipient(), input.sequencerFeeVaultRecipient);
-        assertEq(sequencerFeeVault.MIN_WITHDRAWAL_AMOUNT(), input.sequencerFeeVaultMinimumWithdrawalAmount);
-        assertEq(sequencerFeeVault.minWithdrawalAmount(), input.sequencerFeeVaultMinimumWithdrawalAmount);
-        assertEq(uint8(sequencerFeeVault.WITHDRAWAL_NETWORK()), uint8(input.sequencerFeeVaultWithdrawalNetwork));
-        assertEq(uint8(sequencerFeeVault.withdrawalNetwork()), uint8(input.sequencerFeeVaultWithdrawalNetwork));
-
-        assertEq(operatorFeeVault.RECIPIENT(), input.operatorFeeVaultRecipient);
-        assertEq(operatorFeeVault.recipient(), input.operatorFeeVaultRecipient);
-        assertEq(operatorFeeVault.MIN_WITHDRAWAL_AMOUNT(), input.operatorFeeVaultMinimumWithdrawalAmount);
-        assertEq(operatorFeeVault.minWithdrawalAmount(), input.operatorFeeVaultMinimumWithdrawalAmount);
-        assertEq(uint8(operatorFeeVault.WITHDRAWAL_NETWORK()), uint8(input.operatorFeeVaultWithdrawalNetwork));
-        assertEq(uint8(operatorFeeVault.withdrawalNetwork()), uint8(input.operatorFeeVaultWithdrawalNetwork));
+    function _assertFeeVaultsWithoutRevenueShare() internal view {
+        _assertFeeVault(
+            Predeploys.BASE_FEE_VAULT,
+            input.baseFeeVaultRecipient,
+            input.baseFeeVaultMinimumWithdrawalAmount,
+            input.baseFeeVaultWithdrawalNetwork
+        );
+        _assertFeeVault(
+            Predeploys.L1_FEE_VAULT,
+            input.l1FeeVaultRecipient,
+            input.l1FeeVaultMinimumWithdrawalAmount,
+            input.l1FeeVaultWithdrawalNetwork
+        );
+        _assertFeeVault(
+            Predeploys.SEQUENCER_FEE_WALLET,
+            input.sequencerFeeVaultRecipient,
+            input.sequencerFeeVaultMinimumWithdrawalAmount,
+            input.sequencerFeeVaultWithdrawalNetwork
+        );
+        _assertFeeVault(
+            Predeploys.OPERATOR_FEE_VAULT,
+            input.operatorFeeVaultRecipient,
+            input.operatorFeeVaultMinimumWithdrawalAmount,
+            input.operatorFeeVaultWithdrawalNetwork
+        );
     }
 
-    function testFactories() internal view {
+    function _assertFeeVault(
+        address _vault,
+        address _recipient,
+        uint256 _minWithdrawalAmount,
+        uint256 _withdrawalNetwork
+    )
+        internal
+        view
+    {
+        IFeeVault vault = IFeeVault(payable(_vault));
+
+        assertEq(vault.RECIPIENT(), _recipient);
+        assertEq(vault.recipient(), _recipient);
+        assertEq(vault.MIN_WITHDRAWAL_AMOUNT(), _minWithdrawalAmount);
+        assertEq(vault.minWithdrawalAmount(), _minWithdrawalAmount);
+        assertEq(uint256(vault.WITHDRAWAL_NETWORK()), _withdrawalNetwork);
+        assertEq(uint256(vault.withdrawalNetwork()), _withdrawalNetwork);
+    }
+
+    function _assertFactories() internal view {
         IOptimismMintableERC20Factory erc20Factory =
             IOptimismMintableERC20Factory(payable(Predeploys.OPTIMISM_MINTABLE_ERC20_FACTORY));
         IOptimismMintableERC721Factory erc721Factory =
@@ -117,12 +116,12 @@ abstract contract L2Genesis_TestInit is Test {
         assertEq(erc721Factory.remoteChainID(), input.l1ChainID);
     }
 
-    function testForks() internal view {
-        // The fork should be set to Isthmus at least. Check by validating the GasPriceOracle
+    function _assertForks() internal view {
         IGasPriceOracle gasPriceOracle = IGasPriceOracle(payable(Predeploys.GAS_PRICE_ORACLE));
-        assertEq(gasPriceOracle.isEcotone(), true);
-        assertEq(gasPriceOracle.isFjord(), true);
-        assertEq(gasPriceOracle.isIsthmus(), true);
+        assertTrue(gasPriceOracle.isEcotone());
+        assertTrue(gasPriceOracle.isFjord());
+        assertTrue(gasPriceOracle.isIsthmus());
+        assertTrue(gasPriceOracle.isJovian());
     }
 }
 
@@ -131,26 +130,26 @@ abstract contract L2Genesis_TestInit is Test {
 contract L2Genesis_Run_Test is L2Genesis_TestInit {
     function setUp() public override {
         super.setUp();
-        // Set up default input configuration
+
         input = L2Genesis.Input({
             l1ChainID: 1,
             l2ChainID: 2,
-            l1CrossDomainMessengerProxy: payable(address(0x0000000000000000000000000000000000000001)),
-            l1StandardBridgeProxy: payable(address(0x0000000000000000000000000000000000000002)),
-            l1ERC721BridgeProxy: payable(address(0x0000000000000000000000000000000000000003)),
-            opChainProxyAdminOwner: address(0x0000000000000000000000000000000000000004),
-            sequencerFeeVaultRecipient: address(0x0000000000000000000000000000000000000005),
+            l1CrossDomainMessengerProxy: payable(makeAddr("L1CrossDomainMessengerProxy")),
+            l1StandardBridgeProxy: payable(makeAddr("L1StandardBridgeProxy")),
+            l1ERC721BridgeProxy: payable(makeAddr("L1ERC721BridgeProxy")),
+            opChainProxyAdminOwner: makeAddr("ProxyAdminOwner"),
+            sequencerFeeVaultRecipient: makeAddr("SequencerFeeVaultRecipient"),
             sequencerFeeVaultMinimumWithdrawalAmount: 1,
-            sequencerFeeVaultWithdrawalNetwork: 1,
-            baseFeeVaultRecipient: address(0x0000000000000000000000000000000000000006),
+            sequencerFeeVaultWithdrawalNetwork: uint256(Types.WithdrawalNetwork.L2),
+            baseFeeVaultRecipient: makeAddr("BaseFeeVaultRecipient"),
             baseFeeVaultMinimumWithdrawalAmount: 1,
-            baseFeeVaultWithdrawalNetwork: 1,
-            l1FeeVaultRecipient: address(0x0000000000000000000000000000000000000007),
+            baseFeeVaultWithdrawalNetwork: uint256(Types.WithdrawalNetwork.L2),
+            l1FeeVaultRecipient: makeAddr("L1FeeVaultRecipient"),
             l1FeeVaultMinimumWithdrawalAmount: 1,
-            l1FeeVaultWithdrawalNetwork: 1,
-            operatorFeeVaultRecipient: address(0x0000000000000000000000000000000000000008),
+            l1FeeVaultWithdrawalNetwork: uint256(Types.WithdrawalNetwork.L2),
+            operatorFeeVaultRecipient: makeAddr("OperatorFeeVaultRecipient"),
             operatorFeeVaultMinimumWithdrawalAmount: 1,
-            operatorFeeVaultWithdrawalNetwork: 1,
+            operatorFeeVaultWithdrawalNetwork: uint256(Types.WithdrawalNetwork.L2),
             fork: uint256(LATEST_FORK),
             fundDevAccounts: true
         });
@@ -159,9 +158,10 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
     function test_run_succeeds() external {
         genesis.run(input);
 
-        testProxyAdmin();
-        testPredeploys();
-        testFactories();
-        testForks();
+        _assertProxyAdmin();
+        _assertPredeploys();
+        _assertFeeVaultsWithoutRevenueShare();
+        _assertFactories();
+        _assertForks();
     }
 }

--- a/test/setup/CommonTest.sol
+++ b/test/setup/CommonTest.sol
@@ -12,18 +12,18 @@ import { FFIInterface } from "test/setup/FFIInterface.sol";
 // Contracts
 import { ERC20 } from "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 
-import { console } from "lib/forge-std/src/console.sol";
+import { console2 as console } from "lib/forge-std/src/console2.sol";
 
 // Interfaces
 import { IOptimismMintableERC20Full } from "interfaces/universal/IOptimismMintableERC20Full.sol";
 
 /// @title CommonTest
-/// @dev An extension to `Test` that sets up the optimism smart contracts.
+/// @dev An extension to `Test` that sets up the Optimism smart contracts.
 abstract contract CommonTest is Test, Setup, Events {
     address alice;
     address bob;
 
-    bytes32 constant nonZeroHash = keccak256(abi.encode("NON_ZERO"));
+    uint256 constant DEFAULT_TEST_BALANCE = 10_000 ether;
 
     FFIInterface constant ffi = FFIInterface(address(uint160(uint256(keccak256(abi.encode("optimism.ffi"))))));
 
@@ -52,8 +52,8 @@ abstract contract CommonTest is Test, Setup, Events {
 
         alice = makeAddr("alice");
         bob = makeAddr("bob");
-        vm.deal(alice, 10000 ether);
-        vm.deal(bob, 10000 ether);
+        vm.deal(alice, DEFAULT_TEST_BALANCE);
+        vm.deal(bob, DEFAULT_TEST_BALANCE);
 
         // Override the config after the deploy script initialized the config
         if (useUpgradedFork) {
@@ -76,23 +76,18 @@ abstract contract CommonTest is Test, Setup, Events {
         excludeContract(address(deploy));
         excludeContract(address(deploy.cfg()));
 
-        // Deploy L1
         Setup.L1();
-        // Deploy L2
         Setup.L2();
 
-        // Call bridge initializer setup function
         bridgeInitializerSetUp();
     }
 
-    function bridgeInitializerSetUp() public {
+    function bridgeInitializerSetUp() internal {
         L1Token = new ERC20("Native L1 Token", "L1T");
 
         if (isForkTest()) {
-            console.log("CommonTest: fork test detected, skipping L2 setup");
             L2Token = IOptimismMintableERC20Full(makeAddr("L2Token"));
         } else {
-            // Deploy the L2 ERC20 now
             L2Token = IOptimismMintableERC20Full(
                 l2OptimismMintableERC20Factory.createStandardL2Token(
                     address(L1Token),
@@ -104,23 +99,18 @@ abstract contract CommonTest is Test, Setup, Events {
 
         NativeL2Token = new ERC20("Native L2 Token", "L2T");
 
+        string memory remoteL1TokenName = string(abi.encodePacked("L1-", NativeL2Token.name()));
+        string memory remoteL1TokenSymbol = string(abi.encodePacked("L1-", NativeL2Token.symbol()));
+
         RemoteL1Token = IOptimismMintableERC20Full(
             l1OptimismMintableERC20Factory.createStandardL2Token(
-                address(NativeL2Token),
-                string(abi.encodePacked("L1-", NativeL2Token.name())),
-                string(abi.encodePacked("L1-", NativeL2Token.symbol()))
+                address(NativeL2Token), remoteL1TokenName, remoteL1TokenSymbol
             )
         );
 
         BadL1Token = ERC20(
-            l1OptimismMintableERC20Factory.createStandardL2Token(
-                address(1),
-                string(abi.encodePacked("L1-", NativeL2Token.name())),
-                string(abi.encodePacked("L1-", NativeL2Token.symbol()))
-            )
+            l1OptimismMintableERC20Factory.createStandardL2Token(address(1), remoteL1TokenName, remoteL1TokenSymbol)
         );
-
-        console.log("CommonTest: SetUp complete!");
     }
 
     /// @dev Helper function that wraps `TransactionDeposited` event.
@@ -151,9 +141,9 @@ abstract contract CommonTest is Test, Setup, Events {
     }
 
     /// @dev Disables upgrade mode for testing. By default the fork testing env will be upgraded to the latest
-    ///      implementation. This can be used to disable the upgrade which, is useful for tests targeting the upgrade
+    ///      implementation. This can be used to disable the upgrade, which is useful for tests targeting the upgrade
     ///      process itself.
-    function disableUpgradedFork() public {
+    function disableUpgradedFork() internal {
         _checkNotDeployed("non-upgraded fork");
 
         useUpgradedFork = false;

--- a/test/setup/Events.sol
+++ b/test/setup/Events.sol
@@ -1,28 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Libraries
 import { Types } from "src/libraries/Types.sol";
-import { Timestamp } from "src/libraries/bridge/LibUDT.sol";
-import "src/libraries/bridge/Types.sol";
-
-// Interfaces
-import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
 
 /// @title Events
 /// @dev Contains various events that are tested against. This contract needs to
 ///      exist until we either modularize the implementations or use a newer version of
 ///      solc that allows for referencing events from other contracts.
 abstract contract Events {
-    /// @dev OpenZeppelin Ownable.sol transferOwnership event
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
     event TransactionDeposited(address indexed from, address indexed to, uint256 indexed version, bytes opaqueData);
 
     event WithdrawalFinalized(bytes32 indexed withdrawalHash, bool success);
     event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to);
     event WithdrawalProvenExtension1(bytes32 indexed withdrawalHash, address indexed proofSubmitter);
-    event DisputeGameBlacklisted(IDisputeGame indexed disputeGame);
-    event RespectedGameTypeSet(GameType indexed newGameType, Timestamp indexed updatedAt);
 
     event SentMessage(address indexed target, address sender, bytes message, uint256 messageNonce, uint256 gasLimit);
     event SentMessageExtension1(address indexed sender, uint256 value);
@@ -38,22 +29,6 @@ abstract contract Events {
     event WithdrawerBalanceBurnt(uint256 indexed amount);
     event RelayedMessage(bytes32 indexed msgHash);
     event FailedRelayedMessage(bytes32 indexed msgHash);
-    event TransactionDeposited(
-        address indexed from,
-        address indexed to,
-        uint256 mint,
-        uint256 value,
-        uint64 gasLimit,
-        bool isCreation,
-        bytes data
-    );
-    event WhatHappened(bool success, bytes returndata);
-
-    event OutputProposed(
-        bytes32 indexed outputRoot, uint256 indexed l2OutputIndex, uint256 indexed l2BlockNumber, uint256 l1Timestamp
-    );
-
-    event OutputsDeleted(uint256 indexed prevNextOutputIndex, uint256 indexed newNextOutputIndex);
 
     event Withdrawal(uint256 value, address to, address from);
     event Withdrawal(uint256 value, address to, address from, Types.WithdrawalNetwork withdrawalNetwork);
@@ -75,10 +50,6 @@ abstract contract Events {
     );
 
     event DepositFinalized(
-        address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes data
-    );
-
-    event DepositFailed(
         address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes data
     );
 
@@ -109,12 +80,4 @@ abstract contract Events {
     event Unpaused(address identifier);
 
     event PauseExtended(address identifier);
-
-    event BalanceChanged(address account, uint256 balance);
-
-    event ETHMigrated(address indexed lockbox, uint256 ethBalance);
-
-    event PortalMigrated(
-        address oldLockbox, address newLockbox, address oldAnchorStateRegistry, address newAnchorStateRegistry
-    );
 }

--- a/test/setup/FFIInterface.sol
+++ b/test/setup/FFIInterface.sol
@@ -11,32 +11,17 @@ import { Strings } from "lib/openzeppelin-contracts/contracts/utils/Strings.sol"
 ///         are multiple artifacts for different compiler versions.
 contract FFIInterface {
     Vm internal constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+    string internal constant GO_FFI = "scripts/go-ffi/go-ffi";
+    string internal constant DIFF_MODE = "diff";
 
     function getProveWithdrawalTransactionInputs(Types.WithdrawalTransaction memory _tx)
         external
         returns (bytes32, bytes32, bytes32, bytes32, bytes[] memory)
     {
-        string[] memory cmds = new string[](9);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "getProveWithdrawalTransactionInputs";
-        cmds[3] = vm.toString(_tx.nonce);
-        cmds[4] = vm.toString(_tx.sender);
-        cmds[5] = vm.toString(_tx.target);
-        cmds[6] = vm.toString(_tx.value);
-        cmds[7] = vm.toString(_tx.gasLimit);
-        cmds[8] = vm.toString(_tx.data);
+        string[] memory cmds = _newDiffCommand("getProveWithdrawalTransactionInputs", 6);
+        _setCrossDomainArgs(cmds, _tx.nonce, _tx.sender, _tx.target, _tx.value, _tx.gasLimit, _tx.data);
 
-        bytes memory result = vm.ffi(cmds);
-        (
-            bytes32 stateRoot,
-            bytes32 storageRoot,
-            bytes32 outputRoot,
-            bytes32 withdrawalHash,
-            bytes[] memory withdrawalProof
-        ) = abi.decode(result, (bytes32, bytes32, bytes32, bytes32, bytes[]));
-
-        return (stateRoot, storageRoot, outputRoot, withdrawalHash, withdrawalProof);
+        return abi.decode(vm.ffi(cmds), (bytes32, bytes32, bytes32, bytes32, bytes[]));
     }
 
     function hashCrossDomainMessage(
@@ -50,19 +35,10 @@ contract FFIInterface {
         external
         returns (bytes32)
     {
-        string[] memory cmds = new string[](9);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "hashCrossDomainMessage";
-        cmds[3] = vm.toString(_nonce);
-        cmds[4] = vm.toString(_sender);
-        cmds[5] = vm.toString(_target);
-        cmds[6] = vm.toString(_value);
-        cmds[7] = vm.toString(_gasLimit);
-        cmds[8] = vm.toString(_data);
+        string[] memory cmds = _newDiffCommand("hashCrossDomainMessage", 6);
+        _setCrossDomainArgs(cmds, _nonce, _sender, _target, _value, _gasLimit, _data);
 
-        bytes memory result = vm.ffi(cmds);
-        return abi.decode(result, (bytes32));
+        return abi.decode(vm.ffi(cmds), (bytes32));
     }
 
     function hashWithdrawal(
@@ -76,19 +52,10 @@ contract FFIInterface {
         external
         returns (bytes32)
     {
-        string[] memory cmds = new string[](9);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "hashWithdrawal";
-        cmds[3] = vm.toString(_nonce);
-        cmds[4] = vm.toString(_sender);
-        cmds[5] = vm.toString(_target);
-        cmds[6] = vm.toString(_value);
-        cmds[7] = vm.toString(_gasLimit);
-        cmds[8] = vm.toString(_data);
+        string[] memory cmds = _newDiffCommand("hashWithdrawal", 6);
+        _setCrossDomainArgs(cmds, _nonce, _sender, _target, _value, _gasLimit, _data);
 
-        bytes memory result = vm.ffi(cmds);
-        return abi.decode(result, (bytes32));
+        return abi.decode(vm.ffi(cmds), (bytes32));
     }
 
     function hashOutputRootProof(
@@ -100,17 +67,13 @@ contract FFIInterface {
         external
         returns (bytes32)
     {
-        string[] memory cmds = new string[](7);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "hashOutputRootProof";
+        string[] memory cmds = _newDiffCommand("hashOutputRootProof", 4);
         cmds[3] = Strings.toHexString(uint256(_version));
         cmds[4] = Strings.toHexString(uint256(_stateRoot));
         cmds[5] = Strings.toHexString(uint256(_messagePasserStorageRoot));
         cmds[6] = Strings.toHexString(uint256(_latestBlockhash));
 
-        bytes memory result = vm.ffi(cmds);
-        return abi.decode(result, (bytes32));
+        return abi.decode(vm.ffi(cmds), (bytes32));
     }
 
     function hashDepositTransaction(
@@ -125,10 +88,7 @@ contract FFIInterface {
         external
         returns (bytes32)
     {
-        string[] memory cmds = new string[](11);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "hashDepositTransaction";
+        string[] memory cmds = _newDiffCommand("hashDepositTransaction", 8);
         cmds[3] = "0x0000000000000000000000000000000000000000000000000000000000000000";
         cmds[4] = vm.toString(_logIndex);
         cmds[5] = vm.toString(_from);
@@ -138,15 +98,11 @@ contract FFIInterface {
         cmds[9] = vm.toString(_gas);
         cmds[10] = vm.toString(_data);
 
-        bytes memory result = vm.ffi(cmds);
-        return abi.decode(result, (bytes32));
+        return abi.decode(vm.ffi(cmds), (bytes32));
     }
 
     function encodeDepositTransaction(Types.UserDepositTransaction calldata txn) external returns (bytes memory) {
-        string[] memory cmds = new string[](12);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "encodeDepositTransaction";
+        string[] memory cmds = _newDiffCommand("encodeDepositTransaction", 9);
         cmds[3] = vm.toString(txn.from);
         cmds[4] = vm.toString(txn.to);
         cmds[5] = vm.toString(txn.value);
@@ -157,8 +113,7 @@ contract FFIInterface {
         cmds[10] = vm.toString(txn.l1BlockHash);
         cmds[11] = vm.toString(txn.logIndex);
 
-        bytes memory result = vm.ffi(cmds);
-        return abi.decode(result, (bytes));
+        return abi.decode(vm.ffi(cmds), (bytes));
     }
 
     function encodeCrossDomainMessage(
@@ -172,84 +127,93 @@ contract FFIInterface {
         external
         returns (bytes memory)
     {
-        string[] memory cmds = new string[](9);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "encodeCrossDomainMessage";
-        cmds[3] = vm.toString(_nonce);
-        cmds[4] = vm.toString(_sender);
-        cmds[5] = vm.toString(_target);
-        cmds[6] = vm.toString(_value);
-        cmds[7] = vm.toString(_gasLimit);
-        cmds[8] = vm.toString(_data);
+        string[] memory cmds = _newDiffCommand("encodeCrossDomainMessage", 6);
+        _setCrossDomainArgs(cmds, _nonce, _sender, _target, _value, _gasLimit, _data);
 
-        bytes memory result = vm.ffi(cmds);
-        return abi.decode(result, (bytes));
+        return abi.decode(vm.ffi(cmds), (bytes));
     }
 
     function encodeSuperRootProof(Types.SuperRootProof calldata proof) external returns (bytes memory) {
-        string[] memory cmds = new string[](4);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "encodeSuperRootProof";
+        string[] memory cmds = _newDiffCommand("encodeSuperRootProof", 1);
         cmds[3] = vm.toString(abi.encode(proof));
 
-        bytes memory result = vm.ffi(cmds);
-        return abi.decode(result, (bytes));
+        return abi.decode(vm.ffi(cmds), (bytes));
     }
 
     function hashSuperRootProof(Types.SuperRootProof calldata proof) external returns (bytes32) {
-        string[] memory cmds = new string[](4);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "hashSuperRootProof";
+        string[] memory cmds = _newDiffCommand("hashSuperRootProof", 1);
         cmds[3] = vm.toString(abi.encode(proof));
 
-        bytes memory result = vm.ffi(cmds);
-        return abi.decode(result, (bytes32));
+        return abi.decode(vm.ffi(cmds), (bytes32));
     }
 
     function decodeVersionedNonce(uint256 nonce) external returns (uint256, uint256) {
-        string[] memory cmds = new string[](4);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "decodeVersionedNonce";
+        string[] memory cmds = _newDiffCommand("decodeVersionedNonce", 1);
         cmds[3] = vm.toString(nonce);
 
-        bytes memory result = vm.ffi(cmds);
-        return abi.decode(result, (uint256, uint256));
+        return abi.decode(vm.ffi(cmds), (uint256, uint256));
     }
 
     function getMerkleTrieFuzzCase(string memory variant)
         external
         returns (bytes32, bytes memory, bytes memory, bytes[] memory)
     {
-        string[] memory cmds = new string[](3);
-        cmds[0] = "./scripts/go-ffi/go-ffi";
-        cmds[1] = "trie";
-        cmds[2] = variant;
+        string[] memory cmds = _newCommand("trie", variant, 0);
 
         return abi.decode(vm.ffi(cmds), (bytes32, bytes, bytes, bytes[]));
     }
 
     function encodeScalarEcotone(uint32 _basefeeScalar, uint32 _blobbasefeeScalar) external returns (bytes32) {
-        string[] memory cmds = new string[](5);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "encodeScalarEcotone";
+        string[] memory cmds = _newDiffCommand("encodeScalarEcotone", 2);
         cmds[3] = vm.toString(_basefeeScalar);
         cmds[4] = vm.toString(_blobbasefeeScalar);
-        bytes memory result = vm.ffi(cmds);
-        return abi.decode(result, (bytes32));
+
+        return abi.decode(vm.ffi(cmds), (bytes32));
     }
 
     function decodeScalarEcotone(bytes32 _scalar) external returns (uint32, uint32) {
-        string[] memory cmds = new string[](4);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "decodeScalarEcotone";
+        string[] memory cmds = _newDiffCommand("decodeScalarEcotone", 1);
         cmds[3] = vm.toString(_scalar);
-        bytes memory result = vm.ffi(cmds);
-        return abi.decode(result, (uint32, uint32));
+
+        return abi.decode(vm.ffi(cmds), (uint32, uint32));
+    }
+
+    function _newDiffCommand(string memory _variant, uint256 _argCount) private pure returns (string[] memory cmds) {
+        return _newCommand(DIFF_MODE, _variant, _argCount);
+    }
+
+    function _newCommand(
+        string memory _mode,
+        string memory _variant,
+        uint256 _argCount
+    )
+        private
+        pure
+        returns (string[] memory cmds)
+    {
+        cmds = new string[](3 + _argCount);
+        cmds[0] = GO_FFI;
+        cmds[1] = _mode;
+        cmds[2] = _variant;
+    }
+
+    function _setCrossDomainArgs(
+        string[] memory _cmds,
+        uint256 _nonce,
+        address _sender,
+        address _target,
+        uint256 _value,
+        uint256 _gasLimit,
+        bytes memory _data
+    )
+        private
+        pure
+    {
+        _cmds[3] = vm.toString(_nonce);
+        _cmds[4] = vm.toString(_sender);
+        _cmds[5] = vm.toString(_target);
+        _cmds[6] = vm.toString(_value);
+        _cmds[7] = vm.toString(_gasLimit);
+        _cmds[8] = vm.toString(_data);
     }
 }

--- a/test/setup/FeatureFlags.sol
+++ b/test/setup/FeatureFlags.sol
@@ -6,39 +6,16 @@ import { Vm } from "lib/forge-std/src/Vm.sol";
 // Interfaces
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 
-/// @notice FeatureFlags manages the feature bitmap by either direct user input or via environment
-///         variables.
+/// @notice Provides helpers for checking SystemConfig-gated test behavior.
 abstract contract FeatureFlags {
-    /// @notice The address of the foundry Vm contract.
     Vm private constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
-    /// @notice The development feature bitmap.
-    bytes32 internal devFeatureBitmap;
+    ISystemConfig private sysCfg;
 
-    /// @notice The address of the SystemConfig contract.
-    ISystemConfig internal sysCfg;
-
-    /// @notice Sets the address of the SystemConfig contract.
-    /// @param _sysCfg The address of the SystemConfig contract.
-    function setSystemConfig(ISystemConfig _sysCfg) public {
+    function setSystemConfig(ISystemConfig _sysCfg) internal {
         sysCfg = _sysCfg;
     }
 
-    /// @notice Enables a feature.
-    /// @param _feature The feature to set.
-    function setDevFeatureEnabled(bytes32 _feature) public {
-        devFeatureBitmap |= _feature;
-    }
-
-    /// @notice Disables a feature.
-    /// @param _feature The feature to set.
-    function setDevFeatureDisabled(bytes32 _feature) public {
-        devFeatureBitmap &= ~_feature;
-    }
-
-    /// @notice Checks if a system feature is enabled.
-    /// @param _feature The feature to check.
-    /// @return True if the feature is enabled, false otherwise.
     function isSysFeatureEnabled(bytes32 _feature) public view returns (bool) {
         return sysCfg.isFeatureEnabled(_feature);
     }

--- a/test/setup/ForkLive.s.sol
+++ b/test/setup/ForkLive.s.sol
@@ -3,9 +3,6 @@ pragma solidity ^0.8.0;
 
 import { console2 as console } from "lib/forge-std/src/console2.sol";
 import { Script } from "lib/forge-std/src/Script.sol";
-import { StdAssertions } from "lib/forge-std/src/StdAssertions.sol";
-
-import { FeatureFlags } from "test/setup/FeatureFlags.sol";
 
 // Scripts
 import { Artifacts } from "scripts/Artifacts.s.sol";
@@ -15,21 +12,16 @@ import { Config } from "scripts/libraries/Config.sol";
 
 // Libraries
 import { GameTypes } from "src/libraries/bridge/Types.sol";
-import { Claim } from "src/libraries/bridge/LibUDT.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { Types } from "scripts/libraries/Types.sol";
 
 // Interfaces
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IDisputeGameFactory } from "interfaces/L1/proofs/IDisputeGameFactory.sol";
-import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
 import { IAggregateVerifier } from "interfaces/L1/proofs/IAggregateVerifier.sol";
-import { IAggregateVerifier } from "interfaces/L1/proofs/IAggregateVerifier.sol";
-import { IDelayedWETH } from "interfaces/L1/proofs/IDelayedWETH.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-import { IAnchorStateRegistry } from "interfaces/L1/proofs/IAnchorStateRegistry.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 
@@ -43,12 +35,15 @@ import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 ///         `forkSystemAddresses`.
 ///         This contract must not have constructor logic because it is set into state using `etch`.
 
-contract ForkLive is Script, StdAssertions, FeatureFlags {
+contract ForkLive is Script {
     DeployConfig internal constant cfg =
         DeployConfig(address(uint160(uint256(keccak256(abi.encode("optimism.deployconfig"))))));
 
     Artifacts internal constant artifacts =
         Artifacts(address(uint160(uint256(keccak256(abi.encode("optimism.artifacts"))))));
+
+    SystemDeploy internal constant deploy =
+        SystemDeploy(address(uint160(uint256(keccak256(abi.encode("optimism.deploy"))))));
 
     bool public useOpsRepo;
 
@@ -98,22 +93,15 @@ contract ForkLive is Script, StdAssertions, FeatureFlags {
         useOpsRepo = bytes(superchainOpsAllocsPath).length > 0;
         if (useOpsRepo) {
             console.log("ForkLive: loading state from %s", superchainOpsAllocsPath);
-            // Set the resultant state from the superchain ops repo upgrades.
-            // The allocs are generated when simulating an upgrade task that runs vm.dumpState.
-            // These allocs represent the state of the EVM after the upgrade has been simulated.
+            // Load the simulated post-upgrade state before deriving implementation addresses.
             vm.loadAllocs(superchainOpsAllocsPath);
-            // Next, fetch the addresses from the configured fork entrypoints. This function uses a local EVM
-            // to retrieve implementation addresses by reading from the live proxy addresses.
-            // Setting the allocs first ensures the correct implementation addresses are retrieved.
-            _readForkAddresses();
-        } else {
-            // Read the live system and save the addresses to the Artifacts contract.
-            _readForkAddresses();
-            // Now deploy the updated implementations of the contracts.
+        }
+
+        _readForkAddresses();
+        if (!useOpsRepo) {
             _deployNewImplementations();
         }
 
-        // Now upgrade the contracts (if the config is set to do so)
         if (useOpsRepo) {
             console.log("ForkLive: using ops repo to upgrade");
         } else if (cfg.useUpgradedFork()) {
@@ -189,17 +177,15 @@ contract ForkLive is Script, StdAssertions, FeatureFlags {
     /// @notice Calls to the SystemDeploy.s.sol contract etched by Setup.sol to a deterministic address, sets up the
     /// environment, and deploys new implementations.
     function _deployNewImplementations() internal {
-        SystemDeploy deploy = SystemDeploy(address(uint160(uint256(keccak256(abi.encode("optimism.deploy"))))));
         deploy.deployImplementations();
     }
 
     /// @notice Performs a script-level upgrade without a manager delegatecall.
     /// @param _upgrader The address of the OP Chain ProxyAdmin owner to use for the chain upgrade.
-    function _doUpgrade(address _upgrader) internal {
+    /// @param _systemConfigProxy The OP Chain SystemConfig proxy to upgrade.
+    function _doUpgrade(address _upgrader, ISystemConfig _systemConfigProxy) internal {
         SystemDeploy systemDeploy = new SystemDeploy();
         Types.Implementations memory implementations = _latestImplementations();
-
-        ISystemConfig systemConfigProxy = ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy"));
 
         ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));
         IProxyAdmin superchainProxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig)));
@@ -224,7 +210,7 @@ contract ForkLive is Script, StdAssertions, FeatureFlags {
                 saveArtifacts: false,
                 superchainConfigProxy: ISuperchainConfig(address(0)),
                 implementations: implementations,
-                systemConfigProxy: systemConfigProxy
+                systemConfigProxy: _systemConfigProxy
             })
         );
     }
@@ -237,43 +223,33 @@ contract ForkLive is Script, StdAssertions, FeatureFlags {
         address upgrader = proxyAdmin.owner();
         vm.label(upgrader, "ProxyAdmin Owner");
 
-        // Run past upgrades depending on network.
-        if (block.chainid == 1) {
-            // Mainnet
-            // This is empty because the block number in the justfile is after the most recent upgrade so there are no
-            // past upgrades to run.
-        } else {
+        if (block.chainid != 1) {
             revert UnsupportedChainId();
         }
 
-        // Current upgrade.
-        _doUpgrade(upgrader);
+        _doUpgrade(upgrader, systemConfig);
 
         console.log("ForkLive: Saving newly deployed contracts");
 
         // A new ASR and new dispute games were deployed, so we need to update them
         IDisputeGameFactory disputeGameFactory =
             IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
-        IDisputeGame av = disputeGameFactory.gameImpls(GameTypes.AGGREGATE_VERIFIER);
-        artifacts.save("AggregateVerifier", address(av));
+        IAggregateVerifier aggregateVerifier =
+            IAggregateVerifier(address(disputeGameFactory.gameImpls(GameTypes.AGGREGATE_VERIFIER)));
+        artifacts.save("AggregateVerifier", address(aggregateVerifier));
 
-        IAnchorStateRegistry newAnchorStateRegistry = av.anchorStateRegistry();
-        artifacts.save("AnchorStateRegistryProxy", address(newAnchorStateRegistry));
-
-        // Get the lockbox address from the portal, and save it
         IOptimismPortal2 portal = IOptimismPortal2(artifacts.mustGetAddress("OptimismPortalProxy"));
         address lockboxAddress = address(portal.ethLockbox());
         artifacts.save("ETHLockboxProxy", lockboxAddress);
 
-        // Get the new DelayedWETH address and save it (might be a new proxy).
-        IDelayedWETH newDelayedWeth = IAggregateVerifier(address(av)).DELAYED_WETH();
-        artifacts.save("DelayedWETHProxy", address(newDelayedWeth));
-        artifacts.save("DelayedWETHImpl", EIP1967Helper.getImplementation(address(newDelayedWeth)));
+        GameAddresses memory gameAddresses = _aggregateVerifierAddresses(aggregateVerifier);
+        artifacts.save("AnchorStateRegistryProxy", gameAddresses.anchorStateRegistry);
+        artifacts.save("DelayedWETHProxy", gameAddresses.weth);
+        artifacts.save("DelayedWETHImpl", EIP1967Helper.getImplementation(gameAddresses.weth));
     }
 
     /// @notice Returns the latest implementation set saved by deployImplementations.
     function _latestImplementations() internal view returns (Types.Implementations memory) {
-        SystemDeploy deploy = SystemDeploy(address(uint160(uint256(keccak256(abi.encode("optimism.deploy"))))));
         return deploy.getImplementations();
     }
 

--- a/test/setup/Setup.sol
+++ b/test/setup/Setup.sol
@@ -8,6 +8,7 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { FeatureFlags } from "test/setup/FeatureFlags.sol";
 
 // Scripts
+import { DeployConfig } from "scripts/deploy/DeployConfig.s.sol";
 import { SystemDeploy } from "scripts/deploy/SystemDeploy.s.sol";
 import { ForkLive } from "test/setup/ForkLive.s.sol";
 import { LATEST_FORK } from "scripts/libraries/Config.sol";
@@ -48,11 +49,10 @@ import { IGasPriceOracle } from "interfaces/L2/IGasPriceOracle.sol";
 import { IL1Block } from "interfaces/L2/IL1Block.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IWETH98 } from "interfaces/universal/IWETH98.sol";
-import { IVerifier } from "interfaces/L1/proofs/IVerifier.sol";
 import { TEEProverRegistry } from "src/L1/proofs/tee/TEEProverRegistry.sol";
 
 /// @title Setup
-/// @dev This contact is responsible for setting up the contracts in state. It currently
+/// @dev This contract is responsible for setting up the contracts in state. It currently
 ///      sets the L2 contracts directly at the predeploy addresses instead of setting them
 ///      up behind proxies. In the future we will migrate to importing the genesis JSON
 ///      file that is created to set up the L2 contracts instead of setting them up manually.
@@ -123,7 +123,6 @@ abstract contract Setup is FeatureFlags {
     IGasPriceOracle gasPriceOracle = IGasPriceOracle(Predeploys.GAS_PRICE_ORACLE);
     IL1Block l1Block = IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES);
     IWETH98 weth = IWETH98(payable(Predeploys.WETH));
-    IVerifier aggregateVerifier;
     TEEProverRegistry teeProverRegistry;
 
     /// @notice Indicates whether a test is running against a forked production network.
@@ -131,13 +130,7 @@ abstract contract Setup is FeatureFlags {
         return Config.forkTest();
     }
 
-    /// @notice Indicates whether a test is running against a forked network that is OP.
-    function isOpFork() public view returns (bool) {
-        string memory opChain = Config.forkOpChain();
-        return keccak256(bytes(opChain)) == keccak256(bytes("op"));
-    }
-
-    /// @dev Deploys either the SystemDeploy.s.sol or Fork.s.sol contract, by fetching the bytecode dynamically using
+    /// @dev Deploys the SystemDeploy and ForkLive setup contracts by fetching the bytecode dynamically using
     ///      `vm.getDeployedCode()` and etching it into the state.
     ///      This enables us to avoid including the bytecode of those contracts in the bytecode of this contract.
     ///      If the bytecode of those contracts was included in this contract, then it will double
@@ -147,7 +140,8 @@ abstract contract Setup is FeatureFlags {
     function setUp() public virtual {
         console.log("Setup: L1 setup start!");
 
-        if (isForkTest()) {
+        bool forkTest = isForkTest();
+        if (forkTest) {
             vm.createSelectFork(Config.forkRpcUrl(), Config.forkBlockNumber());
             console.log("Setup: fork selected!");
             require(
@@ -164,15 +158,13 @@ abstract contract Setup is FeatureFlags {
 
         console.log("Setup: L1 setup done!");
 
-        if (isForkTest()) {
-            // Return early if this is a fork test as we don't need to setup L2
+        if (forkTest) {
             console.log("Setup: fork test detected, skipping L2 genesis generation");
             return;
         }
 
         console.log("Setup: L2 setup start!");
-        vm.etch(address(l2Genesis), vm.getDeployedCode("L2Genesis.s.sol:L2Genesis"));
-        vm.allowCheatcodes(address(l2Genesis));
+        DeployUtils.etchLabelAndAllowCheatcodes({ _etchTo: address(l2Genesis), _cname: "L2Genesis" });
         console.log("Setup: L2 setup done!");
     }
 
@@ -213,13 +205,10 @@ abstract contract Setup is FeatureFlags {
     /// @dev Sets up the L1 contracts.
     function L1() public {
         console.log("Setup: creating L1 deployments");
-        // Set the deterministic deployer in state to ensure that it is there
-        vm.etch(
-            0x4e59b44847b379578588920cA78FbF26c0B4956C,
-            hex"7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3"
-        );
+        vm.etch(Preinstalls.DeterministicDeploymentProxy, Preinstalls.DeterministicDeploymentProxyCode);
 
-        if (isForkTest()) {
+        bool forkTest = isForkTest();
+        if (forkTest) {
             forkLive.run();
         } else {
             deploy.run();
@@ -231,7 +220,7 @@ abstract contract Setup is FeatureFlags {
 
         // Only skip ETHLockbox assignment if we're in a fork test with non-upgraded fork
         // TODO(#14691): Remove this check once Upgrade 15 is deployed on Mainnet.
-        if (!isForkTest() || deploy.cfg().useUpgradedFork()) {
+        if (!forkTest || deploy.cfg().useUpgradedFork()) {
             // Here we use getAddress instead of mustGetAddress because some chains might not have
             // the ETHLockbox proxy. Chains that don't have the ETHLockbox proxy will just return
             // address(0) and cause a revert if we use mustGetAddress.
@@ -256,7 +245,6 @@ abstract contract Setup is FeatureFlags {
         proxyAdminOwner = proxyAdmin.owner();
         superchainProxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig)));
         superchainProxyAdminOwner = superchainProxyAdmin.owner();
-        aggregateVerifier = IVerifier(artifacts.getAddress("AggregateVerifier"));
         teeProverRegistry = TEEProverRegistry(artifacts.getAddress("TEEProverRegistry"));
 
         console.log("Setup: registered L1 deployments");
@@ -274,28 +262,29 @@ abstract contract Setup is FeatureFlags {
         }
 
         console.log("Setup: creating L2 genesis with fork %s", l2Fork.toString());
+        DeployConfig cfg = deploy.cfg();
         l2Genesis.run(
             L2Genesis.Input({
-                l1ChainID: deploy.cfg().l1ChainId(),
-                l2ChainID: deploy.cfg().l2ChainId(),
+                l1ChainID: cfg.l1ChainId(),
+                l2ChainID: cfg.l2ChainId(),
                 l1CrossDomainMessengerProxy: payable(address(l1CrossDomainMessenger)),
                 l1StandardBridgeProxy: payable(address(l1StandardBridge)),
                 l1ERC721BridgeProxy: payable(address(l1ERC721Bridge)),
-                opChainProxyAdminOwner: deploy.cfg().proxyAdminOwner(),
-                sequencerFeeVaultRecipient: deploy.cfg().sequencerFeeVaultRecipient(),
-                sequencerFeeVaultMinimumWithdrawalAmount: deploy.cfg().sequencerFeeVaultMinimumWithdrawalAmount(),
-                sequencerFeeVaultWithdrawalNetwork: deploy.cfg().sequencerFeeVaultWithdrawalNetwork(),
-                baseFeeVaultRecipient: deploy.cfg().baseFeeVaultRecipient(),
-                baseFeeVaultMinimumWithdrawalAmount: deploy.cfg().baseFeeVaultMinimumWithdrawalAmount(),
-                baseFeeVaultWithdrawalNetwork: deploy.cfg().baseFeeVaultWithdrawalNetwork(),
-                l1FeeVaultRecipient: deploy.cfg().l1FeeVaultRecipient(),
-                l1FeeVaultMinimumWithdrawalAmount: deploy.cfg().l1FeeVaultMinimumWithdrawalAmount(),
-                l1FeeVaultWithdrawalNetwork: deploy.cfg().l1FeeVaultWithdrawalNetwork(),
-                operatorFeeVaultRecipient: deploy.cfg().operatorFeeVaultRecipient(),
-                operatorFeeVaultMinimumWithdrawalAmount: deploy.cfg().operatorFeeVaultMinimumWithdrawalAmount(),
-                operatorFeeVaultWithdrawalNetwork: deploy.cfg().operatorFeeVaultWithdrawalNetwork(),
+                opChainProxyAdminOwner: cfg.proxyAdminOwner(),
+                sequencerFeeVaultRecipient: cfg.sequencerFeeVaultRecipient(),
+                sequencerFeeVaultMinimumWithdrawalAmount: cfg.sequencerFeeVaultMinimumWithdrawalAmount(),
+                sequencerFeeVaultWithdrawalNetwork: cfg.sequencerFeeVaultWithdrawalNetwork(),
+                baseFeeVaultRecipient: cfg.baseFeeVaultRecipient(),
+                baseFeeVaultMinimumWithdrawalAmount: cfg.baseFeeVaultMinimumWithdrawalAmount(),
+                baseFeeVaultWithdrawalNetwork: cfg.baseFeeVaultWithdrawalNetwork(),
+                l1FeeVaultRecipient: cfg.l1FeeVaultRecipient(),
+                l1FeeVaultMinimumWithdrawalAmount: cfg.l1FeeVaultMinimumWithdrawalAmount(),
+                l1FeeVaultWithdrawalNetwork: cfg.l1FeeVaultWithdrawalNetwork(),
+                operatorFeeVaultRecipient: cfg.operatorFeeVaultRecipient(),
+                operatorFeeVaultMinimumWithdrawalAmount: cfg.operatorFeeVaultMinimumWithdrawalAmount(),
+                operatorFeeVaultWithdrawalNetwork: cfg.operatorFeeVaultWithdrawalNetwork(),
                 fork: uint256(l2Fork),
-                fundDevAccounts: deploy.cfg().fundDevAccounts()
+                fundDevAccounts: cfg.fundDevAccounts()
             })
         );
 


### PR DESCRIPTION
### What changed? Why?

Simplifies test setup helpers and L2 genesis assertions by removing unused setup surface area, consolidating repeated FFI command construction, and tightening setup script helpers.

Also trims unused event declarations/imports and reuses deploy config/local variables to reduce repetition.

### Notes to reviewers

- Test-only cleanup; no production contract changes.
- L2 genesis coverage now includes fee vault assertions and Jovian fork state.