### PR TITLE
chore: configurable salt mixer

### DIFF
--- a/scripts/deploy/DeployConfig.s.sol
+++ b/scripts/deploy/DeployConfig.s.sol
@@ -37,6 +37,8 @@ contract DeployConfig is Script {
     uint32 public basefeeScalar;
     uint32 public blobbasefeeScalar;
 
+    string public saltMixer;
+
     uint256 public baseFeeVaultMinimumWithdrawalAmount;
     uint256 public baseFeeVaultWithdrawalNetwork;
     uint256 public disputeGameFinalityDelaySeconds;
@@ -92,6 +94,7 @@ contract DeployConfig is Script {
         baseFeeVaultMinimumWithdrawalAmount = _json.readUint("$.baseFeeVaultMinimumWithdrawalAmount");
         baseFeeVaultWithdrawalNetwork = _json.readUint("$.baseFeeVaultWithdrawalNetwork");
         disputeGameFinalityDelaySeconds = _json.readUint("$.disputeGameFinalityDelaySeconds");
+        saltMixer = _json.readStringOr("$.saltMixer", vm.envOr("DEPLOY_SALT_MIXER", string("salt mixer")));
         delayedWETHWithdrawalDelay = _json.readUint("$.delayedWETHWithdrawalDelay");
         l1ChainId = _json.readUint("$.l1ChainId");
         l1FeeVaultMinimumWithdrawalAmount = _json.readUint("$.l1FeeVaultMinimumWithdrawalAmount");

--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -287,7 +287,7 @@ contract SystemDeploy is Script {
             startingAnchorRoot: Proposal({
                 root: Hash.wrap(cfg.multiproofGenesisOutputRoot()), l2SequenceNumber: cfg.multiproofGenesisBlockNumber()
             }),
-            saltMixer: "salt mixer",
+            saltMixer: cfg.saltMixer(),
             gasLimit: uint64(cfg.l2GenesisBlockGasLimit())
         });
     }


### PR DESCRIPTION
Makes salt mixer configurable since in development deploys we are using the same wallet address and getting deterministic contracts. So when new instance boots and tries to create a new contract, we get an address conflict. With this we can add some salt to make address new each time.