### PR TITLE
fix(tee): backport preemptive cert revocation to v8.2.1

### DIFF
--- a/interfaces/L1/proofs/tee/INitroEnclaveVerifier.sol
+++ b/interfaces/L1/proofs/tee/INitroEnclaveVerifier.sol
@@ -281,18 +281,17 @@ interface INitroEnclaveVerifier {
         external;
 
     /**
-     * @dev Revokes a trusted intermediate certificate.
+     * @dev Revokes an intermediate certificate, whether or not it has been cached as trusted.
      * @param _certHash Hash of the certificate to revoke
      *
      * Requirements:
      * - Only callable by contract owner or revoker
-     * - Certificate must exist in the trusted set
      *
-     * In addition to clearing the cached entry, this flips a persistent
-     * revocation sentinel that survives later cache writes. Subsequent
-     * verifications whose chain traverses the revoked hash are rejected
-     * regardless of the journal-supplied `trustedCertsPrefixLen`. Re-trust
-     * requires an explicit `unrevokeCert` call.
+     * In addition to clearing any cached entry, this flips a persistent revocation
+     * sentinel that survives later cache writes. Certificates never seen on-chain can
+     * be revoked preemptively. Subsequent verifications whose chain traverses the
+     * revoked hash are rejected regardless of the journal-supplied
+     * `trustedCertsPrefixLen`. Re-trust requires an explicit `unrevokeCert` call.
      */
     function revokeCert(bytes32 _certHash) external;
 

--- a/snapshots/abi/NitroEnclaveVerifier.json
+++ b/snapshots/abi/NitroEnclaveVerifier.json
@@ -1133,17 +1133,6 @@
         "type": "bytes32"
       }
     ],
