### PR TITLE
fix: include withdrawalDelaySeconds in immediate finality config guard

### DIFF
--- a/deploy-config/local-tee.json
+++ b/deploy-config/local-tee.json
@@ -4,7 +4,7 @@
   "baseFeeVaultWithdrawalNetwork": 0,
   "batchSenderAddress": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
   "disputeGameFinalityDelaySeconds": 0,
-  "delayedWETHWithdrawalDelay": 302400,
+  "delayedWETHWithdrawalDelay": 0,
   "finalSystemOwner": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "fundDevAccounts": true,
   "gasPriceOracleBaseFeeScalar": 1368,

--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -1065,18 +1065,17 @@ contract SystemDeploy is Script {
     }
 
     function _assertValidImplementationInput(ImplementationInput memory _input) internal pure {
-        require(_input.withdrawalDelaySeconds != 0, "SystemDeploy: withdrawalDelaySeconds not set");
         if (_input.proofMaturityDelaySeconds == 0) {
             require(
-                _input.disputeGameFinalityDelaySeconds == 0 && _input.slowFinalizationDelay == 0
-                    && _input.fastFinalizationDelay == 0,
-                "SystemDeploy: all finality delays must be zero for immediate finality"
+                _input.withdrawalDelaySeconds == 0 && _input.disputeGameFinalityDelaySeconds == 0
+                    && _input.slowFinalizationDelay == 0 && _input.fastFinalizationDelay == 0,
+                "SystemDeploy: all delays must be zero for immediate finality"
             );
         } else {
             require(
-                _input.disputeGameFinalityDelaySeconds != 0 && _input.slowFinalizationDelay != 0
-                    && _input.fastFinalizationDelay != 0,
-                "SystemDeploy: finality delays must all be nonzero for standard mode"
+                _input.withdrawalDelaySeconds != 0 && _input.disputeGameFinalityDelaySeconds != 0
+                    && _input.slowFinalizationDelay != 0 && _input.fastFinalizationDelay != 0,
+                "SystemDeploy: all delays must be nonzero for standard mode"
             );
         }
     }


### PR DESCRIPTION
The deploy script previously had a standalone `require` that always rejected withdrawalDelaySeconds=0. For L3 chains with TEE-backed immediate finality, DelayedWETH bond withdrawal delays should also be zero since there is no adversarial challenge game.

Fold withdrawalDelaySeconds into the existing all-or-nothing config guard: in immediate finality mode all delays (including WETH withdrawal) must be zero; in standard mode all must be nonzero.

Also update local-tee.json to set delayedWETHWithdrawalDelay=0.