### PR TITLE
chore(tests): simplify universal tests

### DIFF
--- a/test/universal/Counter.sol
+++ b/test/universal/Counter.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.25;
 
 contract Counter {
     address internal immutable OWNER;
-    uint256 public count = 0;
+    uint256 public count;
 
     constructor(address owner) {
         OWNER = owner;
@@ -16,7 +16,7 @@ contract Counter {
     }
 
     function incrementPayable() external payable {
-        require(msg.value != 0, "value must be greater than 0");
+        require(msg.value > 0, "value must be greater than 0");
         count += 1;
     }
 }

--- a/test/universal/CrossDomainMessenger.t.sol
+++ b/test/universal/CrossDomainMessenger.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.15;
 // Testing utilities
 import { Test } from "lib/forge-std/src/Test.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
+import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
 
 // Libraries
 import { Math } from "lib/openzeppelin-contracts/contracts/utils/math/Math.sol";
@@ -17,9 +18,9 @@ import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.s
 /// @notice A mock external contract called via the SafeCall inside the CrossDomainMessenger's
 ///         `relayMessage` function.
 contract CrossDomainMessenger_ExternalRelay_Harness is Test {
-    address internal op;
+    address internal immutable op;
     address internal fuzzedSender;
-    IL1CrossDomainMessenger internal l1CrossDomainMessenger;
+    IL1CrossDomainMessenger internal immutable l1CrossDomainMessenger;
 
     event FailedRelayedMessage(bytes32 indexed msgHash);
 
@@ -28,19 +29,12 @@ contract CrossDomainMessenger_ExternalRelay_Harness is Test {
         op = _op;
     }
 
-    /// @notice Internal helper function to relay a message and perform assertions.
-    function _internalRelay(address _innerSender) internal {
+    function _internalRelay(address _innerSender, bytes memory _callMessage) internal {
         address initialSender = l1CrossDomainMessenger.xDomainMessageSender();
-
-        bytes memory callMessage = getCallData();
+        uint256 nonce = Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 });
 
         bytes32 hash = Hashing.hashCrossDomainMessage({
-            _nonce: Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
-            _sender: _innerSender,
-            _target: address(this),
-            _value: 0,
-            _gasLimit: 0,
-            _data: callMessage
+            _nonce: nonce, _sender: _innerSender, _target: address(this), _value: 0, _gasLimit: 0, _data: _callMessage
         });
 
         vm.expectEmit(true, true, true, true);
@@ -48,12 +42,12 @@ contract CrossDomainMessenger_ExternalRelay_Harness is Test {
 
         vm.prank(address(op));
         l1CrossDomainMessenger.relayMessage({
-            _nonce: Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
+            _nonce: nonce,
             _sender: _innerSender,
             _target: address(this),
             _value: 0,
             _minGasLimit: 0,
-            _message: callMessage
+            _message: _callMessage
         });
 
         assertTrue(l1CrossDomainMessenger.failedMessages(hash));
@@ -63,21 +57,21 @@ contract CrossDomainMessenger_ExternalRelay_Harness is Test {
 
     /// @notice externalCallWithMinGas is called by the CrossDomainMessenger.
     function externalCallWithMinGas() external payable {
+        bytes memory callMessage = getCallData();
+
         for (uint256 i = 0; i < 10; i++) {
             address _innerSender;
             unchecked {
                 _innerSender = address(uint160(uint256(uint160(fuzzedSender)) + i));
             }
-            _internalRelay(_innerSender);
+            _internalRelay(_innerSender, callMessage);
         }
     }
 
-    /// @notice Helper function to get the callData for an `externalCallWithMinGas
     function getCallData() public pure returns (bytes memory) {
         return abi.encodeCall(CrossDomainMessenger_ExternalRelay_Harness.externalCallWithMinGas, ());
     }
 
-    /// @notice Helper function to set the fuzzed sender
     function setFuzzedSender(address _fuzzedSender) public {
         fuzzedSender = _fuzzedSender;
     }
@@ -86,14 +80,25 @@ contract CrossDomainMessenger_ExternalRelay_Harness is Test {
 /// @title CrossDomainMessenger_TestInit
 /// @notice Reusable test initialization for `CrossDomainMessenger` tests.
 abstract contract CrossDomainMessenger_TestInit is CommonTest {
-    // Storage slot of the l2Sender
-    uint256 constant senderSlotIndex = 50;
-
     CrossDomainMessenger_ExternalRelay_Harness public er;
 
     function setUp() public override {
         super.setUp();
         er = new CrossDomainMessenger_ExternalRelay_Harness(l1CrossDomainMessenger, address(optimismPortal2));
+    }
+
+    function _versionedNonce(uint16 _version) internal pure returns (uint256) {
+        return Encoding.encodeVersionedNonce({ _nonce: 0, _version: _version });
+    }
+
+    function _setPortalL2Sender(address _sender) internal {
+        StorageSlot memory senderSlot = ForgeArtifacts.getSlot("OptimismPortal2", "l2Sender");
+        vm.store(address(optimismPortal2), bytes32(senderSlot.slot), bytes32(abi.encode(_sender)));
+    }
+
+    function _assertMessageStatus(bytes32 _hash, bool _successful, bool _failed) internal view {
+        assertEq(l1CrossDomainMessenger.successfulMessages(_hash), _successful);
+        assertEq(l1CrossDomainMessenger.failedMessages(_hash), _failed);
     }
 }
 
@@ -118,32 +123,20 @@ contract CrossDomainMessenger_RelayMessage_Test is CrossDomainMessenger_TestInit
         vm.expectCall(target, callMessage);
 
         uint64 gasLimit = uint64(bound(_gasLimit, 0, 30_000_000));
+        uint256 nonce = _versionedNonce(1);
 
         bytes32 hash = Hashing.hashCrossDomainMessage({
-            _nonce: Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
-            _sender: sender,
-            _target: target,
-            _value: 0,
-            _gasLimit: gasLimit,
-            _data: callMessage
+            _nonce: nonce, _sender: sender, _target: target, _value: 0, _gasLimit: gasLimit, _data: callMessage
         });
 
-        // Set the value of `op.l2Sender()` to be the L2 Cross Domain Messenger.
-        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+        _setPortalL2Sender(sender);
         vm.prank(address(optimismPortal2));
         l1CrossDomainMessenger.relayMessage({
-            _nonce: Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
-            _sender: sender,
-            _target: target,
-            _value: 0,
-            _minGasLimit: gasLimit,
-            _message: callMessage
+            _nonce: nonce, _sender: sender, _target: target, _value: 0, _minGasLimit: gasLimit, _message: callMessage
         });
 
-        assertTrue(l1CrossDomainMessenger.successfulMessages(hash));
-        assertEq(l1CrossDomainMessenger.failedMessages(hash), false);
+        _assertMessageStatus(hash, true, false);
 
-        // Ensures that the `xDomainMsgSender` is set back to `Predeploys.L2_CROSS_DOMAIN_MESSENGER`
         vm.expectRevert("CrossDomainMessenger: xDomainMessageSender is not set");
         l1CrossDomainMessenger.xDomainMessageSender();
     }
@@ -153,6 +146,40 @@ contract CrossDomainMessenger_RelayMessage_Test is CrossDomainMessenger_TestInit
 ///      L2 CrossDomainMessenger contracts. For simplicity, we use the L1 Messenger as the test
 ///      contract.
 contract CrossDomainMessenger_BaseGas_Test is CommonTest {
+    function _totalMessageSize(uint256 _messageLength) internal view returns (uint64) {
+        return uint64(_messageLength + l1CrossDomainMessenger.ENCODING_OVERHEAD());
+    }
+
+    function _executionGas(uint32 _minGasLimit) internal view returns (uint64) {
+        return uint64(
+            l1CrossDomainMessenger.RELAY_CONSTANT_OVERHEAD() + l1CrossDomainMessenger.RELAY_CALL_OVERHEAD()
+                + l1CrossDomainMessenger.RELAY_RESERVED_GAS() + l1CrossDomainMessenger.RELAY_GAS_CHECK_BUFFER()
+                + ((_minGasLimit * l1CrossDomainMessenger.MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR())
+                    / l1CrossDomainMessenger.MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR())
+        );
+    }
+
+    function _floorGas(uint256 _messageLength) internal view returns (uint64) {
+        return l1CrossDomainMessenger.TX_BASE_GAS()
+            + (_totalMessageSize(_messageLength) * l1CrossDomainMessenger.FLOOR_CALLDATA_OVERHEAD());
+    }
+
+    function _executionGasWithOverhead(uint256 _messageLength, uint32 _minGasLimit) internal view returns (uint64) {
+        return l1CrossDomainMessenger.TX_BASE_GAS() + _executionGas(_minGasLimit)
+            + (_totalMessageSize(_messageLength) * l1CrossDomainMessenger.MIN_GAS_CALLDATA_OVERHEAD());
+    }
+
+    function _baseGasMinimum(uint256 _messageLength, uint32 _minGasLimit) internal view returns (uint64) {
+        uint64 totalMessageSize = _totalMessageSize(_messageLength);
+        return l1CrossDomainMessenger.TX_BASE_GAS()
+            + uint64(
+            Math.max(
+            _executionGas(_minGasLimit) + (totalMessageSize * l1CrossDomainMessenger.MIN_GAS_CALLDATA_OVERHEAD()),
+            totalMessageSize * l1CrossDomainMessenger.FLOOR_CALLDATA_OVERHEAD()
+        )
+        );
+    }
+
     /// @notice Ensure that `baseGas` passes for the max value of `_minGasLimit`, this is about
     ///         4 Billion.
     function test_baseGas_succeeds() external view {
@@ -179,50 +206,26 @@ contract CrossDomainMessenger_BaseGas_Test is CommonTest {
 
     /// @notice Test that `baseGas` returns at least the floor cost for calldata
     function test_baseGas_floor_succeeds() external view {
-        // Create a message large enough that the floor cost would be higher than the execution gas
         bytes memory largeMessage = new bytes(100_000);
 
         uint64 baseGasResult = l1CrossDomainMessenger.baseGas(largeMessage, 0);
 
-        // Calculate the expected floor cost
-        uint64 expectedFloorCost = l1CrossDomainMessenger.TX_BASE_GAS()
-            + (uint64(largeMessage.length + l1CrossDomainMessenger.ENCODING_OVERHEAD())
-                * l1CrossDomainMessenger.FLOOR_CALLDATA_OVERHEAD());
-
-        // Verify that the result is at least the floor cost
-        assertTrue(baseGasResult >= expectedFloorCost, "baseGas should return at least the floor cost");
+        assertGe(baseGasResult, _floorGas(largeMessage.length), "baseGas should return at least the floor cost");
     }
 
     /// @notice Test that `baseGas` returns the execution gas when it's higher than the floor cost
     function test_baseGas_executionGas_succeeds() external view {
-        // Create a small message where execution gas would be higher than floor cost
         bytes memory smallMessage = new bytes(10);
         uint32 highGasLimit = 1_000_000;
 
         uint64 baseGasResult = l1CrossDomainMessenger.baseGas(smallMessage, highGasLimit);
+        uint64 expectedExecutionGasWithOverhead = _executionGasWithOverhead(smallMessage.length, highGasLimit);
 
-        // Calculate the expected floor cost
-        uint64 floorCost = l1CrossDomainMessenger.TX_BASE_GAS()
-            + (uint64(smallMessage.length + l1CrossDomainMessenger.ENCODING_OVERHEAD())
-                * l1CrossDomainMessenger.FLOOR_CALLDATA_OVERHEAD());
-
-        // Calculate the expected execution gas (simplified version of what's in the contract)
-        uint64 executionGas = l1CrossDomainMessenger.RELAY_CONSTANT_OVERHEAD()
-            + l1CrossDomainMessenger.RELAY_CALL_OVERHEAD() + l1CrossDomainMessenger.RELAY_RESERVED_GAS()
-            + l1CrossDomainMessenger.RELAY_GAS_CHECK_BUFFER()
-            + ((highGasLimit * l1CrossDomainMessenger.MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR())
-                / l1CrossDomainMessenger.MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR());
-
-        uint64 expectedExecutionGasWithOverhead = l1CrossDomainMessenger.TX_BASE_GAS() + executionGas
-            + (uint64(smallMessage.length + l1CrossDomainMessenger.ENCODING_OVERHEAD())
-                * l1CrossDomainMessenger.MIN_GAS_CALLDATA_OVERHEAD());
-
-        // Verify that the result is the execution gas (which should be higher than floor cost)
-        assertTrue(
-            baseGasResult >= expectedExecutionGasWithOverhead, "baseGas should return at least the execution gas"
-        );
-        assertTrue(
-            expectedExecutionGasWithOverhead > floorCost, "Execution gas should be higher than floor cost for this test"
+        assertGe(baseGasResult, expectedExecutionGasWithOverhead, "baseGas should return at least the execution gas");
+        assertGt(
+            expectedExecutionGasWithOverhead,
+            _floorGas(smallMessage.length),
+            "Execution gas should be higher than floor cost for this test"
         );
     }
 
@@ -232,31 +235,8 @@ contract CrossDomainMessenger_BaseGas_Test is CommonTest {
     /// @param _minGasLimit The minimum gas limit to test
     function testFuzz_baseGas_maxLogic_succeeds(bytes calldata _message, uint32 _minGasLimit) external view {
         uint64 baseGasResult = l1CrossDomainMessenger.baseGas(_message, _minGasLimit);
+        uint64 expectedMinimum = _baseGasMinimum(_message.length, _minGasLimit);
 
-        // Calculate the expected execution gas
-        uint64 executionGas = l1CrossDomainMessenger.RELAY_CONSTANT_OVERHEAD()
-            + l1CrossDomainMessenger.RELAY_CALL_OVERHEAD() + l1CrossDomainMessenger.RELAY_RESERVED_GAS()
-            + l1CrossDomainMessenger.RELAY_GAS_CHECK_BUFFER()
-            + ((_minGasLimit * l1CrossDomainMessenger.MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR())
-                / l1CrossDomainMessenger.MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR());
-
-        uint64 executionGasWithOverhead = executionGas
-            + (uint64(_message.length + l1CrossDomainMessenger.ENCODING_OVERHEAD())
-                * l1CrossDomainMessenger.MIN_GAS_CALLDATA_OVERHEAD());
-
-        // The result should be at least the maximum of the two calculations
-        uint64 expectedMinimum = uint64(
-            Math.max(
-                executionGasWithOverhead,
-                uint64(_message.length + l1CrossDomainMessenger.ENCODING_OVERHEAD())
-                    * l1CrossDomainMessenger.FLOOR_CALLDATA_OVERHEAD()
-            )
-        );
-        expectedMinimum += l1CrossDomainMessenger.TX_BASE_GAS();
-
-        assertTrue(
-            baseGasResult >= expectedMinimum,
-            "baseGas should return at least the maximum of execution gas and floor cost"
-        );
+        assertGe(baseGasResult, expectedMinimum, "baseGas should return at least the max gas path");
     }
 }

--- a/test/universal/ExtendedPause.t.sol
+++ b/test/universal/ExtendedPause.t.sol
@@ -9,34 +9,35 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 ///         that the behavior is consistent.
 contract ExtendedPause_Test is CommonTest {
     /// @notice Tests that other contracts are paused when the superchain config is paused
-    function test_pause_fullSystem_succeeds() public {
-        assertFalse(superchainConfig.paused(address(0)));
+    function test_pause_fullSystem_succeeds() external {
+        _assertFullSystemPaused(false);
 
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(address(0));
+        _pauseSuperchain();
 
-        // validate the paused state
-        assertTrue(superchainConfig.paused(address(0)));
-        assertTrue(optimismPortal2.paused());
-        assertTrue(l1CrossDomainMessenger.paused());
-        assertTrue(l1StandardBridge.paused());
-        assertTrue(l1ERC721Bridge.paused());
+        _assertFullSystemPaused(true);
     }
 
     /// @notice Tests that other contracts are unpaused when the superchain config is paused and
     ///         then unpaused.
     function test_unpause_fullSystem_succeeds() external {
-        // first use the test above to pause the system
-        test_pause_fullSystem_succeeds();
+        _pauseSuperchain();
 
         vm.prank(superchainConfig.guardian());
         superchainConfig.unpause(address(0));
 
-        // validate the unpaused state
-        assertFalse(superchainConfig.paused(address(0)));
-        assertFalse(optimismPortal2.paused());
-        assertFalse(l1CrossDomainMessenger.paused());
-        assertFalse(l1StandardBridge.paused());
-        assertFalse(l1ERC721Bridge.paused());
+        _assertFullSystemPaused(false);
+    }
+
+    function _pauseSuperchain() internal {
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(address(0));
+    }
+
+    function _assertFullSystemPaused(bool _paused) internal view {
+        assertEq(superchainConfig.paused(address(0)), _paused);
+        assertEq(optimismPortal2.paused(), _paused);
+        assertEq(l1CrossDomainMessenger.paused(), _paused);
+        assertEq(l1StandardBridge.paused(), _paused);
+        assertEq(l1ERC721Bridge.paused(), _paused);
     }
 }

--- a/test/universal/MultisigScript.t.sol
+++ b/test/universal/MultisigScript.t.sol
@@ -20,7 +20,7 @@ contract MultisigScriptTest is Test, MultisigScript {
     Vm.Wallet internal wallet3 = vm.createWallet("3");
 
     address internal safe = address(1001);
-    Counter internal counter = new Counter(address(safe));
+    Counter internal counter = new Counter(safe);
 
     /// @dev Controls whether to use hash-based or EIP-712 JSON output. True by default.
     bool internal _useDataHashes = true;
@@ -58,7 +58,7 @@ contract MultisigScriptTest is Test, MultisigScript {
         assertEq(counterValue, 6, "Counter value is not 6");
 
         uint256 counterBalance = address(counter).balance;
-        assertEq(counterBalance, 3 ether, "Counter balance is not 1 ether");
+        assertEq(counterBalance, 3 ether, "Counter balance is not 3 ether");
     }
 
     /// @inheritdoc MultisigScript
@@ -94,12 +94,7 @@ contract MultisigScriptTest is Test, MultisigScript {
 
         Call[] memory calls = new Call[](4);
 
-        calls[0] = Call({
-            operation: Enum.Operation.Call,
-            target: address(counter),
-            data: abi.encodeCall(Counter.increment, ()),
-            value: 0
-        });
+        calls[0] = counterIncrementCall;
 
         // Use multicall to test the delegatecall use case
         calls[1] = Call({
@@ -109,12 +104,7 @@ contract MultisigScriptTest is Test, MultisigScript {
             value: 0
         });
 
-        calls[2] = Call({
-            operation: Enum.Operation.Call,
-            target: address(counter),
-            data: abi.encodeCall(Counter.incrementPayable, ()),
-            value: 1 ether
-        });
+        calls[2] = counterIncrementCallPayable;
 
         calls[3] = Call({
             operation: Enum.Operation.DelegateCall,
@@ -128,12 +118,10 @@ contract MultisigScriptTest is Test, MultisigScript {
 
     /// @inheritdoc MultisigScript
     function _ownerSafe() internal view override returns (address) {
-        return address(safe);
+        return safe;
     }
 
     /// @inheritdoc MultisigScript
-    ///
-    /// @dev Returns `_useDataHashes` which is true by default (hash-based signing).
     function _printDataHashes() internal view override returns (bool) {
         return _useDataHashes;
     }
@@ -145,6 +133,16 @@ contract MultisigScriptTest is Test, MultisigScript {
         return _encodeTransactionData(_ownerSafe(), _buildAggregatedScriptCall({ scriptCalls: _buildCalls() }));
     }
 
+    function _signDigest(Vm.Wallet memory wallet, bytes32 digest) internal returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _lastLoggedBytes() internal returns (bytes memory) {
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        return abi.decode(logs[logs.length - 1].data, (bytes));
+    }
+
     /// @notice Tests that sign() emits the correct data to sign
     function test_sign() external {
         vm.recordLogs();
@@ -152,43 +150,33 @@ contract MultisigScriptTest is Test, MultisigScript {
         vm.prank(wallet1.addr);
         this.sign(new address[](0));
 
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-        bytes memory logged = abi.decode(logs[logs.length - 1].data, (bytes));
+        bytes memory logged = _lastLoggedBytes();
         bytes memory expected = _expectedTxDataForCurrentBuildCalls();
 
-        assertEq(keccak256(logged), keccak256(expected));
+        assertEq(logged, expected);
     }
 
     /// @notice Tests that verify() accepts valid 2-of-2 signatures
     function test_verify_valid_signatures() external {
-        // Two-of-two signatures over the encoded transaction data should verify
         bytes32 digest = keccak256(_expectedTxDataForCurrentBuildCalls());
-        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(wallet1, digest);
-        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(wallet2, digest);
-        bytes memory signatures = abi.encodePacked(r1, s1, v1, r2, s2, v2);
+        bytes memory signatures = abi.encodePacked(_signDigest(wallet1, digest), _signDigest(wallet2, digest));
         verify(new address[](0), signatures);
     }
 
     /// @notice Tests that verify() reverts when given an invalid signature
     function test_verify_reverts_with_invalid_signature() external {
-        // One valid, one invalid should revert
         bytes32 digest = keccak256(_expectedTxDataForCurrentBuildCalls());
-        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(wallet1, digest);
-        bytes memory signatures = abi.encodePacked(r1, s1, v1, bytes32(0), bytes32(0), uint8(27));
-        bytes memory callData = abi.encodeCall(this.verify, (new address[](0), signatures));
-        (bool success, bytes memory ret) = address(this).call(callData);
-        assertFalse(success);
-        assertTrue(ret.length > 0);
+        bytes memory signatures = abi.encodePacked(_signDigest(wallet1, digest), bytes32(0), bytes32(0), uint8(27));
+
+        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
+        this.verify(new address[](0), signatures);
     }
 
     /// @notice Tests that simulate() executes the transaction without broadcasting
     function test_simulate_only() external {
         bytes32 digest = keccak256(_expectedTxDataForCurrentBuildCalls());
-        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(wallet1, digest);
-        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(wallet2, digest);
-        bytes memory signatures = abi.encodePacked(r1, s1, v1, r2, s2, v2);
+        bytes memory signatures = abi.encodePacked(_signDigest(wallet1, digest), _signDigest(wallet2, digest));
 
-        // Simulate should execute successfully and satisfy _postCheck
         simulate(signatures);
     }
 
@@ -196,13 +184,9 @@ contract MultisigScriptTest is Test, MultisigScript {
     ///
     /// @dev Safe is 2/3, but we provide all 3 signatures
     function test_run_with_more_signatures_than_threshold() external {
-        // Sign with all 3 owners (threshold is 2, but we provide 3)
         bytes32 digest = keccak256(_expectedTxDataForCurrentBuildCalls());
-        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(wallet1, digest);
-        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(wallet2, digest);
-        (uint8 v3, bytes32 r3, bytes32 s3) = vm.sign(wallet3, digest);
-
-        bytes memory signatures = abi.encodePacked(r1, s1, v1, r2, s2, v2, r3, s3, v3);
+        bytes memory signatures =
+            abi.encodePacked(_signDigest(wallet1, digest), _signDigest(wallet2, digest), _signDigest(wallet3, digest));
         run(signatures);
     }
 
@@ -217,10 +201,8 @@ contract MultisigScriptTest is Test, MultisigScript {
         vm.prank(wallet1.addr);
         this.sign(new address[](0));
 
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-        bytes memory logged = abi.decode(logs[logs.length - 1].data, (bytes));
+        bytes memory logged = _lastLoggedBytes();
 
-        // Verify the logged data contains EIP-712 JSON structure markers
         string memory loggedStr = string(logged);
         assertTrue(LibString.contains(loggedStr, "EIP712Domain"), "EIP-712 output should contain EIP712Domain");
         assertTrue(LibString.contains(loggedStr, "SafeTx"), "EIP-712 output should contain SafeTx type");
@@ -280,12 +262,24 @@ abstract contract MultisigScriptNestedBase is Test, MultisigScript {
     }
 
     function _assertSignOutput(address[] memory safes, bytes memory dataToSign) internal {
-        bytes memory txData = abi.encodeWithSelector(this.sign.selector, safes);
-        (bool success,) = address(this).call(txData);
-        assertTrue(success);
+        this.sign(safes);
 
+        assertEq(_lastLoggedBytes(), dataToSign);
+    }
+
+    function _signData(Vm.Wallet memory wallet, bytes memory dataToSign) internal returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet, keccak256(dataToSign));
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _approveFrom(address signerSafe, Vm.Wallet memory wallet) internal {
+        (address[] memory safes, bytes memory dataToSign) = _getSignerData(signerSafe);
+        approve(safes, _signData(wallet, dataToSign));
+    }
+
+    function _lastLoggedBytes() internal returns (bytes memory) {
         Vm.Log[] memory logs = vm.getRecordedLogs();
-        assertEq(keccak256(logs[logs.length - 1].data), keccak256(abi.encode(dataToSign)));
+        return abi.decode(logs[logs.length - 1].data, (bytes));
     }
 
     function _signerSafes(address signerSafe) internal view virtual returns (address[] memory safes);
@@ -299,7 +293,7 @@ contract MultisigScriptNestedTest is MultisigScriptNestedBase {
         vm.etch(safe2, safeCode);
         vm.etch(safe3, safeCode);
 
-        nestedCounter = new Counter(address(safe3));
+        nestedCounter = new Counter(safe3);
 
         _setupLeafSafes();
 
@@ -339,55 +333,37 @@ contract MultisigScriptNestedTest is MultisigScriptNestedBase {
 
     /// @notice Tests that approve() succeeds with valid signature from safe1
     function test_approve_safe1() external {
-        (address[] memory safes, bytes memory dataToSign) = _getSignerData(safe1);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(nestedWallet1, keccak256(dataToSign));
-        approve(safes, abi.encodePacked(r, s, v));
+        _approveFrom(safe1, nestedWallet1);
     }
 
     /// @notice Tests that approve() succeeds with valid signature from safe2
     function test_approve_safe2() external {
-        (address[] memory safes, bytes memory dataToSign) = _getSignerData(safe2);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(nestedWallet2, keccak256(dataToSign));
-        approve(safes, abi.encodePacked(r, s, v));
+        _approveFrom(safe2, nestedWallet2);
     }
 
     /// @notice Tests that approve() fails when signature doesn't match the safe
     function test_approve_notOwner() external {
         (, bytes memory dataToSign) = _getSignerData(safe1);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(nestedWallet1, keccak256(dataToSign));
-        (address[] memory safes2,) = _getSignerData(safe2);
+        bytes memory signature = _signData(nestedWallet1, dataToSign);
 
-        bytes memory data = abi.encodeCall(this.approve, (safes2, abi.encodePacked(r, s, v)));
-        (bool success, bytes memory result) = address(this).call(data);
-        assertFalse(success);
-        assertEq(result, abi.encodeWithSignature("Error(string)", "not enough signatures"));
+        vm.expectRevert("not enough signatures");
+        this.approve(_signerSafes(safe2), signature);
     }
 
     /// @notice Tests the full flow: approve from both safes, then run
     function test_run() external {
-        (address[] memory safes1, bytes memory dataToSign1) = _getSignerData(safe1);
-        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(nestedWallet1, keccak256(dataToSign1));
-
-        (address[] memory safes2, bytes memory dataToSign2) = _getSignerData(safe2);
-        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(nestedWallet2, keccak256(dataToSign2));
-
-        approve(safes1, abi.encodePacked(r1, s1, v1));
-        approve(safes2, abi.encodePacked(r2, s2, v2));
+        _approveFrom(safe1, nestedWallet1);
+        _approveFrom(safe2, nestedWallet2);
 
         run("");
     }
 
     /// @notice Tests that run() fails when not all nested safes have approved
     function test_run_notApproved() external {
-        (address[] memory safes1, bytes memory dataToSign) = _getSignerData(safe1);
-        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(nestedWallet1, keccak256(dataToSign));
+        _approveFrom(safe1, nestedWallet1);
 
-        approve(safes1, abi.encodePacked(r1, s1, v1));
-
-        bytes memory data = abi.encodeCall(this.run, (""));
-        (bool success, bytes memory result) = address(this).call(data);
-        assertFalse(success);
-        assertEq(result, abi.encodeWithSignature("Error(string)", "not enough signatures"));
+        vm.expectRevert("not enough signatures");
+        this.run("");
     }
 }
 
@@ -400,7 +376,7 @@ contract MultisigScriptDoubleNestedTest is MultisigScriptNestedBase {
         vm.etch(safe3, safeCode);
         vm.etch(safe4, safeCode);
 
-        nestedCounter = new Counter(address(safe4));
+        nestedCounter = new Counter(safe4);
 
         _setupLeafSafes();
 
@@ -432,43 +408,26 @@ contract MultisigScriptDoubleNestedTest is MultisigScriptNestedBase {
         _assertSignOutput(safes, dataToSign);
     }
 
-    /// @notice Tests the approval flow through all nested levels
-    function test_runInit_double_nested() external {
-        (address[] memory safes1, bytes memory dataToSign1) = _getSignerData(safe1);
-        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(nestedWallet1, keccak256(dataToSign1));
-
-        (address[] memory safes2, bytes memory dataToSign2) = _getSignerData(safe2);
-        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(nestedWallet2, keccak256(dataToSign2));
-
-        approve(safes1, abi.encodePacked(r1, s1, v1));
-        approve(safes2, abi.encodePacked(r2, s2, v2));
+    /// @notice Tests the intermediate approval flow through nested safes
+    function test_approve_double_nested() external {
+        _approveFrom(safe1, nestedWallet1);
+        _approveFrom(safe2, nestedWallet2);
 
         approve(_toArray(safe3), "");
     }
 
     /// @notice Tests that intermediate approve fails when not all leaf safes have approved
     function test_runInit_double_nested_notApproved() external {
-        (address[] memory safes1, bytes memory dataToSign) = _getSignerData(safe1);
-        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(nestedWallet1, keccak256(dataToSign));
+        _approveFrom(safe1, nestedWallet1);
 
-        approve(safes1, abi.encodePacked(r1, s1, v1));
-
-        bytes memory data = abi.encodeCall(this.approve, (_toArray(safe3), ""));
-        (bool success, bytes memory result) = address(this).call(data);
-        assertFalse(success);
-        assertEq(result, abi.encodeWithSignature("Error(string)", "not enough signatures"));
+        vm.expectRevert("not enough signatures");
+        this.approve(_toArray(safe3), "");
     }
 
     /// @notice Tests the full flow: approve from all nested safes, then run
     function test_run_double_nested() external {
-        (address[] memory safes1, bytes memory dataToSign1) = _getSignerData(safe1);
-        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(nestedWallet1, keccak256(dataToSign1));
-
-        (address[] memory safes2, bytes memory dataToSign2) = _getSignerData(safe2);
-        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(nestedWallet2, keccak256(dataToSign2));
-
-        approve(safes1, abi.encodePacked(r1, s1, v1));
-        approve(safes2, abi.encodePacked(r2, s2, v2));
+        _approveFrom(safe1, nestedWallet1);
+        _approveFrom(safe2, nestedWallet2);
         approve(_toArray(safe3), "");
 
         run("");

--- a/test/universal/MultisigScriptDeposit.t.sol
+++ b/test/universal/MultisigScriptDeposit.t.sol
@@ -4,9 +4,10 @@ pragma solidity 0.8.25;
 import { ICBMulticall, Call3Value } from "interfaces/universal/ICBMulticall.sol";
 import { Test } from "lib/forge-std/src/Test.sol";
 import { Vm } from "lib/forge-std/src/Vm.sol";
+import { Bytes } from "src/libraries/Bytes.sol";
 import { Preinstalls } from "src/libraries/Preinstalls.sol";
 
-import { MultisigScriptDeposit } from "scripts/universal/MultisigScriptDeposit.sol";
+import { IOptimismPortal2, MultisigScriptDeposit } from "scripts/universal/MultisigScriptDeposit.sol";
 import { Simulation } from "scripts/universal/Simulation.sol";
 import { IGnosisSafe } from "scripts/universal/IGnosisSafe.sol";
 
@@ -55,21 +56,15 @@ contract MultisigScriptDepositTest is Test, MultisigScriptDeposit {
     MockOptimismPortal internal portal;
     Counter internal l2Counter;
 
-    // Test configuration
-    address internal testL2Target;
     uint64 internal testGasLimit = 200_000;
 
     function() internal view returns (Call3Value[] memory) buildL2CallsInternal;
 
     function setUp() public {
-        // Deploy mock portal
         portal = new MockOptimismPortal();
 
-        // Deploy a counter to use as L2 target (for calldata encoding)
         l2Counter = new Counter(address(this));
-        testL2Target = address(l2Counter);
 
-        // Setup Safe
         vm.etch(safe, Preinstalls.getDeployedCode(Preinstalls.Safe_v130, block.chainid));
         vm.etch(Preinstalls.MultiCall3, Preinstalls.getDeployedCode(Preinstalls.MultiCall3, block.chainid));
         vm.deal(safe, 100 ether);
@@ -114,24 +109,8 @@ contract MultisigScriptDepositTest is Test, MultisigScriptDeposit {
 
         Call[] memory calls = _buildCalls();
 
-        // Should produce exactly one L1 call to the portal
-        assertEq(calls.length, 1, "Should have one L1 call");
-        assertEq(calls[0].target, address(portal), "Target should be portal");
-        assertEq(calls[0].value, 0, "Value should be 0");
-
-        // Decode the depositTransaction call
-        (address to, uint256 value, uint64 gasLimit, bool isCreation, bytes memory data) =
-            _decodeDepositTransaction(calls[0].data);
-
-        assertEq(to, CB_MULTICALL, "L2 target should be CB_MULTICALL");
-        assertEq(value, 0, "Bridged value should be 0");
-        assertEq(gasLimit, testGasLimit, "Gas limit should match");
-        assertFalse(isCreation, "Should not be creation");
-        assertTrue(data.length > 0, "Data should not be empty");
-
-        // Verify the L2 data is an aggregate3Value call
-        bytes4 selector = bytes4(data);
-        assertEq(selector, ICBMulticall.aggregate3Value.selector, "Should be aggregate3Value call");
+        bytes memory l2Data = _assertSinglePortalDeposit(calls, 0);
+        assertEq(bytes4(l2Data), ICBMulticall.aggregate3Value.selector, "Should be aggregate3Value call");
     }
 
     /// @notice Test that multiple L2 calls are batched correctly
@@ -140,28 +119,13 @@ contract MultisigScriptDepositTest is Test, MultisigScriptDeposit {
 
         Call[] memory calls = _buildCalls();
 
-        // Should still produce exactly one L1 call
-        assertEq(calls.length, 1, "Should have one L1 call");
-
-        // Decode and verify
-        (address to, uint256 value, uint64 gasLimit, bool isCreation, bytes memory data) =
-            _decodeDepositTransaction(calls[0].data);
-
-        assertEq(to, CB_MULTICALL, "L2 target should be CB_MULTICALL");
-        assertEq(value, 0, "Bridged value should be 0");
-        assertEq(gasLimit, testGasLimit, "Gas limit should match");
-        assertFalse(isCreation, "Should not be creation");
-
-        // Decode the aggregate3Value call to verify multiple L2 calls are included
-        Call3Value[] memory l2Calls = abi.decode(_stripSelector(data), (Call3Value[]));
+        Call3Value[] memory l2Calls = _decodeAggregate3Value(_assertSinglePortalDeposit(calls, 0));
         assertEq(l2Calls.length, 3, "Should have 3 L2 calls");
 
-        // Verify call parameters are preserved through the wrapping
-        assertEq(l2Calls[0].target, testL2Target, "First call target should be preserved");
-        assertEq(l2Calls[1].target, testL2Target, "Second call target should be preserved");
-        assertEq(l2Calls[2].target, testL2Target, "Third call target should be preserved");
+        assertEq(l2Calls[0].target, address(l2Counter), "First call target should be preserved");
+        assertEq(l2Calls[1].target, address(l2Counter), "Second call target should be preserved");
+        assertEq(l2Calls[2].target, address(l2Counter), "Third call target should be preserved");
 
-        // Verify allowFailure flags are preserved (first two are false, third is true)
         assertFalse(l2Calls[0].allowFailure, "First call allowFailure should be false");
         assertFalse(l2Calls[1].allowFailure, "Second call allowFailure should be false");
         assertTrue(l2Calls[2].allowFailure, "Third call allowFailure should be true (preserved)");
@@ -173,12 +137,7 @@ contract MultisigScriptDepositTest is Test, MultisigScriptDeposit {
 
         Call[] memory calls = _buildCalls();
 
-        // Value should be sum of all L2 call values (1 + 2 + 0.5 = 3.5 ether)
-        assertEq(calls[0].value, 3.5 ether, "L1 call value should be sum of L2 values");
-
-        // Decode and verify bridged value
-        (, uint256 value,,,) = _decodeDepositTransaction(calls[0].data);
-        assertEq(value, 3.5 ether, "Bridged value should be 3.5 ether");
+        _assertSinglePortalDeposit(calls, 3.5 ether);
     }
 
     /// @notice Test that single L2 call still goes through multicall (consistent behavior)
@@ -186,11 +145,9 @@ contract MultisigScriptDepositTest is Test, MultisigScriptDeposit {
         buildL2CallsInternal = _buildSingleL2CallNoValue;
 
         Call[] memory calls = _buildCalls();
-        (,,,, bytes memory data) = _decodeDepositTransaction(calls[0].data);
+        bytes memory l2Data = _assertSinglePortalDeposit(calls, 0);
 
-        // Even single calls should be wrapped in aggregate3Value for consistency
-        bytes4 selector = bytes4(data);
-        assertEq(selector, ICBMulticall.aggregate3Value.selector, "Single call should still use aggregate3Value");
+        assertEq(bytes4(l2Data), ICBMulticall.aggregate3Value.selector, "Single call should still use aggregate3Value");
     }
 
     /// @notice Test the full sign flow with deposit transaction
@@ -198,32 +155,16 @@ contract MultisigScriptDepositTest is Test, MultisigScriptDeposit {
         buildL2CallsInternal = _buildSingleL2CallNoValue;
 
         vm.recordLogs();
-        bytes memory txData = abi.encodeWithSelector(this.sign.selector, new address[](0));
-        vm.prank(wallet1.addr);
-        (bool success,) = address(this).call(txData);
-        assertTrue(success, "Sign should succeed");
+        _signFrom(wallet1.addr);
 
-        // Verify DataToSign event was emitted
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-        bool foundDataToSign = false;
-        for (uint256 i; i < logs.length; i++) {
-            if (logs[i].topics[0] == keccak256("DataToSign(bytes)")) {
-                foundDataToSign = true;
-                break;
-            }
-        }
-        assertTrue(foundDataToSign, "DataToSign event should be emitted");
+        assertEq(_lastLoggedBytes(), _expectedTxDataForCurrentBuildCalls());
     }
 
     /// @notice Test sign flow with ETH value
     function test_sign_depositTransaction_withValue() external {
         buildL2CallsInternal = _buildL2CallsWithValue;
 
-        vm.recordLogs();
-        bytes memory txData = abi.encodeWithSelector(this.sign.selector, new address[](0));
-        vm.prank(wallet1.addr);
-        (bool success,) = address(this).call(txData);
-        assertTrue(success, "Sign with value should succeed");
+        _signFrom(wallet1.addr);
     }
 
     /// @notice Test default _optimismPortal() returns correct address for mainnet
@@ -260,49 +201,75 @@ contract MultisigScriptDepositTest is Test, MultisigScriptDeposit {
     function _buildSingleL2CallNoValue() internal view returns (Call3Value[] memory) {
         Call3Value[] memory calls = new Call3Value[](1);
         calls[0] = Call3Value({
-            target: testL2Target, allowFailure: false, callData: abi.encodeCall(Counter.increment, ()), value: 0
+            target: address(l2Counter), allowFailure: false, callData: abi.encodeCall(Counter.increment, ()), value: 0
         });
         return calls;
     }
 
     function _buildMultipleL2CallsNoValue() internal view returns (Call3Value[] memory) {
+        bytes memory incrementCall = abi.encodeCall(Counter.increment, ());
         Call3Value[] memory calls = new Call3Value[](3);
-        calls[0] = Call3Value({
-            target: testL2Target, allowFailure: false, callData: abi.encodeCall(Counter.increment, ()), value: 0
-        });
-        calls[1] = Call3Value({
-            target: testL2Target, allowFailure: false, callData: abi.encodeCall(Counter.increment, ()), value: 0
-        });
+        calls[0] = Call3Value({ target: address(l2Counter), allowFailure: false, callData: incrementCall, value: 0 });
+        calls[1] = Call3Value({ target: address(l2Counter), allowFailure: false, callData: incrementCall, value: 0 });
         calls[2] = Call3Value({
-            target: testL2Target,
+            target: address(l2Counter),
             allowFailure: true, // Test allowFailure flag preservation
-            callData: abi.encodeCall(Counter.increment, ()),
+            callData: incrementCall,
             value: 0
         });
         return calls;
     }
 
     function _buildL2CallsWithValue() internal view returns (Call3Value[] memory) {
+        bytes memory incrementPayableCall = abi.encodeCall(Counter.incrementPayable, ());
         Call3Value[] memory calls = new Call3Value[](3);
         calls[0] = Call3Value({
-            target: testL2Target,
-            allowFailure: false,
-            callData: abi.encodeCall(Counter.incrementPayable, ()),
-            value: 1 ether
+            target: address(l2Counter), allowFailure: false, callData: incrementPayableCall, value: 1 ether
         });
         calls[1] = Call3Value({
-            target: testL2Target,
-            allowFailure: false,
-            callData: abi.encodeCall(Counter.incrementPayable, ()),
-            value: 2 ether
+            target: address(l2Counter), allowFailure: false, callData: incrementPayableCall, value: 2 ether
         });
         calls[2] = Call3Value({
-            target: testL2Target,
-            allowFailure: false,
-            callData: abi.encodeCall(Counter.incrementPayable, ()),
-            value: 0.5 ether
+            target: address(l2Counter), allowFailure: false, callData: incrementPayableCall, value: 0.5 ether
         });
         return calls;
+    }
+
+    function _assertSinglePortalDeposit(
+        Call[] memory calls,
+        uint256 expectedValue
+    )
+        internal
+        view
+        returns (bytes memory l2Data)
+    {
+        assertEq(calls.length, 1, "Should have one L1 call");
+        assertEq(calls[0].target, address(portal), "Target should be portal");
+        assertEq(calls[0].value, expectedValue, "L1 call value should match bridged value");
+
+        (address to, uint256 value, uint64 gasLimit, bool isCreation, bytes memory data) =
+            _decodeDepositTransaction(calls[0].data);
+
+        assertEq(to, CB_MULTICALL, "L2 target should be CB_MULTICALL");
+        assertEq(value, expectedValue, "Bridged value should match");
+        assertEq(gasLimit, testGasLimit, "Gas limit should match");
+        assertFalse(isCreation, "Should not be creation");
+
+        return data;
+    }
+
+    function _expectedTxDataForCurrentBuildCalls() internal view returns (bytes memory) {
+        return _encodeTransactionData(_ownerSafe(), _buildAggregatedScriptCall({ scriptCalls: _buildCalls() }));
+    }
+
+    function _lastLoggedBytes() internal returns (bytes memory) {
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        return abi.decode(logs[logs.length - 1].data, (bytes));
+    }
+
+    function _signFrom(address signer) internal {
+        vm.prank(signer);
+        this.sign(new address[](0));
     }
 
     /// @notice Decode depositTransaction calldata
@@ -311,19 +278,21 @@ contract MultisigScriptDepositTest is Test, MultisigScriptDeposit {
         pure
         returns (address to, uint256 value, uint64 gasLimit, bool isCreation, bytes memory data)
     {
-        // Skip the 4-byte selector
         bytes memory params = _stripSelector(callData);
+        require(bytes4(callData) == IOptimismPortal2.depositTransaction.selector, "Unexpected deposit selector");
         (to, value, gasLimit, isCreation, data) = abi.decode(params, (address, uint256, uint64, bool, bytes));
+    }
+
+    function _decodeAggregate3Value(bytes memory data) internal pure returns (Call3Value[] memory) {
+        bytes memory params = _stripSelector(data);
+        require(bytes4(data) == ICBMulticall.aggregate3Value.selector, "Unexpected aggregate selector");
+        return abi.decode(params, (Call3Value[]));
     }
 
     /// @notice Strip the 4-byte function selector from calldata
     function _stripSelector(bytes memory data) internal pure returns (bytes memory) {
         require(data.length >= 4, "Data too short");
-        bytes memory result = new bytes(data.length - 4);
-        for (uint256 i = 4; i < data.length; i++) {
-            result[i - 4] = data[i];
-        }
-        return result;
+        return Bytes.slice(data, 4);
     }
 }
 

--- a/test/universal/OptimismMintableERC20.t.sol
+++ b/test/universal/OptimismMintableERC20.t.sol
@@ -11,16 +11,19 @@ import { IERC165 } from "lib/openzeppelin-contracts/contracts/utils/introspectio
 abstract contract OptimismMintableERC20_TestInit is CommonTest {
     event Mint(address indexed account, uint256 amount);
     event Burn(address indexed account, uint256 amount);
+
+    function _bridgeMint(address _to, uint256 _amount) internal {
+        vm.prank(address(l2StandardBridge));
+        L2Token.mint(_to, _amount);
+    }
 }
 
 /// @title OptimismMintableERC20_Permit2_Test
 /// @notice Tests the `permit2` function of the `OptimismMintableERC20` contract.
 contract OptimismMintableERC20_Permit2_Test is OptimismMintableERC20_TestInit {
     function test_permit2_transferFrom_succeeds() external {
-        vm.prank(address(l2StandardBridge));
-        L2Token.mint(alice, 100);
+        _bridgeMint(alice, 100);
 
-        assertEq(L2Token.balanceOf(bob), 0);
         vm.prank(L2Token.PERMIT2());
         L2Token.transferFrom(alice, bob, 100);
         assertEq(L2Token.balanceOf(bob), 100);
@@ -42,14 +45,12 @@ contract OptimismMintableERC20_Mint_Test is OptimismMintableERC20_TestInit {
         vm.expectEmit(true, true, true, true);
         emit Mint(alice, 100);
 
-        vm.prank(address(l2StandardBridge));
-        L2Token.mint(alice, 100);
+        _bridgeMint(alice, 100);
 
         assertEq(L2Token.balanceOf(alice), 100);
     }
 
     function test_mint_notBridge_reverts() external {
-        // NOT the bridge
         vm.expectRevert("OptimismMintableERC20: only bridge can mint and burn");
         vm.prank(address(alice));
         L2Token.mint(alice, 100);
@@ -60,8 +61,7 @@ contract OptimismMintableERC20_Mint_Test is OptimismMintableERC20_TestInit {
 /// @notice Tests the `burn` function of the `OptimismMintableERC20` contract.
 contract OptimismMintableERC20_Burn_Test is OptimismMintableERC20_TestInit {
     function test_burn_succeeds() external {
-        vm.prank(address(l2StandardBridge));
-        L2Token.mint(alice, 100);
+        _bridgeMint(alice, 100);
 
         vm.expectEmit(true, true, true, true);
         emit Burn(alice, 100);
@@ -73,7 +73,6 @@ contract OptimismMintableERC20_Burn_Test is OptimismMintableERC20_TestInit {
     }
 
     function test_burn_notBridge_reverts() external {
-        // NOT the bridge
         vm.expectRevert("OptimismMintableERC20: only bridge can mint and burn");
         vm.prank(address(alice));
         L2Token.burn(alice, 100);
@@ -84,65 +83,19 @@ contract OptimismMintableERC20_Burn_Test is OptimismMintableERC20_TestInit {
 /// @notice Tests the `supportsInterface` function of the `OptimismMintableERC20` contract.
 contract OptimismMintableERC20_SupportsInterface_Test is OptimismMintableERC20_TestInit {
     function test_erc165_supportsInterface_succeeds() external view {
-        // The assertEq calls in this test are comparing the manual calculation of the iface, with
-        // what is returned by the solidity's type().interfaceId, just to be safe.
-        bytes4 iface1 = bytes4(keccak256("supportsInterface(bytes4)"));
-        assertEq(iface1, type(IERC165).interfaceId);
-        assert(L2Token.supportsInterface(iface1));
-
-        bytes4 iface2 = L2Token.l1Token.selector ^ L2Token.mint.selector ^ L2Token.burn.selector;
-        assertEq(iface2, type(ILegacyMintableERC20).interfaceId);
-        assert(L2Token.supportsInterface(iface2));
-
-        bytes4 iface3 =
-            L2Token.remoteToken.selector ^ L2Token.bridge.selector ^ L2Token.mint.selector ^ L2Token.burn.selector;
-        assertEq(iface3, type(IOptimismMintableERC20).interfaceId);
-        assert(L2Token.supportsInterface(iface3));
+        assertTrue(L2Token.supportsInterface(type(IERC165).interfaceId));
+        assertTrue(L2Token.supportsInterface(type(ILegacyMintableERC20).interfaceId));
+        assertTrue(L2Token.supportsInterface(type(IOptimismMintableERC20).interfaceId));
     }
 }
 
-/// @title OptimismMintableERC20_L1Token_Test
-/// @notice Tests the `l1Token` function of the `OptimismMintableERC20` contract.
-contract OptimismMintableERC20_L1Token_Test is OptimismMintableERC20_TestInit {
-    function test_l1Token_succeeds() external view {
-        assertEq(L2Token.l1Token(), address(L1Token));
-    }
-}
-
-/// @title OptimismMintableERC20_L2Bridge_Test
-/// @notice Tests the `l2Bridge` function of the `OptimismMintableERC20` contract.
-contract OptimismMintableERC20_L2Bridge_Test is OptimismMintableERC20_TestInit {
-    function test_l2Bridge_succeeds() external view {
-        assertEq(L2Token.l2Bridge(), address(l2StandardBridge));
-    }
-}
-
-/// @title OptimismMintableERC20_RemoteToken_Test
-/// @notice Tests the `remoteToken` function of the `OptimismMintableERC20` contract.
-contract OptimismMintableERC20_RemoteToken_Test is OptimismMintableERC20_TestInit {
-    function test_remoteToken_succeeds() external view {
-        assertEq(L2Token.remoteToken(), address(L1Token));
-    }
-}
-
-/// @title OptimismMintableERC20_Bridge_Test
-/// @notice Tests the `bridge` function of the `OptimismMintableERC20` contract.
-contract OptimismMintableERC20_Bridge_Test is OptimismMintableERC20_TestInit {
-    function test_bridge_succeeds() external view {
-        assertEq(L2Token.bridge(), address(l2StandardBridge));
-    }
-}
-
-/// @title OptimismMintableERC20_Uncategorized_Test
-/// @notice General tests that are not testing any function directly of the `OptimismMintableERC20`
-///         contract.
-contract OptimismMintableERC20_Uncategorized_Test is OptimismMintableERC20_TestInit {
-    function test_legacy_succeeds() external view {
-        // Getters for the remote token
+/// @title OptimismMintableERC20_Getters_Test
+/// @notice Tests getter and legacy getter functions of the `OptimismMintableERC20` contract.
+contract OptimismMintableERC20_Getters_Test is OptimismMintableERC20_TestInit {
+    function test_getters_succeeds() external view {
         assertEq(L2Token.REMOTE_TOKEN(), address(L1Token));
         assertEq(L2Token.remoteToken(), address(L1Token));
         assertEq(L2Token.l1Token(), address(L1Token));
-        // Getters for the bridge
         assertEq(L2Token.BRIDGE(), address(l2StandardBridge));
         assertEq(L2Token.bridge(), address(l2StandardBridge));
         assertEq(L2Token.l2Bridge(), address(l2StandardBridge));

--- a/test/universal/OptimismMintableERC20Factory.t.sol
+++ b/test/universal/OptimismMintableERC20Factory.t.sol
@@ -20,6 +20,9 @@ abstract contract OptimismMintableERC20Factory_TestInit is CommonTest {
     event StandardL2TokenCreated(address indexed remoteToken, address indexed localToken);
     event OptimismMintableERC20Created(address indexed localToken, address indexed remoteToken, address deployer);
 
+    string internal constant REMOTE_TOKEN_ZERO_REVERT =
+        "OptimismMintableERC20Factory: must provide remote token address";
+
     /// @notice Precalculates the address of the token contract.
     function _calculateTokenAddress(
         address _remote,
@@ -75,11 +78,8 @@ contract OptimismMintableERC20Factory_CreateStandardL2Token_Test is OptimismMint
     )
         external
     {
-        // Assume
         vm.assume(_remoteToken != address(0));
 
-        // Arrange
-        // Defaults to 18 decimals
         address local = _calculateTokenAddress(_remoteToken, _name, _symbol, 18);
 
         vm.expectEmit(address(l2OptimismMintableERC20Factory));
@@ -88,19 +88,17 @@ contract OptimismMintableERC20Factory_CreateStandardL2Token_Test is OptimismMint
         vm.expectEmit(address(l2OptimismMintableERC20Factory));
         emit OptimismMintableERC20Created(local, _remoteToken, _caller);
 
-        // Act
         vm.prank(_caller);
         address addr = l2OptimismMintableERC20Factory.createStandardL2Token(_remoteToken, _name, _symbol);
 
-        // Assert
-        assertTrue(addr == local);
-        assertTrue(OptimismMintableERC20(local).decimals() == 18);
+        assertEq(addr, local);
+        assertEq(OptimismMintableERC20(local).decimals(), 18);
         assertEq(l2OptimismMintableERC20Factory.deployments(local), _remoteToken);
     }
 
     /// @notice Test that calling `createOptimismMintableERC20WithDecimals` with valid parameters
     ///         succeeds.
-    function test_createStandardL2TokenWithDecimals_succeeds(
+    function test_createOptimismMintableERC20WithDecimals_succeeds(
         address _caller,
         address _remoteToken,
         string memory _name,
@@ -109,10 +107,8 @@ contract OptimismMintableERC20Factory_CreateStandardL2Token_Test is OptimismMint
     )
         external
     {
-        // Assume
         vm.assume(_remoteToken != address(0));
 
-        // Arrange
         address local = _calculateTokenAddress(_remoteToken, _name, _symbol, _decimals);
 
         vm.expectEmit(address(l2OptimismMintableERC20Factory));
@@ -121,15 +117,13 @@ contract OptimismMintableERC20Factory_CreateStandardL2Token_Test is OptimismMint
         vm.expectEmit(address(l2OptimismMintableERC20Factory));
         emit OptimismMintableERC20Created(local, _remoteToken, _caller);
 
-        // Act
         vm.prank(_caller);
         address addr = l2OptimismMintableERC20Factory.createOptimismMintableERC20WithDecimals(
             _remoteToken, _name, _symbol, _decimals
         );
 
-        // Assert
-        assertTrue(addr == local);
-        assertTrue(OptimismMintableERC20(local).decimals() == _decimals);
+        assertEq(addr, local);
+        assertEq(OptimismMintableERC20(local).decimals(), _decimals);
         assertEq(l2OptimismMintableERC20Factory.deployments(local), _remoteToken);
     }
 
@@ -142,23 +136,20 @@ contract OptimismMintableERC20Factory_CreateStandardL2Token_Test is OptimismMint
     )
         external
     {
-        // Assume
         vm.assume(_remoteToken != address(0));
 
         vm.prank(_caller);
         l2OptimismMintableERC20Factory.createStandardL2Token(_remoteToken, _name, _symbol);
 
-        // Arrange
-        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
+        vm.expectRevert(bytes(""));
 
-        // Act
         vm.prank(_caller);
         l2OptimismMintableERC20Factory.createStandardL2Token(_remoteToken, _name, _symbol);
     }
 
-    /// @notice Test that calling `createStandardL2TokenWithDecimals` with the same parameters
+    /// @notice Test that calling `createOptimismMintableERC20WithDecimals` with the same parameters
     ///         twice reverts.
-    function test_createStandardL2TokenWithDecimals_sameTwice_reverts(
+    function test_createOptimismMintableERC20WithDecimals_sameTwice_reverts(
         address _caller,
         address _remoteToken,
         string memory _name,
@@ -167,16 +158,13 @@ contract OptimismMintableERC20Factory_CreateStandardL2Token_Test is OptimismMint
     )
         external
     {
-        // Assume
         vm.assume(_remoteToken != address(0));
 
         vm.prank(_caller);
         l2OptimismMintableERC20Factory.createOptimismMintableERC20WithDecimals(_remoteToken, _name, _symbol, _decimals);
 
-        // Arrange
-        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
+        vm.expectRevert(bytes(""));
 
-        // Act
         vm.prank(_caller);
         l2OptimismMintableERC20Factory.createOptimismMintableERC20WithDecimals(_remoteToken, _name, _symbol, _decimals);
     }
@@ -189,18 +177,15 @@ contract OptimismMintableERC20Factory_CreateStandardL2Token_Test is OptimismMint
     )
         external
     {
-        // Arrange
-        address remote = address(0);
-        vm.expectRevert("OptimismMintableERC20Factory: must provide remote token address");
+        vm.expectRevert(bytes(REMOTE_TOKEN_ZERO_REVERT));
 
-        // Act
         vm.prank(_caller);
-        l2OptimismMintableERC20Factory.createStandardL2Token(remote, _name, _symbol);
+        l2OptimismMintableERC20Factory.createStandardL2Token(address(0), _name, _symbol);
     }
 
-    /// @notice Test that calling `createStandardL2TokenWithDecimals` with a zero remote token
+    /// @notice Test that calling `createOptimismMintableERC20WithDecimals` with a zero remote token
     ///         address reverts.
-    function test_createStandardL2TokenWithDecimals_remoteIsZero_reverts(
+    function test_createOptimismMintableERC20WithDecimals_remoteIsZero_reverts(
         address _caller,
         string memory _name,
         string memory _symbol,
@@ -208,13 +193,10 @@ contract OptimismMintableERC20Factory_CreateStandardL2Token_Test is OptimismMint
     )
         external
     {
-        // Arrange
-        address remote = address(0);
-        vm.expectRevert("OptimismMintableERC20Factory: must provide remote token address");
+        vm.expectRevert(bytes(REMOTE_TOKEN_ZERO_REVERT));
 
-        // Act
         vm.prank(_caller);
-        l2OptimismMintableERC20Factory.createOptimismMintableERC20WithDecimals(remote, _name, _symbol, _decimals);
+        l2OptimismMintableERC20Factory.createOptimismMintableERC20WithDecimals(address(0), _name, _symbol, _decimals);
     }
 }
 
@@ -236,7 +218,7 @@ contract OptimismMintableERC20Factory_Uncategorized_Test is OptimismMintableERC2
         proxy.upgradeToAndCall(address(nextImpl), abi.encodeCall(NextImpl.initialize, (2)));
         assertEq(proxy.implementation(), address(nextImpl));
 
-        // Verify that the NextImpl contract initialized its values according as expected
+        // Verify that the NextImpl contract initialized its values as expected.
         bytes32 slot21After = vm.load(address(l1OptimismMintableERC20Factory), bytes32(uint256(21)));
         bytes32 slot21Expected = NextImpl(address(l1OptimismMintableERC20Factory)).slot21Init();
         assertEq(slot21Expected, slot21After);

--- a/test/universal/Proxy.t.sol
+++ b/test/universal/Proxy.t.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.15;
 
 import { Test } from "lib/forge-std/src/Test.sol";
-import { Bytes32AddressLib } from "lib/solmate/src/utils/Bytes32AddressLib.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
-import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Proxy } from "src/universal/Proxy.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 contract Proxy_SimpleStorage_Harness {
     mapping(uint256 => uint256) internal store;
@@ -30,27 +30,35 @@ abstract contract Proxy_TestInit is Test {
     event Upgraded(address indexed implementation);
     event AdminChanged(address previousAdmin, address newAdmin);
 
-    address alice = address(64);
-
-    bytes32 internal constant IMPLEMENTATION_KEY = bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1);
-
-    bytes32 internal constant OWNER_KEY = bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1);
+    address internal constant ADMIN = address(64);
 
     IProxy proxy;
     Proxy_SimpleStorage_Harness simpleStorage;
 
     function setUp() external {
-        // Deploy a proxy and simple storage contract as the implementation
-        proxy = IProxy(
-            DeployUtils.create1({
-                _name: "src/universal/Proxy.sol:Proxy",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (alice)))
-            })
-        );
+        proxy = IProxy(payable(address(new Proxy(ADMIN))));
         simpleStorage = new Proxy_SimpleStorage_Harness();
 
-        vm.prank(alice);
-        proxy.upgradeTo(address(simpleStorage));
+        _upgradeTo(address(simpleStorage));
+    }
+
+    function _proxyStorage() internal view returns (Proxy_SimpleStorage_Harness) {
+        return Proxy_SimpleStorage_Harness(address(proxy));
+    }
+
+    function _upgradeTo(address _newImplementation) internal {
+        vm.prank(ADMIN);
+        proxy.upgradeTo(_newImplementation);
+    }
+
+    function _getImplementation() internal returns (address) {
+        vm.prank(ADMIN);
+        return proxy.implementation();
+    }
+
+    function _adminAs(address _caller) internal returns (address) {
+        vm.prank(_caller);
+        return proxy.admin();
     }
 }
 
@@ -58,52 +66,31 @@ abstract contract Proxy_TestInit is Test {
 /// @notice Tests the `upgradeTo` function of the `Proxy` contract.
 contract Proxy_UpgradeTo_Test is Proxy_TestInit {
     function test_upgradeTo_notAdmin_succeeds() external {
-        // The implementation does not have a `upgradeTo` method, calling `upgradeTo` not as the
-        // owner should revert.
-        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
-        proxy.upgradeTo(address(64));
+        address newImplementation = address(128);
 
-        // Call `upgradeTo` as the owner, it should succeed and emit the `Upgraded` event.
+        vm.expectRevert(bytes(""));
+        proxy.upgradeTo(newImplementation);
+
         vm.expectEmit(true, true, true, true);
-        emit Upgraded(address(64));
-        vm.prank(alice);
-        proxy.upgradeTo(address(64));
+        emit Upgraded(newImplementation);
+        _upgradeTo(newImplementation);
 
-        // Get the implementation as the owner
-        vm.prank(alice);
-        address impl = proxy.implementation();
-        assertEq(impl, address(64));
+        assertEq(_getImplementation(), newImplementation);
     }
 
     function test_upgradeTo_clashingFunctionSignatures_succeeds() external {
-        // Clasher has a clashing function with the proxy.
         Proxy_Clasher_Harness clasher = new Proxy_Clasher_Harness();
 
-        // Set the clasher as the implementation.
-        vm.prank(alice);
-        proxy.upgradeTo(address(clasher));
-
-        {
-            // Assert that the implementation was set properly.
-            vm.prank(alice);
-            address impl = proxy.implementation();
-            assertEq(impl, address(clasher));
-        }
+        _upgradeTo(address(clasher));
+        assertEq(_getImplementation(), address(clasher));
 
         // Call the clashing function on the proxy not as the owner so that the call passes
         // through. The implementation will revert so we can be sure that the call passed through.
         vm.expectRevert(bytes("Clasher: upgradeTo"));
         proxy.upgradeTo(address(0));
 
-        {
-            // Now call the clashing function as the owner and be sure that it doesn't pass through
-            // to the implementation.
-            vm.prank(alice);
-            proxy.upgradeTo(address(0));
-            vm.prank(alice);
-            address impl = proxy.implementation();
-            assertEq(impl, address(0));
-        }
+        _upgradeTo(address(0));
+        assertEq(_getImplementation(), address(0));
     }
 }
 
@@ -111,67 +98,47 @@ contract Proxy_UpgradeTo_Test is Proxy_TestInit {
 /// @notice Tests the `upgradeToAndCall` function of the `Proxy` contract.
 contract Proxy_UpgradeToAndCall_Test is Proxy_TestInit {
     function test_upgradeToAndCall_succeeds() external {
-        {
-            // There should be nothing in the current proxy storage
-            uint256 expect = Proxy_SimpleStorage_Harness(address(proxy)).get(1);
-            assertEq(expect, 0);
-        }
+        assertEq(_proxyStorage().get(1), 0);
 
-        // Deploy a new SimpleStorage
-        simpleStorage = new Proxy_SimpleStorage_Harness();
+        Proxy_SimpleStorage_Harness newSimpleStorage = new Proxy_SimpleStorage_Harness();
 
-        // Set the new SimpleStorage as the implementation and call.
         vm.expectEmit(true, true, true, true);
-        emit Upgraded(address(simpleStorage));
-        vm.prank(alice);
-        proxy.upgradeToAndCall(address(simpleStorage), abi.encodeCall(Proxy_SimpleStorage_Harness.set, (1, 1)));
+        emit Upgraded(address(newSimpleStorage));
+        vm.prank(ADMIN);
+        proxy.upgradeToAndCall(address(newSimpleStorage), abi.encodeCall(Proxy_SimpleStorage_Harness.set, (1, 1)));
 
-        // The call should have impacted the state
-        uint256 result = Proxy_SimpleStorage_Harness(address(proxy)).get(1);
-        assertEq(result, 1);
+        assertEq(_proxyStorage().get(1), 1);
     }
 
     function test_upgradeToAndCall_functionDoesNotExist_reverts() external {
-        // Get the current implementation address
-        vm.prank(alice);
-        address impl = proxy.implementation();
-        assertEq(impl, address(simpleStorage));
+        address initialImplementation = _getImplementation();
+        assertEq(initialImplementation, address(simpleStorage));
 
-        // Deploy a new SimpleStorage
-        simpleStorage = new Proxy_SimpleStorage_Harness();
+        Proxy_SimpleStorage_Harness newSimpleStorage = new Proxy_SimpleStorage_Harness();
 
         // Set the new SimpleStorage as the implementation and call. This reverts because the
         // calldata doesn't match a function on the implementation.
         vm.expectRevert("Proxy: delegatecall to new implementation contract failed");
-        vm.prank(alice);
-        proxy.upgradeToAndCall(address(simpleStorage), hex"");
+        vm.prank(ADMIN);
+        proxy.upgradeToAndCall(address(newSimpleStorage), hex"");
 
-        // The implementation address should have not updated because the call to
-        // `upgradeToAndCall` reverted.
-        vm.prank(alice);
-        address postImpl = proxy.implementation();
-        assertEq(impl, postImpl);
+        assertEq(_getImplementation(), initialImplementation);
 
-        // The attempt to `upgradeToAndCall` should revert when it is not called by the owner.
-        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
-        proxy.upgradeToAndCall(address(simpleStorage), abi.encodeCall(simpleStorage.set, (1, 1)));
+        vm.expectRevert(bytes(""));
+        proxy.upgradeToAndCall(address(newSimpleStorage), abi.encodeCall(Proxy_SimpleStorage_Harness.set, (1, 1)));
     }
 
     function test_upgradeToAndCall_isPayable_succeeds() external {
-        // Give alice some funds
-        vm.deal(alice, 1 ether);
+        uint256 value = 1 ether;
 
-        // Set the implementation and call and send value.
-        vm.prank(alice);
-        proxy.upgradeToAndCall{ value: 1 ether }(address(simpleStorage), abi.encodeCall(simpleStorage.set, (1, 1)));
+        vm.deal(ADMIN, value);
+        vm.prank(ADMIN);
+        proxy.upgradeToAndCall{ value: value }(
+            address(simpleStorage), abi.encodeCall(Proxy_SimpleStorage_Harness.set, (1, 1))
+        );
 
-        // The implementation address should be correct
-        vm.prank(alice);
-        address impl = proxy.implementation();
-        assertEq(impl, address(simpleStorage));
-
-        // The proxy should have a balance
-        assertEq(address(proxy).balance, 1 ether);
+        assertEq(_getImplementation(), address(simpleStorage));
+        assertEq(address(proxy).balance, value);
     }
 }
 
@@ -179,16 +146,13 @@ contract Proxy_UpgradeToAndCall_Test is Proxy_TestInit {
 /// @notice Tests the `changeAdmin` function of the `Proxy` contract.
 contract Proxy_ChangeAdmin_Test is Proxy_TestInit {
     function test_changeAdmin_ownerKey_succeeds() external {
-        // The hardcoded owner key should be correct
-        vm.prank(alice);
-        proxy.changeAdmin(address(6));
+        address newAdmin = address(6);
 
-        bytes32 key = vm.load(address(proxy), OWNER_KEY);
-        assertEq(address(6), Bytes32AddressLib.fromLast20Bytes(key));
+        vm.prank(ADMIN);
+        proxy.changeAdmin(newAdmin);
 
-        vm.prank(address(6));
-        address owner = proxy.admin();
-        assertEq(owner, address(6));
+        assertEq(EIP1967Helper.getAdmin(address(proxy)), newAdmin);
+        assertEq(_adminAs(newAdmin), newAdmin);
     }
 }
 
@@ -196,26 +160,20 @@ contract Proxy_ChangeAdmin_Test is Proxy_TestInit {
 /// @notice Tests the `admin` function of the `Proxy` contract.
 contract Proxy_Admin_Test is Proxy_TestInit {
     function test_admin_notAdmin_succeeds() external {
-        // Calling `changeAdmin` not as the owner should revert as the implementation does not have
-        // a `changeAdmin` method.
-        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
-        proxy.changeAdmin(address(1));
+        address newAdmin = address(1);
 
-        // Call `changeAdmin` as the owner, it should succeed and emit the `AdminChanged` event.
+        vm.expectRevert(bytes(""));
+        proxy.changeAdmin(newAdmin);
+
         vm.expectEmit(true, true, true, true);
-        emit AdminChanged(alice, address(1));
-        vm.prank(alice);
-        proxy.changeAdmin(address(1));
+        emit AdminChanged(ADMIN, newAdmin);
+        vm.prank(ADMIN);
+        proxy.changeAdmin(newAdmin);
 
-        // Calling `admin` not as the owner should revert as the implementation does not have a
-        // `admin` method.
-        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
+        vm.expectRevert(bytes(""));
         proxy.admin();
 
-        // Calling `admin` as the owner should work.
-        vm.prank(address(1));
-        address owner = proxy.admin();
-        assertEq(owner, address(1));
+        assertEq(_adminAs(newAdmin), newAdmin);
     }
 }
 
@@ -223,16 +181,12 @@ contract Proxy_Admin_Test is Proxy_TestInit {
 /// @notice Tests the `implementation` function of the `Proxy` contract.
 contract Proxy_Implementation_Test is Proxy_TestInit {
     function test_implementation_key_succeeds() external {
-        // The hardcoded implementation key should be correct
-        vm.prank(alice);
-        proxy.upgradeTo(address(6));
+        address newImplementation = address(6);
 
-        bytes32 key = vm.load(address(proxy), IMPLEMENTATION_KEY);
-        assertEq(address(6), Bytes32AddressLib.fromLast20Bytes(key));
+        _upgradeTo(newImplementation);
 
-        vm.prank(alice);
-        address impl = proxy.implementation();
-        assertEq(impl, address(6));
+        assertEq(EIP1967Helper.getImplementation(address(proxy)), newImplementation);
+        assertEq(_getImplementation(), newImplementation);
     }
 
     // Allow for `eth_call` to call proxy methods by setting "from" to `address(0)`.
@@ -243,42 +197,24 @@ contract Proxy_Implementation_Test is Proxy_TestInit {
     }
 
     function test_implementation_isZeroAddress_reverts() external {
-        // Set `address(0)` as the implementation.
-        vm.prank(alice);
-        proxy.upgradeTo(address(0));
+        _upgradeTo(address(0));
 
-        (bool success, bytes memory returndata) = address(proxy).call(hex"");
-        assertEq(success, false);
-
-        bytes memory err = abi.encodeWithSignature("Error(string)", "Proxy: implementation not initialized"); // nosemgrep:
-        // sol-style-use-abi-encodecall
-
-        assertEq(returndata, err);
+        vm.expectRevert("Proxy: implementation not initialized");
+        _proxyStorage().get(1);
     }
 }
 
-/// @title Proxy_Uncategorized_Test
-/// @notice General tests that are not testing any function directly of the `Proxy` contract.
-contract Proxy_Uncategorized_Test is Proxy_TestInit {
+/// @title Proxy_Delegation_Test
+/// @notice Tests proxy delegation behavior.
+contract Proxy_Delegation_Test is Proxy_TestInit {
     function test_delegatesToImpl_succeeds() external {
-        // Call the storage setter on the proxy
-        Proxy_SimpleStorage_Harness(address(proxy)).set(1, 1);
+        _proxyStorage().set(1, 1);
 
-        // The key should not be set in the implementation
-        uint256 result = simpleStorage.get(1);
-        assertEq(result, 0);
-        {
-            // The key should be set in the proxy
-            uint256 expect = Proxy_SimpleStorage_Harness(address(proxy)).get(1);
-            assertEq(expect, 1);
-        }
+        assertEq(simpleStorage.get(1), 0);
+        assertEq(_proxyStorage().get(1), 1);
 
-        {
-            // The owner should be able to call through the proxy when there is not a function
-            // selector crash.
-            vm.prank(alice);
-            uint256 expect = Proxy_SimpleStorage_Harness(address(proxy)).get(1);
-            assertEq(expect, 1);
-        }
+        // The owner should be able to call through the proxy when there is no selector clash.
+        vm.prank(ADMIN);
+        assertEq(_proxyStorage().get(1), 1);
     }
 }

--- a/test/universal/ProxyAdmin.t.sol
+++ b/test/universal/ProxyAdmin.t.sol
@@ -17,7 +17,8 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 /// @title ProxyAdmin_TestInit
 /// @notice Reusable test initialization for `ProxyAdmin` tests.
 abstract contract ProxyAdmin_TestInit is Test {
-    address alice = address(64);
+    address internal constant PROXY_ADMIN_OWNER = address(64);
+    address internal constant NEW_PROXY_ADMIN = address(128);
 
     IProxy proxy;
     IL1ChugSplashProxy chugsplash;
@@ -30,15 +31,13 @@ abstract contract ProxyAdmin_TestInit is Test {
     Proxy_SimpleStorage_Harness implementation;
 
     function setUp() external {
-        // Deploy the proxy admin
         admin = IProxyAdmin(
             DeployUtils.create1({
                 _name: "ProxyAdmin",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxyAdmin.__constructor__, (alice)))
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxyAdmin.__constructor__, (PROXY_ADMIN_OWNER)))
             })
         );
 
-        // Deploy the standard proxy
         proxy = IProxy(
             DeployUtils.create1({
                 _name: "src/universal/Proxy.sol:Proxy",
@@ -46,7 +45,6 @@ abstract contract ProxyAdmin_TestInit is Test {
             })
         );
 
-        // Deploy the legacy L1ChugSplashProxy with the admin as the owner
         chugsplash = IL1ChugSplashProxy(
             DeployUtils.create1({
                 _name: "L1ChugSplashProxy",
@@ -56,15 +54,14 @@ abstract contract ProxyAdmin_TestInit is Test {
             })
         );
 
-        // Deploy the legacy AddressManager
         addressManager = IAddressManager(
             DeployUtils.create1({
                 _name: "AddressManager",
                 _args: DeployUtils.encodeConstructor(abi.encodeCall(IAddressManager.__constructor__, ()))
             })
         );
-        // The proxy admin must be the new owner of the address manager
         addressManager.transferOwnership(address(admin));
+
         // Deploy a legacy ResolvedDelegateProxy with the name `a`. Whatever `a` is set to in
         // AddressManager will be the address that is used for the implementation.
         resolved = IResolvedDelegateProxy(
@@ -75,15 +72,13 @@ abstract contract ProxyAdmin_TestInit is Test {
                 )
             })
         );
-        // Impersonate alice for setting up the admin.
-        vm.startPrank(alice);
-        // Set the address of the address manager in the admin so that it can resolve the
+
+        vm.startPrank(PROXY_ADMIN_OWNER);
+        // Set the address manager so the admin can resolve the
         // implementation address of legacy ResolvedDelegateProxy based proxies.
-        admin.setAddressManager(IAddressManager(address(addressManager)));
-        // Set the reverse lookup of the ResolvedDelegateProxy proxy
+        admin.setAddressManager(addressManager);
         admin.setImplementationName(address(resolved), "a");
 
-        // Set the proxy types
         admin.setProxyType(address(proxy), IProxyAdmin.ProxyType.ERC1967);
         admin.setProxyType(address(chugsplash), IProxyAdmin.ProxyType.CHUGSPLASH);
         admin.setProxyType(address(resolved), IProxyAdmin.ProxyType.RESOLVED);
@@ -106,7 +101,7 @@ contract ProxyAdmin_SetProxyType_Test is ProxyAdmin_TestInit {
 /// @notice Tests the `setImplementationName` function of the `ProxyAdmin` contract.
 contract ProxyAdmin_SetImplementationName_Test is ProxyAdmin_TestInit {
     function test_setImplementationName_succeeds() external {
-        vm.prank(alice);
+        vm.prank(PROXY_ADMIN_OWNER);
         admin.setImplementationName(address(1), "foo");
         assertEq(admin.implementationName(address(1)), "foo");
     }
@@ -122,7 +117,7 @@ contract ProxyAdmin_SetImplementationName_Test is ProxyAdmin_TestInit {
 contract ProxyAdmin_SetAddressManager_Test is ProxyAdmin_TestInit {
     function test_setAddressManager_notOwner_reverts() external {
         vm.expectRevert("Ownable: caller is not the owner");
-        admin.setAddressManager(IAddressManager((address(0))));
+        admin.setAddressManager(IAddressManager(address(0)));
     }
 }
 
@@ -130,74 +125,67 @@ contract ProxyAdmin_SetAddressManager_Test is ProxyAdmin_TestInit {
 /// @notice Tests the `isUpgrading` function of the `ProxyAdmin` contract.
 contract ProxyAdmin_IsUpgrading_Test is ProxyAdmin_TestInit {
     function test_isUpgrading_succeeds() external {
-        assertEq(false, admin.isUpgrading());
+        assertFalse(admin.isUpgrading());
 
-        vm.prank(alice);
+        vm.prank(PROXY_ADMIN_OWNER);
         admin.setUpgrading(true);
-        assertEq(true, admin.isUpgrading());
+        assertTrue(admin.isUpgrading());
     }
 }
 
 /// @title ProxyAdmin_GetProxyImplementation_Test
 /// @notice Tests the `getProxyImplementation` function of the `ProxyAdmin` contract.
 contract ProxyAdmin_GetProxyImplementation_Test is ProxyAdmin_TestInit {
-    function getProxyImplementation(address payable _proxy) internal {
-        {
-            address impl = admin.getProxyImplementation(_proxy);
-            assertEq(impl, address(0));
-        }
+    function _assertProxyImplementation(address payable _proxy) internal {
+        assertEq(admin.getProxyImplementation(_proxy), address(0));
 
-        vm.prank(alice);
+        vm.prank(PROXY_ADMIN_OWNER);
         admin.upgrade(_proxy, address(implementation));
 
-        {
-            address impl = admin.getProxyImplementation(_proxy);
-            assertEq(impl, address(implementation));
-        }
+        assertEq(admin.getProxyImplementation(_proxy), address(implementation));
     }
 
     function test_getProxyImplementation_erc1967_succeeds() external {
-        getProxyImplementation(payable(proxy));
+        _assertProxyImplementation(payable(proxy));
     }
 
     function test_getProxyImplementation_chugsplash_succeeds() external {
-        getProxyImplementation(payable(chugsplash));
+        _assertProxyImplementation(payable(chugsplash));
     }
 
     function test_getProxyImplementation_resolved_succeeds() external {
-        getProxyImplementation(payable(resolved));
+        _assertProxyImplementation(payable(resolved));
     }
 }
 
 /// @title ProxyAdmin_GetProxyAdmin_Test
 /// @notice Tests the `getProxyAdmin` function of the `ProxyAdmin` contract.
 contract ProxyAdmin_GetProxyAdmin_Test is ProxyAdmin_TestInit {
-    function getProxyAdmin(address payable _proxy) internal view {
-        address owner = admin.getProxyAdmin(_proxy);
-        assertEq(owner, address(admin));
+    function _assertProxyAdmin(address payable _proxy) internal view {
+        assertEq(admin.getProxyAdmin(_proxy), address(admin));
     }
 
     function test_getProxyAdmin_erc1967_succeeds() external view {
-        getProxyAdmin(payable(proxy));
+        _assertProxyAdmin(payable(proxy));
     }
 
     function test_getProxyAdmin_chugsplash_succeeds() external view {
-        getProxyAdmin(payable(chugsplash));
+        _assertProxyAdmin(payable(chugsplash));
     }
 
     function test_getProxyAdmin_resolved_succeeds() external view {
-        getProxyAdmin(payable(resolved));
+        _assertProxyAdmin(payable(resolved));
     }
 }
 
 /// @title ProxyAdmin_ChangeProxyAdmin_Test
 /// @notice Tests the `changeProxyAdmin` function of the `ProxyAdmin` contract.
 contract ProxyAdmin_ChangeProxyAdmin_Test is ProxyAdmin_TestInit {
-    function changeProxyAdmin(address payable _proxy) internal {
+    function _assertChangeProxyAdmin(address payable _proxy) internal {
         IProxyAdmin.ProxyType proxyType = admin.proxyType(address(_proxy));
 
-        vm.prank(alice);
-        admin.changeProxyAdmin(_proxy, address(128));
+        vm.prank(PROXY_ADMIN_OWNER);
+        admin.changeProxyAdmin(_proxy, NEW_PROXY_ADMIN);
 
         // The proxy is no longer the admin and can
         // no longer call the proxy interface except for
@@ -210,86 +198,79 @@ contract ProxyAdmin_ChangeProxyAdmin_Test is ProxyAdmin_TestInit {
             vm.expectRevert("L1ChugSplashProxy: implementation is not set yet");
             admin.getProxyAdmin(_proxy);
         } else if (proxyType == IProxyAdmin.ProxyType.RESOLVED) {
-            // Just an empty block to show that all cases are covered
-        } else {
-            vm.expectRevert("ProxyAdmin: unknown proxy type");
+            assertEq(admin.getProxyAdmin(_proxy), NEW_PROXY_ADMIN);
         }
 
         // Call the proxy contract directly to get the admin.
         // Different proxy types have different interfaces.
-        vm.prank(address(128));
+        vm.prank(NEW_PROXY_ADMIN);
         if (proxyType == IProxyAdmin.ProxyType.ERC1967) {
-            assertEq(IProxy(payable(_proxy)).admin(), address(128));
+            assertEq(IProxy(payable(_proxy)).admin(), NEW_PROXY_ADMIN);
         } else if (proxyType == IProxyAdmin.ProxyType.CHUGSPLASH) {
-            assertEq(IL1ChugSplashProxy(payable(_proxy)).getOwner(), address(128));
+            assertEq(IL1ChugSplashProxy(payable(_proxy)).getOwner(), NEW_PROXY_ADMIN);
         } else if (proxyType == IProxyAdmin.ProxyType.RESOLVED) {
-            assertEq(addressManager.owner(), address(128));
-        } else {
-            assert(false);
+            assertEq(addressManager.owner(), NEW_PROXY_ADMIN);
         }
     }
 
     function test_changeProxyAdmin_erc1967_succeeds() external {
-        changeProxyAdmin(payable(proxy));
+        _assertChangeProxyAdmin(payable(proxy));
     }
 
     function test_changeProxyAdmin_chugsplash_succeeds() external {
-        changeProxyAdmin(payable(chugsplash));
+        _assertChangeProxyAdmin(payable(chugsplash));
     }
 
     function test_changeProxyAdmin_resolved_succeeds() external {
-        changeProxyAdmin(payable(resolved));
+        _assertChangeProxyAdmin(payable(resolved));
     }
 }
 
 /// @title ProxyAdmin_Upgrade_Test
 /// @notice Tests the `upgrade` function of the `ProxyAdmin` contract.
 contract ProxyAdmin_Upgrade_Test is ProxyAdmin_TestInit {
-    function upgrade(address payable _proxy) internal {
-        vm.prank(alice);
+    function _assertUpgrade(address payable _proxy) internal {
+        vm.prank(PROXY_ADMIN_OWNER);
         admin.upgrade(_proxy, address(implementation));
 
-        address impl = admin.getProxyImplementation(_proxy);
-        assertEq(impl, address(implementation));
+        assertEq(admin.getProxyImplementation(_proxy), address(implementation));
     }
 
     function test_upgrade_erc1967_succeeds() external {
-        upgrade(payable(proxy));
+        _assertUpgrade(payable(proxy));
     }
 
     function test_upgrade_chugsplash_succeeds() external {
-        upgrade(payable(chugsplash));
+        _assertUpgrade(payable(chugsplash));
     }
 
     function test_upgrade_resolved_succeeds() external {
-        upgrade(payable(resolved));
+        _assertUpgrade(payable(resolved));
     }
 }
 
 /// @title ProxyAdmin_UpgradeAndCall_Test
 /// @notice Tests the `upgradeAndCall` function of the `ProxyAdmin` contract.
 contract ProxyAdmin_UpgradeAndCall_Test is ProxyAdmin_TestInit {
-    function upgradeAndCall(address payable _proxy) internal {
-        vm.prank(alice);
+    function _assertUpgradeAndCall(address payable _proxy) internal {
+        vm.prank(PROXY_ADMIN_OWNER);
         admin.upgradeAndCall(_proxy, address(implementation), abi.encodeCall(Proxy_SimpleStorage_Harness.set, (1, 1)));
 
-        address impl = admin.getProxyImplementation(_proxy);
-        assertEq(impl, address(implementation));
+        assertEq(admin.getProxyImplementation(_proxy), address(implementation));
 
-        uint256 got = Proxy_SimpleStorage_Harness(address(_proxy)).get(1);
-        assertEq(got, 1);
+        assertEq(Proxy_SimpleStorage_Harness(address(_proxy)).get(1), 1);
     }
 
-    function test_erc1967UpgradeAndCall_succeeds() external {
-        upgradeAndCall(payable(proxy));
+    function test_upgradeAndCall_erc1967_succeeds() external {
+        _assertUpgradeAndCall(payable(proxy));
     }
 
-    function test_chugsplashUpgradeAndCall_succeeds() external {
-        upgradeAndCall(payable(chugsplash));
+    function test_upgradeAndCall_chugsplash_succeeds() external {
+        _assertUpgradeAndCall(payable(chugsplash));
     }
 
-    function test_delegateResolvedUpgradeAndCall_succeeds() external {
-        upgradeAndCall(payable(resolved));
+    function test_upgradeAndCall_resolved_succeeds() external {
+        _assertUpgradeAndCall(payable(resolved));
     }
 }
 
@@ -298,7 +279,7 @@ contract ProxyAdmin_UpgradeAndCall_Test is ProxyAdmin_TestInit {
 ///         functions of the `ProxyAdmin` contract.
 contract ProxyAdmin_Uncategorized_Test is ProxyAdmin_TestInit {
     function test_owner_succeeds() external view {
-        assertEq(admin.owner(), alice);
+        assertEq(admin.owner(), PROXY_ADMIN_OWNER);
     }
 
     function test_proxyType_succeeds() external view {

--- a/test/universal/ProxyAdminOwnedBase.t.sol
+++ b/test/universal/ProxyAdminOwnedBase.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
-import { Constants } from "src/libraries/Constants.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Contracts
 import { ProxyAdminOwnedBase } from "src/universal/ProxyAdminOwnedBase.sol";
@@ -12,10 +12,10 @@ import { ProxyAdminOwnedBase } from "src/universal/ProxyAdminOwnedBase.sol";
 /// @notice Contract implementing the abstract `ProxyAdminOwnedBase` contract so we can write unit
 ///         tests for the `ProxyAdminOwnedBase` contract.
 contract ProxyAdminOwnedBase_Harness is ProxyAdminOwnedBase {
-    /// @notice Slot 0, used to test ResolvedDelegateProxy behavior.
+    /// @notice Slot 0, matching the legacy ResolvedDelegateProxy storage layout.
     mapping(address => string) public slot0;
 
-    /// @notice Slot 1, used to test ResolvedDelegateProxy behavior.
+    /// @notice Slot 1, matching the legacy ResolvedDelegateProxy storage layout.
     mapping(address => address) public slot1;
 
     /// @notice Assert that the proxy admin owner of the current contract is the same as the proxy
@@ -38,19 +38,15 @@ contract ProxyAdminOwnedBase_Harness is ProxyAdminOwnedBase {
     function assertOnlyProxyAdminOrProxyAdminOwner() public view {
         _assertOnlyProxyAdminOrProxyAdminOwner();
     }
-
-    /// @notice Set the value of slot 0 for the provided address.
-    function setSlot0(address _address, string memory _value) public {
-        slot0[_address] = _value;
-    }
-
-    /// @notice Set the value of slot 1 for the provided address.
-    function setSlot1(address _address, address _value) public {
-        slot1[_address] = _value;
-    }
 }
 
 abstract contract ProxyAdminOwnedBase_TestInit is CommonTest {
+    /// @notice Stored name value that identifies the legacy ResolvedDelegateProxy.
+    bytes32 internal constant RESOLVED_DELEGATE_PROXY_NAME = bytes32("OVM_L1CrossDomainMessenger");
+
+    /// @notice Length of the stored ResolvedDelegateProxy name.
+    uint256 internal constant RESOLVED_DELEGATE_PROXY_NAME_LENGTH = 26;
+
     /// @notice Harness for the `ProxyAdminOwnedBase` contract.
     ProxyAdminOwnedBase_Harness public harness;
 
@@ -58,13 +54,38 @@ abstract contract ProxyAdminOwnedBase_TestInit is CommonTest {
     function setUp() public override {
         super.setUp();
 
-        // Create a new harness
         harness = new ProxyAdminOwnedBase_Harness();
+        EIP1967Helper.setAdmin(address(harness), address(proxyAdmin));
+    }
 
-        // Set the owner of the harness to the ProxyAdmin contract.
+    /// @notice Clears the EIP-1967 admin slot and sets the legacy ResolvedDelegateProxy slots.
+    function setResolvedDelegateProxy(address _addressManager) internal {
+        EIP1967Helper.setAdmin(address(harness), address(0));
+        vm.store(address(harness), resolvedDelegateProxyNameSlot(), resolvedDelegateProxyNameSlotValue());
         vm.store(
-            address(harness), bytes32(Constants.PROXY_OWNER_ADDRESS), bytes32(uint256(uint160(address(proxyAdmin))))
+            address(harness), resolvedDelegateProxyAddressManagerSlot(), bytes32(uint256(uint160(_addressManager)))
         );
+    }
+
+    /// @notice Stores a raw value in the ResolvedDelegateProxy name slot.
+    function setResolvedDelegateProxyNameSlot(bytes32 _value) internal {
+        EIP1967Helper.setAdmin(address(harness), address(0));
+        vm.store(address(harness), resolvedDelegateProxyNameSlot(), _value);
+    }
+
+    /// @notice Returns the storage slot for `slot0[address(harness)]`.
+    function resolvedDelegateProxyNameSlot() internal view returns (bytes32) {
+        return keccak256(abi.encode(address(harness), uint256(0)));
+    }
+
+    /// @notice Returns the storage value Solidity uses for the short string name.
+    function resolvedDelegateProxyNameSlotValue() internal pure returns (bytes32) {
+        return bytes32(uint256(RESOLVED_DELEGATE_PROXY_NAME) | uint256(RESOLVED_DELEGATE_PROXY_NAME_LENGTH * 2));
+    }
+
+    /// @notice Returns the storage slot for `slot1[address(harness)]`.
+    function resolvedDelegateProxyAddressManagerSlot() internal view returns (bytes32) {
+        return keccak256(abi.encode(address(harness), uint256(1)));
     }
 }
 
@@ -84,49 +105,25 @@ contract ProxyAdminOwnedBase_proxyAdmin_Test is ProxyAdminOwnedBase_TestInit {
     /// @notice Tests that the proxyAdmin function returns the correct proxy when the current
     ///         contract is a full ResolvedDelegateProxy.
     function test_proxyAdmin_fullResolvedDelegateProxy_succeeds() public {
-        // Unset the standard proxy owner slot.
-        vm.store(address(harness), bytes32(Constants.PROXY_OWNER_ADDRESS), bytes32(0));
-
-        // Store the string "OVM_L1CrossDomainMessenger" in slot 0.
-        harness.setSlot0(address(harness), "OVM_L1CrossDomainMessenger");
-
-        // Store the address of the proxyAdmin in slot 1.
-        harness.setSlot1(address(harness), address(addressManager));
-
-        // Expect no revert.
+        setResolvedDelegateProxy(address(addressManager));
         assertEq(address(harness.proxyAdmin()), address(proxyAdmin));
     }
 
     /// @notice Tests that the proxyAdmin function reverts if the current contract is not a
     ///         ResolvedDelegateProxy.
-    /// @param _slot0Value The value to store in slot 0.
-    function test_proxyAdmin_notResolvedDelegateProxy_reverts(string memory _slot0Value) public {
-        // Assume the slot 0 value is not "OVM_L1CrossDomainMessenger".
-        vm.assume(keccak256(abi.encode(_slot0Value)) != keccak256(abi.encode("OVM_L1CrossDomainMessenger")));
+    /// @param _slot0Value The raw value to store in the ResolvedDelegateProxy name slot.
+    function test_proxyAdmin_notResolvedDelegateProxy_reverts(bytes32 _slot0Value) public {
+        vm.assume(_slot0Value != resolvedDelegateProxyNameSlotValue());
+        setResolvedDelegateProxyNameSlot(_slot0Value);
 
-        // Unset the standard proxy owner slot.
-        vm.store(address(harness), bytes32(Constants.PROXY_OWNER_ADDRESS), bytes32(0));
-
-        // Store the slot 0 value.
-        harness.setSlot0(address(harness), _slot0Value);
-
-        // Expect a revert.
         vm.expectRevert(ProxyAdminOwnedBase.ProxyAdminOwnedBase_NotResolvedDelegateProxy.selector);
         harness.proxyAdmin();
     }
 
     /// @notice Tests that the proxyAdmin function reverts if the proxy admin is not found.
     function test_proxyAdmin_proxyAdminNotFound_reverts() public {
-        // Unset the standard proxy owner slot.
-        vm.store(address(harness), bytes32(Constants.PROXY_OWNER_ADDRESS), bytes32(0));
+        setResolvedDelegateProxy(address(0));
 
-        // Store the string "OVM_L1CrossDomainMessenger" in slot 0.
-        harness.setSlot0(address(harness), "OVM_L1CrossDomainMessenger");
-
-        // Store address(0) in slot 1.
-        harness.setSlot1(address(harness), address(0));
-
-        // Expect a revert.
         vm.expectRevert(ProxyAdminOwnedBase.ProxyAdminOwnedBase_ProxyAdminNotFound.selector);
         harness.proxyAdmin();
     }
@@ -136,13 +133,10 @@ contract ProxyAdminOwnedBase_assertSharedProxyAdminOwner_Test is ProxyAdminOwned
     /// @notice Tests that the assertSharedProxyAdminOwner function does not revert if the provided
     ///         proxy has the same owner as the current contract.
     function test_assertSharedProxyAdminOwner_sameOwner_succeeds(address _proxy) public {
-        // Assume the provided proxy is not a forge address.
         assumeNotForgeAddress(_proxy);
 
-        // Mock the proxyAdminOwner function to return the same owner as the current contract.
         vm.mockCall(_proxy, abi.encodeCall(ProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(proxyAdminOwner));
 
-        // Expect no revert.
         harness.assertSharedProxyAdminOwner(_proxy);
     }
 
@@ -154,17 +148,11 @@ contract ProxyAdminOwnedBase_assertSharedProxyAdminOwner_Test is ProxyAdminOwned
     )
         public
     {
-        // Assume the provided proxy is not a forge address.
         assumeNotForgeAddress(_proxy);
-        assumeNotForgeAddress(_otherProxyOwner);
-
-        // Assume the other proxy owner is not the same as the current owner.
         vm.assume(_otherProxyOwner != proxyAdminOwner);
 
-        // Mock the proxyAdminOwner function to return the other proxy owner.
         vm.mockCall(_proxy, abi.encodeCall(ProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(_otherProxyOwner));
 
-        // Expect a revert.
         vm.expectRevert(ProxyAdminOwnedBase.ProxyAdminOwnedBase_NotSharedProxyAdminOwner.selector);
         harness.assertSharedProxyAdminOwner(_proxy);
     }
@@ -174,10 +162,7 @@ contract ProxyAdminOwnedBase_assertOnlyProxyAdmin_Test is ProxyAdminOwnedBase_Te
     /// @notice Tests that the assertOnlyProxyAdmin function does not revert if the caller is the
     ///         ProxyAdmin.
     function test_assertOnlyProxyAdmin_proxyAdmin_succeeds() public {
-        // Prank as the ProxyAdmin.
         vm.prank(address(proxyAdmin));
-
-        // Expect no revert.
         harness.assertOnlyProxyAdmin();
     }
 
@@ -185,11 +170,9 @@ contract ProxyAdminOwnedBase_assertOnlyProxyAdmin_Test is ProxyAdminOwnedBase_Te
     ///         ProxyAdmin.
     /// @param _sender The address of the sender to test.
     function test_assertOnlyProxyAdmin_notProxyAdmin_reverts(address _sender) public {
-        // Prank as the not ProxyAdmin.
         vm.assume(_sender != address(proxyAdmin));
         vm.prank(_sender);
 
-        // Expect a revert.
         vm.expectRevert(ProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdmin.selector);
         harness.assertOnlyProxyAdmin();
     }
@@ -199,10 +182,7 @@ contract ProxyAdminOwnedBase_assertOnlyProxyAdminOwner_Test is ProxyAdminOwnedBa
     /// @notice Tests that the assertOnlyProxyAdminOwner function does not revert if the caller is
     ///         the ProxyAdmin owner.
     function test_assertOnlyProxyAdminOwner_proxyAdminOwner_succeeds() public {
-        // Prank as the ProxyAdmin owner.
         vm.prank(proxyAdminOwner);
-
-        // Expect no revert.
         harness.assertOnlyProxyAdminOwner();
     }
 
@@ -210,11 +190,9 @@ contract ProxyAdminOwnedBase_assertOnlyProxyAdminOwner_Test is ProxyAdminOwnedBa
     ///         ProxyAdmin owner.
     /// @param _sender The address of the sender to test.
     function test_assertOnlyProxyAdminOwner_notProxyAdminOwner_reverts(address _sender) public {
-        // Prank as the not ProxyAdmin owner.
         vm.assume(_sender != proxyAdminOwner);
         vm.prank(_sender);
 
-        // Expect a revert.
         vm.expectRevert(ProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOwner.selector);
         harness.assertOnlyProxyAdminOwner();
     }
@@ -224,20 +202,14 @@ contract ProxyAdminOwnedBase_assertOnlyProxyAdminOrProxyAdminOwner_Test is Proxy
     /// @notice Tests that the assertOnlyProxyAdminOrProxyAdminOwner function does not revert if
     ///         the caller is the ProxyAdmin or the ProxyAdmin owner.
     function test_assertOnlyProxyAdminOrProxyAdminOwner_proxyAdmin_succeeds() public {
-        // Prank as the ProxyAdmin.
         vm.prank(address(proxyAdmin));
-
-        // Expect no revert.
         harness.assertOnlyProxyAdminOrProxyAdminOwner();
     }
 
     /// @notice Tests that the assertOnlyProxyAdminOrProxyAdminOwner function does not revert if
     ///         the caller is the ProxyAdmin owner.
     function test_assertOnlyProxyAdminOrProxyAdminOwner_proxyAdminOwner_succeeds() public {
-        // Prank as the ProxyAdmin owner.
         vm.prank(proxyAdminOwner);
-
-        // Expect no revert.
         harness.assertOnlyProxyAdminOrProxyAdminOwner();
     }
 
@@ -245,11 +217,9 @@ contract ProxyAdminOwnedBase_assertOnlyProxyAdminOrProxyAdminOwner_Test is Proxy
     ///         is not the ProxyAdmin or the ProxyAdmin owner.
     /// @param _sender The address of the sender to test.
     function test_assertOnlyProxyAdminOrProxyAdminOwner_notProxyAdminOrProxyAdminOwner_reverts(address _sender) public {
-        // Prank as the not ProxyAdmin or ProxyAdmin owner.
         vm.assume(_sender != address(proxyAdmin) && _sender != proxyAdminOwner);
         vm.prank(_sender);
 
-        // Expect a revert.
         vm.expectRevert(ProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
         harness.assertOnlyProxyAdminOrProxyAdminOwner();
     }

--- a/test/universal/ReinitializableBase.t.sol
+++ b/test/universal/ReinitializableBase.t.sol
@@ -7,27 +7,18 @@ import { Test } from "lib/forge-std/src/Test.sol";
 // Contracts
 import { ReinitializableBase } from "src/universal/ReinitializableBase.sol";
 
-/// @title ReinitializableBase_Harness
-/// @notice Harness contract to allow direct instantiation and testing of `ReinitializableBase`
-///         logic.
 contract ReinitializableBase_Harness is ReinitializableBase {
     constructor(uint8 _initVersion) ReinitializableBase(_initVersion) { }
 }
 
-/// @title ReinitializableBase_Constructor_Test
-/// @notice Tests the constructor of the `ReinitializableBase` contract.
 contract ReinitializableBase_Constructor_Test is Test {
-    /// @notice Tests that the contract creation reverts when init version is zero.
-    function test_constructor_zeroVersion_reverts() public {
+    function test_constructor_zeroVersion_reverts() external {
         vm.expectRevert(ReinitializableBase.ReinitializableBase_ZeroInitVersion.selector);
         new ReinitializableBase_Harness(0);
     }
 
-    /// @notice Tests that constructor succeeds with valid non-zero init versions.
-    /// @param _initVersion Init version to use when creating the contract.
-    function testFuzz_constructor_validVersion_succeeds(uint8 _initVersion) public {
+    function testFuzz_constructor_validVersion_succeeds(uint8 _initVersion) external {
         _initVersion = uint8(bound(_initVersion, 1, type(uint8).max));
-        ReinitializableBase_Harness harness = new ReinitializableBase_Harness(_initVersion);
-        assertEq(harness.initVersion(), _initVersion);
+        assertEq(new ReinitializableBase_Harness(_initVersion).initVersion(), _initVersion);
     }
 }

--- a/test/universal/StandardBridge.t.sol
+++ b/test/universal/StandardBridge.t.sol
@@ -3,15 +3,15 @@ pragma solidity 0.8.15;
 
 import { StandardBridge } from "src/universal/StandardBridge.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
-import { OptimismMintableERC20, ILegacyMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
+import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
+import { ILegacyMintableERC20 } from "interfaces/legacy/ILegacyMintableERC20.sol";
 import { ERC20 } from "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import { IERC165 } from "lib/openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
 
 /// @title StandardBridgeTester
 /// @notice Simple wrapper around the StandardBridge contract that exposes
 ///         internal functions so they can be more easily tested directly.
 contract StandardBridgeTester is StandardBridge {
-    constructor() StandardBridge() { }
-
     function isOptimismMintableERC20(address _token) external view returns (bool) {
         return _isOptimismMintableERC20(_token);
     }
@@ -36,15 +36,9 @@ contract LegacyMintable is ERC20 {
 
     function burn(address _from, uint256 _amount) external pure { }
 
-    /// @notice Implements ERC165. This implementation should not be changed as
-    ///         it is how the actual legacy optimism mintable token does the
-    ///         check. Allows for testing against code that is has been deployed,
-    ///         assuming different compiler version is no problem.
+    /// @notice Matches the deployed legacy mintable token's ERC165 support.
     function supportsInterface(bytes4 _interfaceId) external pure returns (bool) {
-        bytes4 firstSupportedInterface = bytes4(keccak256("supportsInterface(bytes4)")); // ERC165
-        bytes4 secondSupportedInterface = ILegacyMintableERC20.l1Token.selector ^ ILegacyMintableERC20.mint.selector
-            ^ ILegacyMintableERC20.burn.selector;
-        return _interfaceId == firstSupportedInterface || _interfaceId == secondSupportedInterface;
+        return _interfaceId == type(IERC165).interfaceId || _interfaceId == type(ILegacyMintableERC20).interfaceId;
     }
 }
 
@@ -53,9 +47,10 @@ contract LegacyMintable is ERC20 {
 /// @dev This setup is primarily for tests focusing on internal stateless logic or default states
 ///      of the `StandardBridge` contract.
 abstract contract StandardBridge_TestInit is CommonTest {
+    address internal constant OTHER_TOKEN = address(0x20);
+
     StandardBridgeTester internal bridge;
     OptimismMintableERC20 internal mintable;
-    ERC20 internal erc20;
     LegacyMintable internal legacy;
 
     function setUp() public override {
@@ -67,7 +62,6 @@ abstract contract StandardBridge_TestInit is CommonTest {
             _bridge: address(0), _remoteToken: address(0), _name: "Stonks", _symbol: "STONK", _decimals: 18
         });
 
-        erc20 = new ERC20("Altcoin", "ALT");
         legacy = new LegacyMintable("Legacy", "LEG");
     }
 }
@@ -84,40 +78,28 @@ contract StandardBridge_Paused_Test is StandardBridge_TestInit {
 /// @title StandardBridge_IsOptimismMintableERC20_Test
 /// @notice Tests the `_isOptimismMintableERC20` internal function of `StandardBridge`.
 contract StandardBridge_IsOptimismMintableERC20_Test is StandardBridge_TestInit {
-    /// @notice Test coverage for identifying OptimismMintableERC20 tokens. This function should
-    ///         return true for both modern and legacy OptimismMintableERC20 tokens and false for
-    ///         any accounts that do not implement the interface.
     function test_isOptimismMintableERC20_succeeds() external view {
-        // Both the modern and legacy mintable tokens should return true
         assertTrue(bridge.isOptimismMintableERC20(address(mintable)));
         assertTrue(bridge.isOptimismMintableERC20(address(legacy)));
-        // A regular ERC20 should return false
-        assertFalse(bridge.isOptimismMintableERC20(address(erc20)));
-        // Non existent contracts should return false and not revert
-        assertEq(address(0x20).code.length, 0);
-        assertFalse(bridge.isOptimismMintableERC20(address(0x20)));
+        assertFalse(bridge.isOptimismMintableERC20(address(L1Token)));
+
+        assertEq(OTHER_TOKEN.code.length, 0);
+        assertFalse(bridge.isOptimismMintableERC20(OTHER_TOKEN));
     }
 }
 
 /// @title StandardBridge_IsCorrectTokenPair_Test
 /// @notice Tests the `_isCorrectTokenPair` internal function of `StandardBridge`.
 contract StandardBridge_IsCorrectTokenPair_Test is StandardBridge_TestInit {
-    /// @notice Test coverage of `isCorrectTokenPair` under different types of tokens.
     function test_isCorrectTokenPair_succeeds() external {
-        // Modern + known to be correct remote token
         assertTrue(bridge.isCorrectTokenPair(address(mintable), mintable.remoteToken()));
-        // Modern + known to be correct l1Token (legacy interface)
         assertTrue(bridge.isCorrectTokenPair(address(mintable), mintable.l1Token()));
-        // Modern + known to be incorrect remote token
-        assertTrue(mintable.remoteToken() != address(0x20));
-        assertFalse(bridge.isCorrectTokenPair(address(mintable), address(0x20)));
-        // Legacy + known to be correct l1Token
+        assertFalse(bridge.isCorrectTokenPair(address(mintable), OTHER_TOKEN));
+
         assertTrue(bridge.isCorrectTokenPair(address(legacy), legacy.l1Token()));
-        // Legacy + known to be incorrect l1Token
-        assertTrue(legacy.l1Token() != address(0x20));
-        assertFalse(bridge.isCorrectTokenPair(address(legacy), address(0x20)));
-        // A token that doesn't support either modern or legacy interface will revert
+        assertFalse(bridge.isCorrectTokenPair(address(legacy), OTHER_TOKEN));
+
         vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
-        bridge.isCorrectTokenPair(address(erc20), address(1));
+        bridge.isCorrectTokenPair(address(L1Token), address(1));
     }
 }

--- a/test/universal/WETH98.t.sol
+++ b/test/universal/WETH98.t.sol
@@ -5,8 +5,7 @@ pragma solidity 0.8.15;
 import { Test } from "lib/forge-std/src/Test.sol";
 
 // Contracts
-import { IWETH98 } from "interfaces/universal/IWETH98.sol";
-import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { WETH98 } from "src/universal/WETH98.sol";
 
 /// @title WETH98_TestInit
 /// @notice Reusable test initialization for `WETH98` tests.
@@ -16,19 +15,20 @@ abstract contract WETH98_TestInit is Test {
     event Deposit(address indexed dst, uint256 wad);
     event Withdrawal(address indexed src, uint256 wad);
 
-    IWETH98 public weth;
+    WETH98 public weth;
     address alice;
     address bob;
 
     function setUp() public {
-        weth = IWETH98(
-            DeployUtils.create1({
-                _name: "WETH98", _args: DeployUtils.encodeConstructor(abi.encodeCall(IWETH98.__constructor__, ()))
-            })
-        );
+        weth = new WETH98();
         alice = makeAddr("alice");
         bob = makeAddr("bob");
-        deal(alice, 1 ether);
+    }
+
+    function _depositAlice(uint256 _amount) internal {
+        deal(alice, _amount);
+        vm.prank(alice);
+        weth.deposit{ value: _amount }();
     }
 }
 
@@ -36,6 +36,7 @@ abstract contract WETH98_TestInit is Test {
 /// @notice Tests the `receive` function of the `WETH98` contract.
 contract WETH98_Receive_Test is WETH98_TestInit {
     function test_receive_succeeds() public {
+        deal(alice, 1 ether);
         vm.expectEmit(address(weth));
         emit Deposit(alice, 1 ether);
         vm.prank(alice);
@@ -49,6 +50,7 @@ contract WETH98_Receive_Test is WETH98_TestInit {
 /// @notice Tests the `fallback` function of the `WETH98` contract.
 contract WETH98_Fallback_Test is WETH98_TestInit {
     function test_fallback_succeeds() public {
+        deal(alice, 1 ether);
         vm.expectEmit(address(weth));
         emit Deposit(alice, 1 ether);
         vm.prank(alice);
@@ -62,6 +64,7 @@ contract WETH98_Fallback_Test is WETH98_TestInit {
 /// @notice Tests the `deposit` function of the `WETH98` contract.
 contract WETH98_Deposit_Test is WETH98_TestInit {
     function test_deposit_succeeds() public {
+        deal(alice, 1 ether);
         vm.expectEmit(address(weth));
         emit Deposit(alice, 1 ether);
         vm.prank(alice);
@@ -74,8 +77,7 @@ contract WETH98_Deposit_Test is WETH98_TestInit {
 /// @notice Tests the `withdraw` function of the `WETH98` contract.
 contract WETH98_Withdraw_Test is WETH98_TestInit {
     function test_withdraw_succeeds() public {
-        vm.prank(alice);
-        weth.deposit{ value: 1 ether }();
+        _depositAlice(1 ether);
         vm.expectEmit(address(weth));
         emit Withdrawal(alice, 1 ether);
         vm.prank(alice);
@@ -84,8 +86,7 @@ contract WETH98_Withdraw_Test is WETH98_TestInit {
     }
 
     function test_withdraw_partialWithdrawal_succeeds() public {
-        vm.prank(alice);
-        weth.deposit{ value: 1 ether }();
+        _depositAlice(1 ether);
         vm.expectEmit(address(weth));
         emit Withdrawal(alice, 1 ether / 2);
         vm.prank(alice);
@@ -94,9 +95,8 @@ contract WETH98_Withdraw_Test is WETH98_TestInit {
     }
 
     function test_withdraw_tooLargeWithdrawal_fails() public {
-        vm.prank(alice);
-        weth.deposit{ value: 1 ether }();
-        vm.expectRevert();
+        _depositAlice(1 ether);
+        vm.expectRevert(bytes(""));
         vm.prank(alice);
         weth.withdraw(1 ether + 1);
     }
@@ -118,8 +118,7 @@ contract WETH98_Approve_Test is WETH98_TestInit {
 /// @notice Tests the `transfer` function of the `WETH98` contract.
 contract WETH98_Transfer_Test is WETH98_TestInit {
     function test_transfer_succeeds() public {
-        vm.prank(alice);
-        weth.deposit{ value: 1 ether }();
+        _depositAlice(1 ether);
         vm.expectEmit(address(weth));
         emit Transfer(alice, bob, 1 ether);
         vm.prank(alice);
@@ -129,9 +128,8 @@ contract WETH98_Transfer_Test is WETH98_TestInit {
     }
 
     function test_transfer_tooLarge_fails() public {
-        vm.prank(alice);
-        weth.deposit{ value: 1 ether }();
-        vm.expectRevert();
+        _depositAlice(1 ether);
+        vm.expectRevert(bytes(""));
         vm.prank(alice);
         weth.transfer(bob, 1 ether + 1);
     }
@@ -141,8 +139,7 @@ contract WETH98_Transfer_Test is WETH98_TestInit {
 /// @notice Tests the `transferFrom` function of the `WETH98` contract.
 contract WETH98_TransferFrom_Test is WETH98_TestInit {
     function test_transferFrom_succeeds() public {
-        vm.prank(alice);
-        weth.deposit{ value: 1 ether }();
+        _depositAlice(1 ether);
         vm.prank(alice);
         weth.approve(bob, 1 ether);
         vm.expectEmit(address(weth));
@@ -154,21 +151,19 @@ contract WETH98_TransferFrom_Test is WETH98_TestInit {
     }
 
     function test_transferFrom_tooLittleApproval_fails() public {
-        vm.prank(alice);
-        weth.deposit{ value: 1 ether }();
+        _depositAlice(1 ether);
         vm.prank(alice);
         weth.approve(bob, 1 ether);
-        vm.expectRevert();
+        vm.expectRevert(bytes(""));
         vm.prank(bob);
         weth.transferFrom(alice, bob, 1 ether + 1);
     }
 
     function test_transferFrom_tooLittleBalance_fails() public {
-        vm.prank(alice);
-        weth.deposit{ value: 1 ether }();
+        _depositAlice(1 ether);
         vm.prank(alice);
         weth.approve(bob, 2 ether);
-        vm.expectRevert();
+        vm.expectRevert(bytes(""));
         vm.prank(bob);
         weth.transferFrom(alice, bob, 1 ether + 1);
     }


### PR DESCRIPTION
### What changed? Why?

Simplifies the universal test suite by removing repeated setup, repeated assertions, and duplicate getter/interface coverage across the affected tests.

This keeps the same behavioral coverage while making the tests shorter and easier to review. The cleanup touches the universal test files for CrossDomainMessenger, multisig scripts, OptimismMintableERC20, Proxy, ProxyAdmin, ProxyAdminOwnedBase, StandardBridge, WETH98, and related helpers.

### Notes to reviewers

- This is test-only and does not change production contracts.
- Proxy tests now deploy `Proxy` directly instead of going through `DeployUtils.create1`.
- CrossDomainMessenger tests now use `ForgeArtifacts.getSlot` to look up the portal `l2Sender` storage slot instead of relying on a hardcoded slot index.
- Several tests now share small helper functions for repeated minting, proxy admin calls, gas calculations, and message status assertions.

### How has it been tested?

- `FOUNDRY_PROFILE=lite forge test --match-path 'test/universal/*.t.sol'`