### PR TITLE
Update README Base links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 This repo contains contracts and scripts for Base.
 Note that Base primarily utilizes Optimism's bedrock contracts located in Optimism's repo [here](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock).
-For contract deployment artifacts, see [base-org/contract-deployments](https://github.com/base-org/contract-deployments).
+For contract deployment artifacts, see [base/contract-deployments](https://github.com/base/contract-deployments).
 
 <!-- Badge row 1 - status -->
 
-[![GitHub contributors](https://img.shields.io/github/contributors/base-org/contracts)](https://github.com/base/contracts/graphs/contributors)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base-org/contracts)](https://github.com/base/contracts/graphs/contributors)
-[![GitHub Stars](https://img.shields.io/github/stars/base-org/contracts.svg)](https://github.com/base/contracts/stargazers)
-![GitHub repo size](https://img.shields.io/github/repo-size/base-org/contracts)
-[![GitHub](https://img.shields.io/github/license/base-org/contracts?color=blue)](https://github.com/base/contracts/blob/main/LICENSE)
+[![GitHub contributors](https://img.shields.io/github/contributors/base/contracts)](https://github.com/base/contracts/graphs/contributors)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base/contracts)](https://github.com/base/contracts/graphs/contributors)
+[![GitHub Stars](https://img.shields.io/github/stars/base/contracts.svg)](https://github.com/base/contracts/stargazers)
+![GitHub repo size](https://img.shields.io/github/repo-size/base/contracts)
+[![GitHub](https://img.shields.io/github/license/base/contracts?color=blue)](https://github.com/base/contracts/blob/main/LICENSE)
 
 <!-- Badge row 2 - links and profiles -->
 
@@ -24,8 +24,8 @@ For contract deployment artifacts, see [base-org/contract-deployments](https://g
 
 <!-- Badge row 3 - detailed status -->
 
-[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base-org/contracts)](https://github.com/base/contracts/pulls)
-[![GitHub Issues](https://img.shields.io/github/issues-raw/base-org/contracts.svg)](https://github.com/base/contracts/issues)
+[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base/contracts)](https://github.com/base/contracts/pulls)
+[![GitHub Issues](https://img.shields.io/github/issues-raw/base/contracts.svg)](https://github.com/base/contracts/issues)
 
 ### Fixing semver-lock CI failures
 


### PR DESCRIPTION
Summary:
- Updates README links that still pointed to the old base-org GitHub organization.
- Points the contract deployment and badge references to the current base organization.

Testing:
- Ran git diff --check.
- No build was run because this is a README-only documentation change.