-    "name": "CertificateNotFound",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "certHash",
-        "type": "bytes32"
-      }
-    ],
     "name": "CertificateNotRevoked",
     "type": "error"
   },

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -44,8 +44,8 @@
     "sourceCodeHash": "0xf6ca679ff7463ade68e1ad1ae49f5b406e0c723ec1a2a718828f6bec12c8e8a6"
   },
   "src/L1/proofs/tee/NitroEnclaveVerifier.sol:NitroEnclaveVerifier": {
-    "initCodeHash": "0x1be3b9418c022094fb60ea68d025910c69e95c7a2314bf1b57c740f601b7cb0e",
-    "sourceCodeHash": "0xa0bb07f71960cda20c3b3a46c8cc24842f991c00469a9e90ce8d9a1c26e7a8d6"
+    "initCodeHash": "0xf79cd59d23f6a5ad78960b664e20779592d73bfcf52527c3e03adda04edd9645",
+    "sourceCodeHash": "0x87c59e16167407772ce33d735d7174ce947adb77809c234841bb5f5b9af249ba"
   },
   "src/L1/proofs/tee/TEEProverRegistry.sol:TEEProverRegistry": {
     "initCodeHash": "0xfd1942e1c2f59b0aa72b33d698a948a53b6e4cf1040106f173fb5d89f63f57b0",

--- a/src/L1/proofs/tee/NitroEnclaveVerifier.sol
+++ b/src/L1/proofs/tee/NitroEnclaveVerifier.sol
@@ -97,9 +97,6 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
     /// @dev Thrown when a caller other than the authorized proof submitter calls verify or batchVerify
     error CallerNotProofSubmitter();
 
-    /// @dev Thrown when a certificate hash is not found in the trusted intermediate certificates set
-    error CertificateNotFound(bytes32 certHash);
-
     /// @dev Thrown when a program ID argument is bytes32(0)
     error ZeroProgramId();
 
@@ -356,15 +353,17 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
     }
 
     /**
-     * @dev Revokes a trusted intermediate certificate.
+     * @dev Revokes an intermediate certificate, whether or not it has been cached as trusted.
      * @param certHash Hash of the certificate to revoke
      *
      * Requirements:
      * - Only callable by contract owner or revoker
-     * - Certificate must exist in the trusted intermediate certificates set
      *
-     * This function allows the owner or revoker to revoke compromised intermediate certificates
-     * without affecting the root certificate or other trusted certificates.
+     * Certificates that have never been seen on-chain can be revoked preemptively; the
+     * persistent `revokedCerts` sentinel blocks them from being trusted on first
+     * verification. This function allows the owner or revoker to revoke compromised
+     * intermediate certificates without affecting the root certificate or other trusted
+     * certificates.
      *
      * Durability: in addition to clearing `trustedIntermediateCerts[certHash]`, this
      * function flips the persistent `revokedCerts[certHash]` sentinel. The sentinel
@@ -375,9 +374,6 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
      * explicit `unrevokeCert` call by the owner.
      */
     function revokeCert(bytes32 certHash) external onlyOwnerOrRevoker {
-        if (trustedIntermediateCerts[certHash] == 0) {
-            revert CertificateNotFound(certHash);
-        }
         delete trustedIntermediateCerts[certHash];
         revokedCerts[certHash] = true;
         emit CertRevoked(certHash);

--- a/test/L1/proofs/NitroEnclaveVerifier.t.sol
+++ b/test/L1/proofs/NitroEnclaveVerifier.t.sol
@@ -205,12 +205,6 @@ contract NitroEnclaveVerifierTest is Test {
         assertEq(verifier.trustedIntermediateCerts(INTERMEDIATE_CERT_1), 0);
     }
 
-    function testRevokeCertRevertsIfNotTrusted() public {
-        bytes32 unknown = keccak256("unknown-cert");
-        vm.expectRevert(abi.encodeWithSelector(NitroEnclaveVerifier.CertificateNotFound.selector, unknown));
-        verifier.revokeCert(unknown);
-    }
-
     function testRevokeCertRevertsIfNotOwnerOrRevoker() public {
         vm.prank(submitter);
         vm.expectRevert(NitroEnclaveVerifier.CallerNotOwnerOrRevoker.selector);
@@ -221,6 +215,64 @@ contract NitroEnclaveVerifierTest is Test {
         assertFalse(verifier.revokedCerts(INTERMEDIATE_CERT_1));
         verifier.revokeCert(INTERMEDIATE_CERT_1);
         assertTrue(verifier.revokedCerts(INTERMEDIATE_CERT_1));
+    }
+
+    function testRevokeCertPreemptiveUnknownCert() public {
+        bytes32 unknown = keccak256("unknown-cert");
+        assertEq(verifier.trustedIntermediateCerts(unknown), 0);
+        assertFalse(verifier.revokedCerts(unknown));
+
+        vm.expectEmit(false, false, false, true);
+        emit NitroEnclaveVerifier.CertRevoked(unknown);
+        verifier.revokeCert(unknown);
+
+        assertTrue(verifier.revokedCerts(unknown));
+        assertEq(verifier.trustedIntermediateCerts(unknown), 0);
+    }
+
+    function testVerifyRejectsPreemptivelyRevokedCertInSuffix() public {
+        _setUpRiscZeroConfig();
+        bytes32 unknown = keccak256("unknown-compromised-intermediate");
+        verifier.revokeCert(unknown);
+
+        VerifierJournal memory journal = _createSuccessJournal();
+        bytes32[] memory certs = new bytes32[](3);
+        certs[0] = ROOT_CERT;
+        certs[1] = unknown; // preemptively revoked, lives in the suffix
+        certs[2] = keccak256("attacker-leaf");
+        journal.certs = certs;
+
+        uint64[] memory expiries = new uint64[](3);
+        expiries[0] = ROOT_CERT_EXPIRY;
+        expiries[1] = NEW_LEAF_CERT_EXPIRY;
+        expiries[2] = NEW_LEAF_CERT_EXPIRY;
+        journal.certExpiries = expiries;
+        journal.trustedCertsPrefixLen = 1;
+
+        bytes memory output = abi.encode(journal);
+        bytes memory proofBytes = abi.encodePacked(bytes4(0), bytes32(0));
+        _mockRiscZeroVerify(VERIFIER_ID, output, proofBytes);
+
+        vm.prank(submitter);
+        VerifierJournal memory result = verifier.verify(output, ZkCoProcessorType.RiscZero, proofBytes);
+
+        assertEq(uint8(result.result), uint8(VerificationResult.IntermediateCertsNotTrusted));
+        assertEq(verifier.trustedIntermediateCerts(unknown), 0);
+        assertTrue(verifier.revokedCerts(unknown));
+    }
+
+    function testCheckTrustedIntermediateCertsBreaksAtPreemptivelyRevokedEntry() public {
+        bytes32 unknown = keccak256("unknown-compromised-intermediate");
+        verifier.revokeCert(unknown);
+
+        bytes32[][] memory reportCerts = new bytes32[][](1);
+        reportCerts[0] = new bytes32[](3);
+        reportCerts[0][0] = ROOT_CERT;
+        reportCerts[0][1] = unknown;
+        reportCerts[0][2] = keccak256("leaf");
+
+        uint8[] memory prefixLens = verifier.checkTrustedIntermediateCerts(reportCerts);
+        assertEq(prefixLens[0], 1);
     }
 
     // ============ unrevokeCert Tests ============


### PR DESCRIPTION
### What changed? Why?

Backports #329 to `releases/v8.2.1`. This allows `NitroEnclaveVerifier.revokeCert` to mark intermediate certificate hashes as revoked even if they were never cached as trusted, so compromised certs can be blocklisted before they appear onchain.

The backport removes the `trustedIntermediateCerts[certHash] == 0` guard and unused `CertificateNotFound` error, relies on the existing `revokedCerts` sentinel to block first-time verification of preemptively revoked certs, updates NatSpec on the contract and interface, and carries over the ABI and semver snapshots.

### Notes to reviewers

Cherry-picked the two commits from #329 onto `releases/v8.2.1`. The diff is limited to the Nitro enclave verifier contract/interface, ABI and semver snapshots, and the matching tests.

### How has it been tested?

`just test-dev --match-path test/L1/proofs/NitroEnclaveVerifier.t.sol`

Result: 80 passed, 0 failed, 0 skipped.