### PR TITLE
chore(tests): simplify util and vendor tests

### DIFF
--- a/test/utils/CBMulticall.t.sol
+++ b/test/utils/CBMulticall.t.sol
@@ -4,9 +4,7 @@ pragma solidity 0.8.25;
 import { CBMulticall, Call, Call3, Call3Value, Result } from "src/universal/CBMulticall.sol";
 import { Test } from "lib/forge-std/src/Test.sol";
 
-/// @dev Helper contract used to invoke `aggregateDelegateCalls` via `delegatecall`.
-///      This simulates the intended multisig usage pattern where the multicall
-///      logic is executed in the context of another contract.
+/// @dev Invokes `aggregateDelegateCalls` through `delegatecall` to simulate multisig execution.
 contract CBMulticallDelegateCaller {
     CBMulticall public mc;
 
@@ -15,8 +13,13 @@ contract CBMulticallDelegateCaller {
     }
 
     function aggregateDelegateCalls(Call3[] calldata calls) external returns (Result[] memory) {
-        (, bytes memory data) =
+        (bool success, bytes memory data) =
             address(mc).delegatecall(abi.encodeWithSelector(CBMulticall.aggregateDelegateCalls.selector, calls));
+        if (!success) {
+            assembly ("memory-safe") {
+                revert(add(data, 0x20), mload(data))
+            }
+        }
         return abi.decode(data, (Result[]));
     }
 }
@@ -36,20 +39,40 @@ contract MockReceiver {
 }
 
 contract CBMulticallTest is Test {
+    string internal constant MULTICALL_CALL_FAILED = "Multicall3: call failed";
+
     CBMulticall mc;
     MockReceiver target;
-    CBMulticallDelegateCaller delegateCaller;
 
     function setUp() public {
         mc = new CBMulticall();
         target = new MockReceiver();
-        delegateCaller = new CBMulticallDelegateCaller(mc);
+    }
+
+    function _bumpCall(uint256 x) internal view returns (Call memory) {
+        return Call({ target: address(target), callData: abi.encodeCall(MockReceiver.bump, (x)) });
+    }
+
+    function _revertingCall() internal view returns (Call memory) {
+        return Call({ target: address(target), callData: abi.encodeCall(MockReceiver.willRevert, ()) });
+    }
+
+    function _bumpCall3(bool allowFailure, uint256 x) internal view returns (Call3 memory) {
+        return Call3({
+            target: address(target), allowFailure: allowFailure, callData: abi.encodeCall(MockReceiver.bump, (x))
+        });
+    }
+
+    function _revertingCall3(bool allowFailure) internal view returns (Call3 memory) {
+        return Call3({
+            target: address(target), allowFailure: allowFailure, callData: abi.encodeCall(MockReceiver.willRevert, ())
+        });
     }
 
     function test_aggregate_returnsBlockNumberAndData() external {
         Call[] memory calls = new Call[](2);
-        calls[0] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 41) });
-        calls[1] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 1) });
+        calls[0] = _bumpCall(41);
+        calls[1] = _bumpCall(1);
 
         (uint256 bn, bytes[] memory rdata) = mc.aggregate(calls);
         assertEq(bn, block.number);
@@ -59,16 +82,16 @@ contract CBMulticallTest is Test {
 
     function test_aggregate_revertsOnFailedCall() external {
         Call[] memory calls = new Call[](2);
-        calls[0] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 0) });
-        calls[1] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.willRevert.selector) });
-        vm.expectRevert(bytes("Multicall3: call failed"));
+        calls[0] = _bumpCall(0);
+        calls[1] = _revertingCall();
+        vm.expectRevert(bytes(MULTICALL_CALL_FAILED));
         mc.aggregate(calls);
     }
 
     function test_tryAggregate_noRequire_returnsResults() external {
         Call[] memory calls = new Call[](2);
-        calls[0] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 1) });
-        calls[1] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.willRevert.selector) });
+        calls[0] = _bumpCall(1);
+        calls[1] = _revertingCall();
 
         Result[] memory results = mc.tryAggregate(false, calls);
         assertEq(results.length, 2);
@@ -79,16 +102,16 @@ contract CBMulticallTest is Test {
 
     function test_tryAggregate_requireSuccess_revertsOnFailure() external {
         Call[] memory calls = new Call[](2);
-        calls[0] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 0) });
-        calls[1] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.willRevert.selector) });
-        vm.expectRevert(bytes("Multicall3: call failed"));
+        calls[0] = _bumpCall(0);
+        calls[1] = _revertingCall();
+        vm.expectRevert(bytes(MULTICALL_CALL_FAILED));
         mc.tryAggregate(true, calls);
     }
 
     function test_tryBlockAndAggregate_noRequire_returnsBlockInfoAndResults() external {
         Call[] memory calls = new Call[](2);
-        calls[0] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 0) });
-        calls[1] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.willRevert.selector) });
+        calls[0] = _bumpCall(0);
+        calls[1] = _revertingCall();
 
         (uint256 bn, bytes32 bh, Result[] memory res) = mc.tryBlockAndAggregate(false, calls);
         assertEq(bn, block.number);
