### PR TITLE
chore: configure Heimdall for privacy branch

### DIFF
--- a/.codeflow.yml
+++ b/.codeflow.yml
@@ -1,3 +1,11 @@
+# Heimdall configuration.
+#
+# This file lives on the `privacy` branch only and should NOT be merged into
+# `main`. Heimdall reads `.codeflow.yml` from a PR's target branch, so keeping
+# this file off `main` scopes the policy below to PRs targeting `privacy`,
+# leaving `main`'s review requirements unchanged.
 secure:
+  branches:
+    - privacy
   required_reviews: 1
-  requires_mfa: true
+  force_mfa: true


### PR DESCRIPTION
Addresses BASE-99

## Summary
- Adds branch-scoped `.codeflow.yml` on the `privacy` branch with Heimdall policy (1 required review + MFA)
- Mirrors the Heimdall setup from `base/base` (PR #3181)
- This file should NOT be merged into `main` — Heimdall reads `.codeflow.yml` from the PR's target branch, so keeping it off `main` scopes the policy to PRs targeting `privacy` only

Made with [Cursor](https://cursor.com)