@@ -100,8 +123,8 @@ contract CBMulticallTest is Test {
 
     function test_blockAndAggregate_allSuccess_returnsResults() external {
         Call[] memory calls = new Call[](2);
-        calls[0] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 1) });
-        calls[1] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 2) });
+        calls[0] = _bumpCall(1);
+        calls[1] = _bumpCall(2);
         (uint256 bn, bytes32 bh, Result[] memory res) = mc.blockAndAggregate(calls);
         assertEq(bn, block.number);
         assertEq(bh, blockhash(block.number));
@@ -111,126 +134,101 @@ contract CBMulticallTest is Test {
 
     function test_blockAndAggregate_revertsOnFailure() external {
         Call[] memory calls = new Call[](2);
-        calls[0] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 0) });
-        calls[1] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.willRevert.selector) });
-        vm.expectRevert(bytes("Multicall3: call failed"));
+        calls[0] = _bumpCall(0);
+        calls[1] = _revertingCall();
+        vm.expectRevert(bytes(MULTICALL_CALL_FAILED));
         mc.blockAndAggregate(calls);
     }
 
     function test_tryBlockAndAggregate_requireSuccess_revertsOnFailure() external {
         Call[] memory calls = new Call[](2);
-        calls[0] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.bump.selector, 0) });
-        calls[1] = Call({ target: address(target), callData: abi.encodeWithSelector(MockReceiver.willRevert.selector) });
-        vm.expectRevert(bytes("Multicall3: call failed"));
+        calls[0] = _bumpCall(0);
+        calls[1] = _revertingCall();
+        vm.expectRevert(bytes(MULTICALL_CALL_FAILED));
         mc.tryBlockAndAggregate(true, calls);
     }
 
     function test_aggregate3_success() external {
-        Call3[] memory calls3 = new Call3[](1);
-        calls3[0] = Call3({
-            target: address(target),
-            allowFailure: false,
-            callData: abi.encodeWithSelector(MockReceiver.bump.selector, 4)
-        });
-        Result[] memory ret3 = mc.aggregate3(calls3);
-        assertTrue(ret3[0].success);
-        assertEq(abi.decode(ret3[0].returnData, (uint256)), 5);
+        Call3[] memory calls = new Call3[](1);
+        calls[0] = _bumpCall3(false, 4);
+        Result[] memory results = mc.aggregate3(calls);
+        assertTrue(results[0].success);
+        assertEq(abi.decode(results[0].returnData, (uint256)), 5);
     }
 
     function test_aggregate3_allowedFailure_returnsFalse() external {
-        Call3[] memory calls3 = new Call3[](1);
-        calls3[0] = Call3({
-            target: address(target),
-            allowFailure: true,
-            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
-        });
-        Result[] memory ret3 = mc.aggregate3(calls3);
-        assertFalse(ret3[0].success);
+        Call3[] memory calls = new Call3[](1);
+        calls[0] = _revertingCall3(true);
+        Result[] memory results = mc.aggregate3(calls);
+        assertFalse(results[0].success);
     }
 
     function test_aggregate3_revertsOnNonAllowedFailure() external {
-        Call3[] memory calls3 = new Call3[](1);
-        calls3[0] = Call3({
-            target: address(target),
-            allowFailure: false,
-            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
-        });
-        vm.expectRevert(bytes("Multicall3: call failed"));
-        mc.aggregate3(calls3);
+        Call3[] memory calls = new Call3[](1);
+        calls[0] = _revertingCall3(false);
+        vm.expectRevert(bytes(MULTICALL_CALL_FAILED));
+        mc.aggregate3(calls);
     }
 
     function test_aggregateDelegateCalls_success() external {
-        Call3[] memory calls3 = new Call3[](1);
-        calls3[0] = Call3({
-            target: address(target),
-            allowFailure: false,
-            callData: abi.encodeWithSelector(MockReceiver.bump.selector, 4)
-        });
-        Result[] memory ret3 = delegateCaller.aggregateDelegateCalls(calls3);
-        assertTrue(ret3[0].success);
-        assertEq(abi.decode(ret3[0].returnData, (uint256)), 5);
+        CBMulticallDelegateCaller caller = new CBMulticallDelegateCaller(mc);
+        Call3[] memory calls = new Call3[](1);
+        calls[0] = _bumpCall3(false, 4);
+        Result[] memory results = caller.aggregateDelegateCalls(calls);
+        assertTrue(results[0].success);
+        assertEq(abi.decode(results[0].returnData, (uint256)), 5);
     }
 
     function test_aggregateDelegateCalls_allowedFailure_returnsFalse() external {
-        Call3[] memory calls3 = new Call3[](1);
-        calls3[0] = Call3({
-            target: address(target),
-            allowFailure: true,
-            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
-        });
-        Result[] memory ret3 = delegateCaller.aggregateDelegateCalls(calls3);
-        assertFalse(ret3[0].success);
+        CBMulticallDelegateCaller caller = new CBMulticallDelegateCaller(mc);
+        Call3[] memory calls = new Call3[](1);
+        calls[0] = _revertingCall3(true);
+        Result[] memory results = caller.aggregateDelegateCalls(calls);
+        assertFalse(results[0].success);
     }
 
     function test_aggregateDelegateCalls_revertsOnNonAllowedFailure() external {
-        Call3[] memory calls3 = new Call3[](1);
-        calls3[0] = Call3({
-            target: address(target),
-            allowFailure: false,
-            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
-        });
-        vm.expectRevert();
-        delegateCaller.aggregateDelegateCalls(calls3);
+        CBMulticallDelegateCaller caller = new CBMulticallDelegateCaller(mc);
+        Call3[] memory calls = new Call3[](1);
+        calls[0] = _revertingCall3(false);
+        vm.expectRevert(bytes(MULTICALL_CALL_FAILED));
+        caller.aggregateDelegateCalls(calls);
     }
 
     function test_aggregateDelegateCalls_directCall_revertsWithMustDelegateCall() external {
-        Call3[] memory calls3 = new Call3[](1);
-        calls3[0] = Call3({
-            target: address(target),
-            allowFailure: false,
-            callData: abi.encodeWithSelector(MockReceiver.bump.selector, 1)
-        });
+        Call3[] memory calls = new Call3[](1);
+        calls[0] = _bumpCall3(false, 1);
 
         vm.expectRevert(CBMulticall.MustDelegateCall.selector);
-        mc.aggregateDelegateCalls(calls3);
+        mc.aggregateDelegateCalls(calls);
     }
 
     function test_aggregate3Value_success_usesContractBalance() external {
         vm.deal(address(mc), 1 ether);
-        Call3Value[] memory callsV = new Call3Value[](1);
-        callsV[0] = Call3Value({
+        Call3Value[] memory calls = new Call3Value[](1);
+        calls[0] = Call3Value({
             target: address(target),
             allowFailure: false,
             value: 0.5 ether,
-            callData: abi.encodeWithSelector(MockReceiver.payAndEcho.selector, 7)
+            callData: abi.encodeCall(MockReceiver.payAndEcho, (7))
         });
-        Result[] memory retV = mc.aggregate3Value(callsV);
-        (uint256 x, uint256 v) = abi.decode(retV[0].returnData, (uint256, uint256));
+        Result[] memory results = mc.aggregate3Value(calls);
+        (uint256 x, uint256 v) = abi.decode(results[0].returnData, (uint256, uint256));
         assertEq(x, 7);
         assertEq(v, 0.5 ether);
         assertEq(address(target).balance, 0.5 ether);
     }
 
     function test_aggregate3Value_revertsOnNonAllowedFailure() external {
-        Call3Value[] memory callsV = new Call3Value[](1);
-        callsV[0] = Call3Value({
+        Call3Value[] memory calls = new Call3Value[](1);
+        calls[0] = Call3Value({
             target: address(target),
             allowFailure: false,
             value: 0,
-            callData: abi.encodeWithSelector(MockReceiver.willRevert.selector)
+            callData: abi.encodeCall(MockReceiver.willRevert, ())
         });
-        vm.expectRevert(bytes("Multicall3: call failed"));
-        mc.aggregate3Value(callsV);
+        vm.expectRevert(bytes(MULTICALL_CALL_FAILED));
+        mc.aggregate3Value(calls);
     }
 
     function test_getBlockNumber() external view {

--- a/test/vendor/AddressAliasHelper.t.sol
+++ b/test/vendor/AddressAliasHelper.t.sol
@@ -8,7 +8,6 @@ import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 /// @notice General tests that are not testing any function directly of the `AddressAliasHelper`
 ///         contract or are testing multiple functions at once.
 contract AddressAliasHelper_Uncategorized_Test is Test {
-    /// @notice Tests that applying and then undoing an alias results in the original address.
     function testFuzz_applyAndUndo_succeeds(address _address) external pure {
         address aliased = AddressAliasHelper.applyL1ToL2Alias(_address);
         address unaliased = AddressAliasHelper.undoL1ToL2Alias(aliased);

--- a/test/vendor/Initializable.t.sol
+++ b/test/vendor/Initializable.t.sol
@@ -22,9 +22,7 @@ import { TEEProverRegistry } from "src/L1/proofs/tee/TEEProverRegistry.sol";
 
 /// @title Initializer_Test
 /// @dev Ensures that the `initialize()` function on contracts cannot be called more than
-///      once. This contract inherits from `ERC721Bridge_Initializer` because it is the
-///      deepest contract in the inheritance chain for setting up the system contracts.
-///      For each L1 contract both the implementation and the proxy are tested.
+///      once. For each L1 contract both the implementation and the proxy are tested.
 contract Initializer_Test is CommonTest {
     /// @notice Contains the address of an `Initializable` contract and the calldata
     ///         used to initialize it.
@@ -37,263 +35,195 @@ contract Initializer_Test is CommonTest {
     /// @notice Array of contracts to test.
     InitializeableContract[] contracts;
 
-    /// @notice Mapping of nickname to actual contract name.
-    /// @dev Nicknames are only used when one proxy contract has multiple potential implementations
-    ///      as can happen when a new implementation is being developed.
-    mapping(string => string) nicknames;
-
     function setUp() public override {
         super.setUp();
 
-        // Initialize the `contracts` array with the addresses of the contracts to test, the
-        // calldata used to initialize them, and the storage slot of their `_initialized` flag.
+        // Initialize the `contracts` array with the addresses of the contracts to test and the
+        // calldata used to initialize them.
         // This array should contain all initializable L1 contracts. L2 contract initialization is
         // tested in Predeploys.t.sol.
-        // The 'name' field should be the name of the contract as it saved in the deployment
+        // The 'name' field should be the name of the contract as it is saved in the deployment
         // script.
 
-        // L1CrossDomainMessengerImpl
+        bytes memory initCalldata = abi.encodeCall(l1CrossDomainMessenger.initialize, (systemConfig, optimismPortal2));
         contracts.push(
             InitializeableContract({
                 name: "L1CrossDomainMessengerImpl",
                 target: addressManager.getAddress("OVM_L1CrossDomainMessenger"),
-                initCalldata: abi.encodeCall(l1CrossDomainMessenger.initialize, (systemConfig, optimismPortal2))
+                initCalldata: initCalldata
             })
         );
-        // L1CrossDomainMessengerProxy
         contracts.push(
             InitializeableContract({
-                name: "L1CrossDomainMessengerProxy",
-                target: address(l1CrossDomainMessenger),
-                initCalldata: abi.encodeCall(l1CrossDomainMessenger.initialize, (systemConfig, optimismPortal2))
+                name: "L1CrossDomainMessengerProxy", target: address(l1CrossDomainMessenger), initCalldata: initCalldata
             })
         );
-        // DisputeGameFactoryImpl
+
+        initCalldata = abi.encodeCall(disputeGameFactory.initialize, (address(0)));
         contracts.push(
             InitializeableContract({
                 name: "DisputeGameFactoryImpl",
                 target: EIP1967Helper.getImplementation(address(disputeGameFactory)),
-                initCalldata: abi.encodeCall(disputeGameFactory.initialize, (address(0)))
+                initCalldata: initCalldata
             })
         );
-        // DisputeGameFactoryProxy
         contracts.push(
             InitializeableContract({
-                name: "DisputeGameFactoryProxy",
-                target: address(disputeGameFactory),
-                initCalldata: abi.encodeCall(disputeGameFactory.initialize, (address(0)))
+                name: "DisputeGameFactoryProxy", target: address(disputeGameFactory), initCalldata: initCalldata
             })
         );
-        // DelayedWETHImpl
+
+        initCalldata = abi.encodeCall(delayedWeth.initialize, (ISystemConfig(address(0))));
         contracts.push(
             InitializeableContract({
                 name: "DelayedWETHImpl",
                 target: EIP1967Helper.getImplementation(address(delayedWeth)),
-                initCalldata: abi.encodeCall(delayedWeth.initialize, (ISystemConfig(address(0))))
+                initCalldata: initCalldata
             })
         );
-        // DelayedWETHProxy
         contracts.push(
             InitializeableContract({
-                name: "DelayedWETHProxy",
-                target: address(delayedWeth),
-                initCalldata: abi.encodeCall(delayedWeth.initialize, (ISystemConfig(address(0))))
+                name: "DelayedWETHProxy", target: address(delayedWeth), initCalldata: initCalldata
             })
         );
 
-        // OptimismPortal2Impl
+        initCalldata = abi.encodeCall(optimismPortal2.initialize, (systemConfig, anchorStateRegistry));
         contracts.push(
             InitializeableContract({
                 name: "OptimismPortal2Impl",
                 target: EIP1967Helper.getImplementation(address(optimismPortal2)),
-                initCalldata: abi.encodeCall(optimismPortal2.initialize, (systemConfig, anchorStateRegistry))
+                initCalldata: initCalldata
             })
         );
-        // OptimismPortal2Proxy
         contracts.push(
             InitializeableContract({
-                name: "OptimismPortal2Proxy",
-                target: address(optimismPortal2),
-                initCalldata: abi.encodeCall(optimismPortal2.initialize, (systemConfig, anchorStateRegistry))
+                name: "OptimismPortal2Proxy", target: address(optimismPortal2), initCalldata: initCalldata
             })
         );
 
-        // SystemConfigImpl
+        initCalldata = abi.encodeCall(
+            systemConfig.initialize,
+            (
+                address(0xdead),
+                0,
+                0,
+                bytes32(0),
+                1,
+                address(0),
+                IResourceMetering.ResourceConfig({
+                    maxResourceLimit: 1,
+                    elasticityMultiplier: 1,
+                    baseFeeMaxChangeDenominator: 2,
+                    minimumBaseFee: 0,
+                    systemTxMaxGas: 0,
+                    maximumBaseFee: 0
+                }),
+                address(0),
+                ISystemConfig.Addresses({
+                    l1CrossDomainMessenger: address(0),
+                    l1ERC721Bridge: address(0),
+                    l1StandardBridge: address(0),
+                    optimismPortal: address(0),
+                    optimismMintableERC20Factory: address(0),
+                    delayedWETH: address(0)
+                }),
+                0,
+                ISuperchainConfig(address(0))
+            )
+        );
         contracts.push(
             InitializeableContract({
                 name: "SystemConfigImpl",
                 target: EIP1967Helper.getImplementation(address(systemConfig)),
-                initCalldata: abi.encodeCall(
-                    systemConfig.initialize,
-                    (
-                        address(0xdead),
-                        0,
-                        0,
-                        bytes32(0),
-                        1,
-                        address(0),
-                        IResourceMetering.ResourceConfig({
-                            maxResourceLimit: 1,
-                            elasticityMultiplier: 1,
-                            baseFeeMaxChangeDenominator: 2,
-                            minimumBaseFee: 0,
-                            systemTxMaxGas: 0,
-                            maximumBaseFee: 0
-                        }),
-                        address(0),
-                        ISystemConfig.Addresses({
-                            l1CrossDomainMessenger: address(0),
-                            l1ERC721Bridge: address(0),
-                            l1StandardBridge: address(0),
-                            optimismPortal: address(0),
-                            optimismMintableERC20Factory: address(0),
-                            delayedWETH: address(0)
-                        }),
-                        0,
-                        ISuperchainConfig(address(0))
-                    )
-                )
+                initCalldata: initCalldata
             })
         );
-        // SystemConfigProxy
         contracts.push(
             InitializeableContract({
-                name: "SystemConfigProxy",
-                target: address(systemConfig),
-                initCalldata: abi.encodeCall(
-                    systemConfig.initialize,
-                    (
-                        address(0xdead),
-                        0,
-                        0,
-                        bytes32(0),
-                        1,
-                        address(0),
-                        IResourceMetering.ResourceConfig({
-                            maxResourceLimit: 1,
-                            elasticityMultiplier: 1,
-                            baseFeeMaxChangeDenominator: 2,
-                            minimumBaseFee: 0,
-                            systemTxMaxGas: 0,
-                            maximumBaseFee: 0
-                        }),
-                        address(0),
-                        ISystemConfig.Addresses({
-                            l1CrossDomainMessenger: address(0),
-                            l1ERC721Bridge: address(0),
-                            l1StandardBridge: address(0),
-                            optimismPortal: address(0),
-                            optimismMintableERC20Factory: address(0),
-                            delayedWETH: address(0)
-                        }),
-                        0,
-                        ISuperchainConfig(address(0))
-                    )
-                )
+                name: "SystemConfigProxy", target: address(systemConfig), initCalldata: initCalldata
             })
         );
-        // L1StandardBridgeImpl
+
+        initCalldata = abi.encodeCall(l1StandardBridge.initialize, (l1CrossDomainMessenger, systemConfig));
         contracts.push(
             InitializeableContract({
                 name: "L1StandardBridgeImpl",
                 target: EIP1967Helper.getImplementation(address(l1StandardBridge)),
-                initCalldata: abi.encodeCall(l1StandardBridge.initialize, (l1CrossDomainMessenger, systemConfig))
+                initCalldata: initCalldata
             })
         );
-        // L1StandardBridgeProxy
         contracts.push(
             InitializeableContract({
-                name: "L1StandardBridgeProxy",
-                target: address(l1StandardBridge),
-                initCalldata: abi.encodeCall(l1StandardBridge.initialize, (l1CrossDomainMessenger, systemConfig))
+                name: "L1StandardBridgeProxy", target: address(l1StandardBridge), initCalldata: initCalldata
             })
         );
-        // L1ERC721BridgeImpl
+
+        initCalldata = abi.encodeCall(l1ERC721Bridge.initialize, (l1CrossDomainMessenger, systemConfig));
         contracts.push(
             InitializeableContract({
                 name: "L1ERC721BridgeImpl",
                 target: EIP1967Helper.getImplementation(address(l1ERC721Bridge)),
-                initCalldata: abi.encodeCall(l1ERC721Bridge.initialize, (l1CrossDomainMessenger, systemConfig))
+                initCalldata: initCalldata
             })
         );
-        // L1ERC721BridgeProxy
         contracts.push(
             InitializeableContract({
-                name: "L1ERC721BridgeProxy",
-                target: address(l1ERC721Bridge),
-                initCalldata: abi.encodeCall(l1ERC721Bridge.initialize, (l1CrossDomainMessenger, systemConfig))
+                name: "L1ERC721BridgeProxy", target: address(l1ERC721Bridge), initCalldata: initCalldata
             })
         );
-        // OptimismMintableERC20FactoryImpl
+
+        initCalldata = abi.encodeCall(l1OptimismMintableERC20Factory.initialize, (address(l1StandardBridge)));
         contracts.push(
             InitializeableContract({
                 name: "OptimismMintableERC20FactoryImpl",
                 target: EIP1967Helper.getImplementation(address(l1OptimismMintableERC20Factory)),
-                initCalldata: abi.encodeCall(l1OptimismMintableERC20Factory.initialize, (address(l1StandardBridge)))
+                initCalldata: initCalldata
             })
         );
-        // OptimismMintableERC20FactoryProxy
         contracts.push(
             InitializeableContract({
                 name: "OptimismMintableERC20FactoryProxy",
                 target: address(l1OptimismMintableERC20Factory),
-                initCalldata: abi.encodeCall(l1OptimismMintableERC20Factory.initialize, (address(l1StandardBridge)))
+                initCalldata: initCalldata
             })
         );
-        // AnchorStateRegistry
+
+        initCalldata = abi.encodeCall(
+            anchorStateRegistry.initialize,
+            (
+                ISystemConfig(address(0)),
+                IDisputeGameFactory(address(0)),
+                Proposal({ root: Hash.wrap(bytes32(0)), l2SequenceNumber: 0 }),
+                GameType.wrap(uint32(deploy.cfg().respectedGameType()))
+            )
+        );
         contracts.push(
             InitializeableContract({
                 name: "AnchorStateRegistryImpl",
                 target: EIP1967Helper.getImplementation(address(anchorStateRegistry)),
-                initCalldata: abi.encodeCall(
-                    anchorStateRegistry.initialize,
-                    (
-                        ISystemConfig(address(0)),
-                        IDisputeGameFactory(address(0)),
-                        Proposal({ root: Hash.wrap(bytes32(0)), l2SequenceNumber: 0 }),
-                        GameType.wrap(uint32(deploy.cfg().respectedGameType()))
-                    )
-                )
+                initCalldata: initCalldata
             })
         );
-        // AnchorStateRegistryProxy
         contracts.push(
             InitializeableContract({
-                name: "AnchorStateRegistryProxy",
-                target: address(anchorStateRegistry),
-                initCalldata: abi.encodeCall(
-                    anchorStateRegistry.initialize,
-                    (
-                        ISystemConfig(address(0)),
-                        IDisputeGameFactory(address(0)),
-                        Proposal({ root: Hash.wrap(bytes32(0)), l2SequenceNumber: 0 }),
-                        GameType.wrap(uint32(deploy.cfg().respectedGameType()))
-                    )
-                )
+                name: "AnchorStateRegistryProxy", target: address(anchorStateRegistry), initCalldata: initCalldata
             })
         );
 
         // ETHLockbox is only deployed when interop is enabled
         if (address(ethLockbox) != address(0)) {
-            // ETHLockboxImpl
+            initCalldata = abi.encodeCall(ethLockbox.initialize, (ISystemConfig(address(0)), new IOptimismPortal2[](0)));
             contracts.push(
                 InitializeableContract({
                     name: "ETHLockboxImpl",
                     target: EIP1967Helper.getImplementation(address(ethLockbox)),
-                    initCalldata: abi.encodeCall(
-                        ethLockbox.initialize, (ISystemConfig(address(0)), new IOptimismPortal2[](0))
-                    )
+                    initCalldata: initCalldata
                 })
             );
 
-            // ETHLockboxProxy
             contracts.push(
                 InitializeableContract({
-                    name: "ETHLockboxProxy",
-                    target: address(ethLockbox),
-                    initCalldata: abi.encodeCall(
-                        ethLockbox.initialize, (ISystemConfig(address(0)), new IOptimismPortal2[](0))
-                    )
+                    name: "ETHLockboxProxy", target: address(ethLockbox), initCalldata: initCalldata
                 })
             );
         }
@@ -302,7 +232,6 @@ contract Initializer_Test is CommonTest {
         // uint8, so it cannot be tested by this framework. It is excluded below.
 
         if (address(teeProverRegistry) != address(0)) {
-            // TEEProverRegistryImpl
             contracts.push(
                 InitializeableContract({
                     name: "TEEProverRegistryImpl",
@@ -395,11 +324,10 @@ contract Initializer_Test is CommonTest {
         // Attempt to re-initialize all contracts within the `contracts` array.
         for (uint256 i; i < contracts.length; i++) {
             InitializeableContract memory _contract = contracts[i];
-            string memory deploymentName = _getRealContractName(_contract.name);
 
             // Assert that the contract is already initialized.
             assertTrue(
-                ForgeArtifacts.isInitialized({ _name: _removeSuffix(deploymentName), _address: _contract.target }),
+                ForgeArtifacts.isInitialized({ _name: _removeSuffix(_contract.name), _address: _contract.target }),
                 "Initializable: contract is not initialized"
             );
 
@@ -415,18 +343,10 @@ contract Initializer_Test is CommonTest {
     /// @return matching_ True if the contract is in the `contracts` array, false otherwise.
     function _hasMatchingContract(string memory _name) internal view returns (bool matching_) {
         for (uint256 i; i < contracts.length; i++) {
-            if (LibString.eq(contracts[i].name, _getRealContractName(_name))) {
-                // return early
+            if (LibString.eq(contracts[i].name, _name)) {
                 return true;
             }
         }
-    }
-
-    /// @dev Returns the real name of the contract, including any nicknames.
-    /// @param _name The name of the contract.
-    /// @return real_ The real name of the contract.
-    function _getRealContractName(string memory _name) internal view returns (string memory real_) {
-        real_ = bytes(nicknames[_name]).length > 0 ? nicknames[_name] : _name;
     }
 
     /// @dev Extracts the revert string from returndata encoded in the form of `Error(string)`.

--- a/test/vendor/InitializableOZv5.t.sol
+++ b/test/vendor/InitializableOZv5.t.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.25;
 
 import { Test } from "lib/forge-std/src/Test.sol";
-import { Initializable } from "lib/openzeppelin-contracts-v5/contracts/proxy/utils/Initializable.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
 import { Types } from "src/libraries/Types.sol";
+import { Initializable } from "src/vendor/Initializable.sol";
 
 /// @title InitializerOZv5_Test
 /// @dev Ensures that the `initialize()` function on contracts cannot be called more than

--- a/test/vendor/InitializableOZv5.t.sol
+++ b/test/vendor/InitializableOZv5.t.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.25;
 
 import { Test } from "lib/forge-std/src/Test.sol";
+import { Initializable } from "lib/openzeppelin-contracts-v5/contracts/proxy/utils/Initializable.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
 import { Types } from "src/libraries/Types.sol";
-import { Initializable } from "src/vendor/Initializable.sol";
 
 /// @title InitializerOZv5_Test
 /// @dev Ensures that the `initialize()` function on contracts cannot be called more than
@@ -16,95 +16,55 @@ contract InitializerOZv5_Test is Test {
     /// keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.Initializable")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant INITIALIZABLE_STORAGE = 0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
 
-    /// @notice Contains the address of an `Initializable` contract and the calldata
-    ///         used to initialize it.
-    struct InitializeableContract {
+    struct InitializableContract {
         address target;
         bytes initCalldata;
     }
 
-    /// @notice Contains the addresses of the contracts to test as well as the calldata
-    ///         used to initialize them.
-    InitializeableContract[] contracts;
+    InitializableContract[] private contracts;
 
     function setUp() public {
-        // Initialize the `contracts` array with the addresses of the contracts to test and the
-        // calldata used to initialize them
+        bytes memory constructorArgs = DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, ()));
+        bytes memory initCalldata = abi.encodeCall(IFeeVault.initialize, (address(0), 0, Types.WithdrawalNetwork.L1));
 
-        // BaseFeeVault
         contracts.push(
-            InitializeableContract({
-                target: address(
-                    DeployUtils.create1({
-                        _name: "BaseFeeVault",
-                        _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, ()))
-                    })
-                ),
-                initCalldata: abi.encodeCall(IFeeVault.initialize, (address(0), 0, Types.WithdrawalNetwork.L1))
+            InitializableContract({
+                target: address(DeployUtils.create1({ _name: "BaseFeeVault", _args: constructorArgs })),
+                initCalldata: initCalldata
             })
         );
 
-        // OperatorFeeVault
         contracts.push(
-            InitializeableContract({
-                target: address(
-                    DeployUtils.create1({
-                        _name: "OperatorFeeVault",
-                        _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, ()))
-                    })
-                ),
-                initCalldata: abi.encodeCall(IFeeVault.initialize, (address(0), 0, Types.WithdrawalNetwork.L1))
+            InitializableContract({
+                target: address(DeployUtils.create1({ _name: "OperatorFeeVault", _args: constructorArgs })),
+                initCalldata: initCalldata
             })
         );
 
-        // SequencerFeeVault
         contracts.push(
-            InitializeableContract({
-                target: address(
-                    DeployUtils.create1({
-                        _name: "SequencerFeeVault",
-                        _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, ()))
-                    })
-                ),
-                initCalldata: abi.encodeCall(IFeeVault.initialize, (address(0), 0, Types.WithdrawalNetwork.L1))
+            InitializableContract({
+                target: address(DeployUtils.create1({ _name: "SequencerFeeVault", _args: constructorArgs })),
+                initCalldata: initCalldata
             })
         );
 
-        // L1FeeVault
         contracts.push(
-            InitializeableContract({
-                target: address(
-                    DeployUtils.create1({
-                        _name: "L1FeeVault",
-                        _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, ()))
-                    })
-                ),
-                initCalldata: abi.encodeCall(IFeeVault.initialize, (address(0), 0, Types.WithdrawalNetwork.L1))
+            InitializableContract({
+                target: address(DeployUtils.create1({ _name: "L1FeeVault", _args: constructorArgs })),
+                initCalldata: initCalldata
             })
         );
     }
 
-    /// @notice Tests that:
-    ///         1. The `initialized` flag of each contract is properly set to `type(uint64).max`,
-    ///            signifying that the contracts are initialized.
-    ///         2. The `initialize()` function of each contract cannot be called more than once.
-    ///         3. Returns the correct error when attempting to re-initialize a contract.
+    /// @notice Ensures OZ v5 initializers are disabled on deployed FeeVault contracts.
     function test_cannotReinitialize_succeeds() public {
-        // Attempt to re-initialize all contracts within the `contracts` array.
         for (uint256 i; i < contracts.length; i++) {
-            InitializeableContract memory _contract = contracts[i];
-            uint256 size;
-            address target = _contract.target;
-            assembly {
-                size := extcodesize(target)
-            }
+            InitializableContract memory _contract = contracts[i];
 
-            // Assert that the contract is already initialized.
             bytes32 slotVal = vm.load(_contract.target, INITIALIZABLE_STORAGE);
             uint64 initialized = uint64(uint256(slotVal));
             assertEq(initialized, type(uint64).max);
 
-            // Then, attempt to re-initialize the contract. This should fail.
             (bool success, bytes memory returnData) = _contract.target.call(_contract.initCalldata);
             assertFalse(success);
             assertEq(bytes4(returnData), Initializable.InvalidInitialization.selector);


### PR DESCRIPTION
### What changed? Why?

Simplifies the utility and vendor test suites by reducing repeated test setup and reusing common calldata construction.

- Adds helper constructors for repeated CBMulticall call payloads and makes delegatecall failures bubble the underlying revert data in the test helper.
- Reuses initializer calldata across implementation/proxy pairs in Initializable.t.sol and removes the unused nickname indirection.
- Updates the OpenZeppelin v5 initializer test to import the v5 Initializable type directly, reuse FeeVault constructor/init calldata, and assert the expected custom error selector.
- Removes redundant test comments where the test name already captures the behavior.

### Notes to reviewers

This is intended to be a test-only cleanup. The production contract surface is unchanged.

The CBMulticallDelegateCaller test helper now bubbles revert data so the non-allowed delegatecall failure test can assert the expected "Multicall3: call failed" revert instead of accepting any revert.

### How has it been tested?

```sh
forge test --match-path test/utils/CBMulticall.t.sol
```

Result: 26 passed, 0 failed, 0 skipped.