### PR TITLE
docs(tee): backport Nitro verifier NatSpec comments to v8.2.1

### DIFF
--- a/interfaces/L1/proofs/tee/INitroEnclaveVerifier.sol
+++ b/interfaces/L1/proofs/tee/INitroEnclaveVerifier.sol
@@ -9,10 +9,8 @@ pragma solidity ^0.8.0;
 /// - Errors and events moved to the implementation contract
 /// - Adds new admin functions
 
-/**
- * @dev Enumeration of supported zero-knowledge proof coprocessor types
- * Used to specify which proving system to use for attestation verification
- */
+/// @dev Enumeration of supported zero-knowledge proof coprocessor types
+/// Used to specify which proving system to use for attestation verification
 enum ZkCoProcessorType {
     Unknown,
     // RISC Zero zkVM proving system
@@ -21,10 +19,8 @@ enum ZkCoProcessorType {
     Succinct
 }
 
-/**
- * @dev Configuration parameters for a specific zero-knowledge coprocessor
- * Contains all necessary identifiers and addresses for ZK proof verification
- */
+/// @dev Configuration parameters for a specific zero-knowledge coprocessor
+/// Contains all necessary identifiers and addresses for ZK proof verification
 struct ZkCoProcessorConfig {
     // Latest program ID for single attestation verification
     bytes32 verifierId;
@@ -34,10 +30,8 @@ struct ZkCoProcessorConfig {
     address zkVerifier;
 }
 
-/**
- * @dev Input structure for attestation report verification
- * Contains the raw attestation data and trusted certificate chain length
- */
+/// @dev Input structure for attestation report verification
+/// Contains the raw attestation data and trusted certificate chain length
 struct VerifierInput {
     // Number of trusted certificates in the chain
     uint8 trustedCertsPrefixLen;
@@ -45,10 +39,8 @@ struct VerifierInput {
     bytes attestationReport;
 }
 
-/**
- * @dev Output structure containing verified attestation data and metadata
- * This represents the journal/output from zero-knowledge proof verification
- */
+/// @dev Output structure containing verified attestation data and metadata
+/// This represents the journal/output from zero-knowledge proof verification
 struct VerifierJournal {
     // Overall verification result status
     VerificationResult result;
@@ -72,10 +64,8 @@ struct VerifierJournal {
     string moduleId;
 }
 
-/**
- * @dev Public value (journal) structure for batch verification operations
- * Contains the aggregated results of multiple attestation verifications
- */
+/// @dev Public value (journal) structure for batch verification operations
+/// Contains the aggregated results of multiple attestation verifications
 struct BatchVerifierJournal {
     // Verification key that was used for batch verification
     bytes32 verifierVk;
@@ -83,19 +73,15 @@ struct BatchVerifierJournal {
     VerifierJournal[] outputs;
 }
 
-/**
- * @dev 48-byte data structure for storing PCR values
- * Split into two parts due to Solidity's 32-byte word limitation
- */
+/// @dev 48-byte data structure for storing PCR values
+/// Split into two parts due to Solidity's 32-byte word limitation
 struct Bytes48 {
     bytes32 first;
     bytes16 second;
 }
 
-/**
- * @dev Platform Configuration Register (PCR) entry
- * PCRs contain cryptographic measurements of the enclave's runtime state
- */
+/// @dev Platform Configuration Register (PCR) entry
+/// PCRs contain cryptographic measurements of the enclave's runtime state
 struct Pcr {
     // PCR index number (0-23 for AWS Nitro Enclaves)
     uint64 index;
@@ -103,13 +89,11 @@ struct Pcr {
     Bytes48 value;
 }
 
-/**
- * @dev Enumeration of possible attestation verification results
- * Indicates the outcome of the verification process
- *
- * Note: Unknown is intentionally placed at index 0 so that uninitialized enum
- * variables default to a failure state rather than Success (fail-closed).
- */
+/// @dev Enumeration of possible attestation verification results
+/// Indicates the outcome of the verification process
+///
+/// Note: Unknown is intentionally placed at index 0 so that uninitialized enum
+/// variables default to a failure state rather than Success (fail-closed).
 enum VerificationResult {
     // Default/uninitialized value — treated as a verification failure
     Unknown,
@@ -123,156 +107,124 @@ enum VerificationResult {
     InvalidTimestamp
 }
 
-/**
- * @title INitroEnclaveVerifier
- * @dev Interface for AWS Nitro Enclave attestation verification using zero-knowledge proofs
- *
- * This interface defines the contract for verifying AWS Nitro Enclave attestation reports
- * on-chain using zero-knowledge proof systems (RISC Zero or Succinct SP1). The verifier
- * validates the cryptographic integrity of attestation reports while maintaining privacy
- * and reducing gas costs through ZK proofs.
- *
- * Key features:
- * - Single and batch attestation verification
- * - Support for multiple ZK proving systems
- * - Route-based verifier configuration
- * - Certificate chain management and revocation
- * - Timestamp validation with configurable tolerance
- * - Platform Configuration Register (PCR) verification
- */
+/// @title INitroEnclaveVerifier
+/// @dev Interface for AWS Nitro Enclave attestation verification using zero-knowledge proofs
+///
+/// This interface defines the contract for verifying AWS Nitro Enclave attestation reports
+/// onchain using zero-knowledge proof systems (RISC Zero or Succinct SP1). The verifier
+/// validates the cryptographic integrity of attestation reports while maintaining privacy
+/// and reducing gas costs through ZK proofs.
+///
+/// Key features:
+/// - Single and batch attestation verification
+/// - Support for multiple ZK proving systems
+/// - Route-based verifier configuration
+/// - Certificate chain management and revocation
+/// - Timestamp validation with configurable tolerance
+/// - Platform Configuration Register (PCR) verification
 interface INitroEnclaveVerifier {
     // ============ Query Functions ============
 
-    /**
-     * @dev Returns the maximum allowed time difference for attestation timestamp validation
-     * @return Maximum time difference in seconds between attestation time and current block time
-     */
+    /// @dev Returns the maximum allowed time difference for attestation timestamp validation
+    /// @return Maximum time difference in seconds between attestation time and current block time
     function maxTimeDiff() external view returns (uint64);
 
-    /**
-     * @dev Returns the hash of the trusted root certificate
-     * @return Hash of the AWS Nitro Enclave root certificate
-     */
+    /// @dev Returns the hash of the trusted root certificate
+    /// @return Hash of the AWS Nitro Enclave root certificate
     function rootCert() external view returns (bytes32);
 
-    /**
-     * @dev Returns the address of the proof submitter
-     * @return Address of the proof submitter
-     */
+    /// @dev Returns the address of the proof submitter
+    /// @return Address of the proof submitter
     function proofSubmitter() external view returns (address);
 
-    /**
-     * @dev Returns the address authorized to revoke intermediate certificates
-     * @return Address of the revoker (address(0) if disabled)
-     */
+    /// @dev Returns the address authorized to revoke intermediate certificates
+    /// @return Address of the revoker (address(0) if disabled)
     function revoker() external view returns (address);
 
-    /**
-     * @dev Returns whether the given intermediate certificate hash has been revoked.
-     * @param _certHash Hash of the certificate
-     * @return `true` if the certificate is currently marked as revoked
-     *
-     * The revocation sentinel is persistent across `_cacheNewCert` overwrites and
-     * blocks both verification (via `_verifyJournal`) and the off-chain
-     * `checkTrustedIntermediateCerts` helper from re-trusting the hash. Re-trust
-     * requires an explicit `unrevokeCert` call.
-     */
+    /// @dev Returns whether the given intermediate certificate hash has been revoked.
+    /// @param _certHash Hash of the certificate
+    /// @return `true` if the certificate is currently marked as revoked
+    ///
+    /// The revocation sentinel is persistent across `_cacheNewCert` overwrites and
+    /// blocks both verification (via `_verifyJournal`) and the offchain
+    /// `checkTrustedIntermediateCerts` helper from re-trusting the hash. Re-trust
+    /// requires an explicit `unrevokeCert` call.
     function revokedCerts(bytes32 _certHash) external view returns (bool);
 
-    /**
-     * @dev Returns the cached `notAfter` timestamp (seconds) for an intermediate certificate.
-     * @param _certHash Hash of the certificate
-     * @return Cached expiry timestamp; `0` indicates the certificate is not currently
-     *         cached (either never seen, expired-and-evicted, or revoked).
-     */
+    /// @dev Returns the cached `notAfter` timestamp (seconds) for an intermediate certificate.
+    /// @param _certHash Hash of the certificate
+    /// @return Cached expiry timestamp; `0` indicates the certificate is not currently
+    ///         cached (either never seen, expired-and-evicted, or revoked).
     function trustedIntermediateCerts(bytes32 _certHash) external view returns (uint64);
 
-    /**
-     * @dev Retrieves the configuration for a specific coprocessor
-     * @param _zkCoProcessor Type of ZK coprocessor (RiscZero or Succinct)
-     * @return ZkCoProcessorConfig Configuration parameters including program IDs and verifier address
-     */
+    /// @dev Retrieves the configuration for a specific coprocessor
+    /// @param _zkCoProcessor Type of ZK coprocessor (RiscZero or Succinct)
+    /// @return ZkCoProcessorConfig Configuration parameters including program IDs and verifier address
     function getZkConfig(ZkCoProcessorType _zkCoProcessor) external view returns (ZkCoProcessorConfig memory);
 
-    /**
-     * @dev Gets the verifier address for a specific route
-     * @param _zkCoProcessor Type of ZK coprocessor
-     * @param _selector Proof selector
-     * @return Verifier address (route-specific or default fallback)
-     *
-     * Note: Reverts if the route is frozen
-     */
+    /// @dev Gets the verifier address for a specific route
+    /// @param _zkCoProcessor Type of ZK coprocessor
+    /// @param _selector Proof selector
+    /// @return Verifier address (route-specific or default fallback)
+    ///
+    /// Note: Reverts if the route is frozen
     function getZkVerifier(ZkCoProcessorType _zkCoProcessor, bytes4 _selector) external view returns (address);
 
-    /**
-     * @dev Returns the verifierProofId for a given ZkCoProcessorType
-     * @param _zkCoProcessor Type of ZK coprocessor
-     * @return The corresponding verifierProofId
-     */
+    /// @dev Returns the verifierProofId for a given ZkCoProcessorType
+    /// @param _zkCoProcessor Type of ZK coprocessor
+    /// @return The corresponding verifierProofId
     function getVerifierProofId(ZkCoProcessorType _zkCoProcessor) external view returns (bytes32);
 
-    /**
-     * @dev Checks how many certificates in each report are trusted
-     * @param _report_certs Array of certificate chains, each containing certificate hashes
-     * @return Array indicating the number of trusted certificates in each chain
-     *
-     * For each certificate chain:
-     * - Validates that the first certificate matches the root certificate
-     * - Counts consecutive trusted certificates starting from the root
-     * - Returns the count of trusted certificates for each chain
-     */
+    /// @dev Checks how many certificates in each report are trusted
+    /// @param _report_certs Array of certificate chains, each containing certificate hashes
+    /// @return Array indicating the number of trusted certificates in each chain
+    ///
+    /// For each certificate chain:
+    /// - Validates that the first certificate matches the root certificate
+    /// - Counts consecutive trusted certificates starting from the root
+    /// - Returns the count of trusted certificates for each chain
     function checkTrustedIntermediateCerts(bytes32[][] calldata _report_certs) external view returns (uint8[] memory);
 
     // ============ Admin Functions ============
 
-    /**
-     * @dev Sets the trusted root certificate hash
-     * @param _rootCert Hash of the new root certificate
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     */
+    /// @dev Sets the trusted root certificate hash
+    /// @param _rootCert Hash of the new root certificate
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
     function setRootCert(bytes32 _rootCert) external;
 
-    /**
-     * @dev Updates the maximum allowed time difference for attestation timestamp validation
-     * @param _maxTimeDiff New maximum time difference in seconds
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     * - Must be greater than zero
-     */
+    /// @dev Updates the maximum allowed time difference for attestation timestamp validation
+    /// @param _maxTimeDiff New maximum time difference in seconds
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    /// - Must be greater than zero
     function setMaxTimeDiff(uint64 _maxTimeDiff) external;
 
-    /**
-     * @dev Sets the proof submitter address
-     * @param _proofSubmitter The address of the proof submitter
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     * - Address must not be zero
-     */
+    /// @dev Sets the proof submitter address
+    /// @param _proofSubmitter The address of the proof submitter
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    /// - Address must not be zero
     function setProofSubmitter(address _proofSubmitter) external;
 
-    /**
-     * @dev Updates the revoker address
-     * @param _newRevoker New revoker address (can be address(0) to disable the revoker role)
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     */
+    /// @dev Updates the revoker address
+    /// @param _newRevoker New revoker address (can be address(0) to disable the revoker role)
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
     function setRevoker(address _newRevoker) external;
 
-    /**
-     * @dev Configures the zero-knowledge verification parameters for a specific coprocessor
-     * @param _zkCoProcessor Type of ZK coprocessor (RiscZero or Succinct)
-     * @param _config Configuration parameters including program IDs and verifier address
-     * @param _verifierProofId The verifierProofId corresponding to the verifierId in config
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     * - Must specify valid coprocessor type and configuration
-     */
+    /// @dev Configures the zero-knowledge verification parameters for a specific coprocessor
+    /// @param _zkCoProcessor Type of ZK coprocessor (RiscZero or Succinct)
+    /// @param _config Configuration parameters including program IDs and verifier address
+    /// @param _verifierProofId The verifierProofId corresponding to the verifierId in config
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    /// - Must specify valid coprocessor type and configuration
     function setZkConfiguration(
         ZkCoProcessorType _zkCoProcessor,
         ZkCoProcessorConfig memory _config,
@@ -280,46 +232,40 @@ interface INitroEnclaveVerifier {
     )
         external;
 
-    /**
-     * @dev Revokes an intermediate certificate, whether or not it has been cached as trusted.
-     * @param _certHash Hash of the certificate to revoke
-     *
-     * Requirements:
-     * - Only callable by contract owner or revoker
-     *
-     * In addition to clearing any cached entry, this flips a persistent revocation
-     * sentinel that survives later cache writes. Certificates never seen on-chain can
-     * be revoked preemptively. Subsequent verifications whose chain traverses the
-     * revoked hash are rejected regardless of the journal-supplied
-     * `trustedCertsPrefixLen`. Re-trust requires an explicit `unrevokeCert` call.
-     */
+    /// @dev Revokes an intermediate certificate, whether or not it has been cached as trusted.
+    /// @param _certHash Hash of the certificate to revoke
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner or revoker
+    ///
+    /// In addition to clearing any cached entry, this flips a persistent revocation
+    /// sentinel that survives later cache writes. Certificates never seen onchain can
+    /// be revoked preemptively. Subsequent verifications whose chain traverses the
+    /// revoked hash are rejected regardless of the journal-supplied
+    /// `trustedCertsPrefixLen`. Re-trust requires an explicit `unrevokeCert` call.
     function revokeCert(bytes32 _certHash) external;
 
-    /**
-     * @dev Explicitly re-trusts a previously revoked intermediate certificate.
-     * @param _certHash Hash of the certificate to un-revoke
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     * - Certificate must currently be marked as revoked
-     *
-     * Clears the persistent revocation sentinel. The cached expiry is not
-     * restored here; the next successful verification whose chain traverses
-     * `_certHash` will re-cache it via `_cacheNewCert` with the journal-supplied
-     * `notAfter` timestamp.
-     */
+    /// @dev Explicitly re-trusts a previously revoked intermediate certificate.
+    /// @param _certHash Hash of the certificate to un-revoke
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    /// - Certificate must currently be marked as revoked
+    ///
+    /// Clears the persistent revocation sentinel. The cached expiry is not
+    /// restored here; the next successful verification whose chain traverses
+    /// `_certHash` will re-cache it via `_cacheNewCert` with the journal-supplied
+    /// `notAfter` timestamp.
     function unrevokeCert(bytes32 _certHash) external;
 
-    /**
-     * @dev Updates the verifier program ID, adding the new version to the supported set
-     * @param _zkCoProcessor Type of ZK coprocessor
-     * @param _newVerifierId New verifier program ID to set as latest
-     * @param _newVerifierProofId New verifier proof ID (used in batch verification)
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     * - New ID must be different from current latest
-     */
+    /// @dev Updates the verifier program ID, adding the new version to the supported set
+    /// @param _zkCoProcessor Type of ZK coprocessor
+    /// @param _newVerifierId New verifier program ID to set as latest
+    /// @param _newVerifierProofId New verifier proof ID (used in batch verification)
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    /// - New ID must be different from current latest
     function updateVerifierId(
         ZkCoProcessorType _zkCoProcessor,
         bytes32 _newVerifierId,
@@ -327,60 +273,52 @@ interface INitroEnclaveVerifier {
     )
         external;
 
-    /**
-     * @dev Updates the aggregator program ID, adding the new version to the supported set
-     * @param _zkCoProcessor Type of ZK coprocessor
-     * @param _newAggregatorId New aggregator program ID to set as latest
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     * - New ID must be different from current latest
-     */
+    /// @dev Updates the aggregator program ID, adding the new version to the supported set
+    /// @param _zkCoProcessor Type of ZK coprocessor
+    /// @param _newAggregatorId New aggregator program ID to set as latest
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    /// - New ID must be different from current latest
     function updateAggregatorId(ZkCoProcessorType _zkCoProcessor, bytes32 _newAggregatorId) external;
 
-    /**
-     * @dev Adds a route-specific verifier override
-     * @param _zkCoProcessor Type of ZK coprocessor
-     * @param _selector Proof selector (first 4 bytes of proof data)
-     * @param _verifier Address of the verifier contract for this route
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     * - Route must not be frozen
-     * - Verifier address must not be zero
-     */
+    /// @dev Adds a route-specific verifier override
+    /// @param _zkCoProcessor Type of ZK coprocessor
+    /// @param _selector Proof selector (first 4 bytes of proof data)
+    /// @param _verifier Address of the verifier contract for this route
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    /// - Route must not be frozen
+    /// - Verifier address must not be zero
     function addVerifyRoute(ZkCoProcessorType _zkCoProcessor, bytes4 _selector, address _verifier) external;
 
-    /**
-     * @dev Permanently freezes a verification route
-     * @param _zkCoProcessor Type of ZK coprocessor
-     * @param _selector Proof selector to freeze
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     * - Route must not already be frozen
-     *
-     * WARNING: This action is IRREVERSIBLE
-     */
+    /// @dev Permanently freezes a verification route
+    /// @param _zkCoProcessor Type of ZK coprocessor
+    /// @param _selector Proof selector to freeze
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    /// - Route must not already be frozen
+    ///
+    /// WARNING: This action is IRREVERSIBLE
     function freezeVerifyRoute(ZkCoProcessorType _zkCoProcessor, bytes4 _selector) external;
 
     // ============ Verification Functions ============
 
-    /**
-     * @dev Verifies a single attestation report using zero-knowledge proof
-     * @param output Encoded VerifierJournal containing the verification result
-     * @param zkCoprocessor Type of ZK coprocessor used to generate the proof
-     * @param proofBytes Zero-knowledge proof data for the attestation
-     * @return VerifierJournal containing the verification result and extracted data
-     *
-     * This function:
-     * 1. Verifies the ZK proof using the specified coprocessor
-     * 2. Decodes the verification result
-     * 3. Validates the certificate chain against trusted certificates
-     * 4. Checks timestamp validity within the allowed time difference
-     * 5. Caches newly discovered trusted certificates
-     * 6. Returns the complete verification result
-     */
+    /// @dev Verifies a single attestation report using zero-knowledge proof
+    /// @param output Encoded VerifierJournal containing the verification result
+    /// @param zkCoprocessor Type of ZK coprocessor used to generate the proof
+    /// @param proofBytes Zero-knowledge proof data for the attestation
+    /// @return VerifierJournal containing the verification result and extracted data
+    ///
+    /// This function:
+    /// 1. Verifies the ZK proof using the specified coprocessor
+    /// 2. Decodes the verification result
+    /// 3. Validates the certificate chain against trusted certificates
+    /// 4. Checks timestamp validity within the allowed time difference
+    /// 5. Caches newly discovered trusted certificates
+    /// 6. Returns the complete verification result
     function verify(
         bytes calldata output,
         ZkCoProcessorType zkCoprocessor,
@@ -389,20 +327,18 @@ interface INitroEnclaveVerifier {
         external
         returns (VerifierJournal memory);
 
-    /**
-     * @dev Verifies multiple attestation reports in a single batch operation
-     * @param output Encoded BatchVerifierJournal containing aggregated verification results
-     * @param zkCoprocessor Type of ZK coprocessor used to generate the proof
-     * @param proofBytes Zero-knowledge proof data for batch verification
-     * @return Array of VerifierJournal results, one for each attestation in the batch
-     *
-     * This function:
-     * 1. Verifies the ZK proof using the specified coprocessor
-     * 2. Decodes the batch verification results
-     * 3. Validates each attestation's certificate chain and timestamp
-     * 4. Caches newly discovered trusted certificates
-     * 5. Returns the verification results for all attestations
-     */
+    /// @dev Verifies multiple attestation reports in a single batch operation
+    /// @param output Encoded BatchVerifierJournal containing aggregated verification results
+    /// @param zkCoprocessor Type of ZK coprocessor used to generate the proof
+    /// @param proofBytes Zero-knowledge proof data for batch verification
+    /// @return Array of VerifierJournal results, one for each attestation in the batch
+    ///
+    /// This function:
+    /// 1. Verifies the ZK proof using the specified coprocessor
+    /// 2. Decodes the batch verification results
+    /// 3. Validates each attestation's certificate chain and timestamp
+    /// 4. Caches newly discovered trusted certificates
+    /// 5. Returns the verification results for all attestations
     function batchVerify(
         bytes calldata output,
         ZkCoProcessorType zkCoprocessor,

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -45,7 +45,7 @@
   },
   "src/L1/proofs/tee/NitroEnclaveVerifier.sol:NitroEnclaveVerifier": {
     "initCodeHash": "0xf79cd59d23f6a5ad78960b664e20779592d73bfcf52527c3e03adda04edd9645",
-    "sourceCodeHash": "0x87c59e16167407772ce33d735d7174ce947adb77809c234841bb5f5b9af249ba"
+    "sourceCodeHash": "0x03c164216b27f82ee13064ace6079d5e24e187d888f41bd01c8daffa60c575d6"
   },
   "src/L1/proofs/tee/TEEProverRegistry.sol:TEEProverRegistry": {
     "initCodeHash": "0xfd1942e1c2f59b0aa72b33d698a948a53b6e4cf1040106f173fb5d89f63f57b0",

--- a/src/L1/proofs/tee/NitroEnclaveVerifier.sol
+++ b/src/L1/proofs/tee/NitroEnclaveVerifier.sol
@@ -14,34 +14,32 @@ import { IRiscZeroVerifier } from "lib/risc0-ethereum/contracts/src/IRiscZeroVer
 import { ISP1Verifier } from "interfaces/L1/proofs/zk/ISP1Verifier.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
-/**
- * @title NitroEnclaveVerifier
- * @dev Implementation contract for AWS Nitro Enclave attestation verification using zero-knowledge proofs
- * @dev Custom version of Automata's NitroEnclaveVerifier contract at
- * https://github.com/automata-network/aws-nitro-enclave-attestation/tree/26c90565cb009e6539643a0956f9502a12ade672
- *
- * Differences from the upstream Automata contract:
- * - Verification of ZK proofs is restricted to an authorized proof submitter address
- * - All privileged actions emit events for monitoring
- * - Removes verification-with-explicit-program-ID and Pico logic
- *
- * This contract provides on-chain verification of AWS Nitro Enclave attestation reports by validating
- * zero-knowledge proofs generated off-chain. It supports both single and batch verification modes
- * and can work with multiple ZK proof systems (RISC Zero and Succinct SP1).
- *
- * Key features:
- * - Certificate chain management with automatic caching of newly discovered certificates
- * - Timestamp validation with configurable time tolerance
- * - Certificate revocation capabilities for compromised intermediate certificates
- * - Gas-efficient batch verification for multiple attestations
- * - Support for both RISC Zero and SP1 proving systems
- *
- * Security considerations:
- * - Only the contract owner can manage certificates and configurations
- * - Root certificate is immutable once set (requires owner to change)
- * - Intermediate certificates are automatically cached but can be revoked
- * - Timestamp validation prevents replay attacks within the configured time window
- */
+/// @title NitroEnclaveVerifier
+/// @dev Implementation contract for AWS Nitro Enclave attestation verification using zero-knowledge proofs
+/// @dev Custom version of Automata's NitroEnclaveVerifier contract at
+/// https://github.com/automata-network/aws-nitro-enclave-attestation/tree/26c90565cb009e6539643a0956f9502a12ade672
+///
+/// Differences from the upstream Automata contract:
+/// - Verification of ZK proofs is restricted to an authorized proof submitter address
+/// - All privileged actions emit events for monitoring
+/// - Removes verification-with-explicit-program-ID and Pico logic
+///
+/// This contract provides onchain verification of AWS Nitro Enclave attestation reports by validating
+/// zero-knowledge proofs generated offchain. It supports both single and batch verification modes
+/// and can work with multiple ZK proof systems (RISC Zero and Succinct SP1).
+///
+/// Key features:
+/// - Certificate chain management with automatic caching of newly discovered certificates
+/// - Timestamp validation with configurable time tolerance
+/// - Certificate revocation capabilities for compromised intermediate certificates
+/// - Gas-efficient batch verification for multiple attestations
+/// - Support for both RISC Zero and SP1 proving systems
+///
+/// Security considerations:
+/// - Only the contract owner can manage certificates and configurations
+/// - Root certificate is immutable once set (requires owner to change)
+/// - Intermediate certificates are automatically cached but can be revoked
+/// - Timestamp validation prevents replay attacks within the configured time window
 contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
     /// @dev Sentinel address to indicate a route has been permanently frozen
     address private constant FROZEN = address(0xdead);
@@ -177,19 +175,17 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         _;
     }
 
-    /**
-     * @dev Initializes the contract with owner, time tolerance and initial trusted certificates
-     * @param owner Address to be set as the contract owner
-     * @param initialMaxTimeDiff Maximum time difference in seconds for timestamp validation
-     * @param initializeTrustedCerts Array of initial trusted intermediate certificate hashes
-     * @param initializeTrustedCertExpiries Array of notAfter timestamps (seconds) for each initial cert
-     * @param initialRootCert Hash of the AWS Nitro Enclave root certificate
-     * @param initialProofSubmitter Address that is authorized to submit proofs
-     * @param initialRevoker Address authorized to revoke intermediate certificates (can be address(0) to disable)
-     * @param zkCoProcessor Type of ZK coprocessor to configure (RiscZero or Succinct)
-     * @param config Configuration parameters for the ZK coprocessor
-     * @param verifierProofId The verifierProofId corresponding to the verifierId in config
-     */
+    /// @dev Initializes the contract with owner, time tolerance and initial trusted certificates
+    /// @param owner Address to be set as the contract owner
+    /// @param initialMaxTimeDiff Maximum time difference in seconds for timestamp validation
+    /// @param initializeTrustedCerts Array of initial trusted intermediate certificate hashes
+    /// @param initializeTrustedCertExpiries Array of notAfter timestamps (seconds) for each initial cert
+    /// @param initialRootCert Hash of the AWS Nitro Enclave root certificate
+    /// @param initialProofSubmitter Address that is authorized to submit proofs
+    /// @param initialRevoker Address authorized to revoke intermediate certificates (can be address(0) to disable)
+    /// @param zkCoProcessor Type of ZK coprocessor to configure (RiscZero or Succinct)
+    /// @param config Configuration parameters for the ZK coprocessor
+    /// @param verifierProofId The verifierProofId corresponding to the verifierId in config
     constructor(
         address owner,
         uint64 initialMaxTimeDiff,
@@ -219,21 +215,17 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
 
     // ============ Query Functions ============
 
-    /**
-     * @dev Retrieves the configuration for a specific coprocessor
-     * @param zkCoProcessor Type of ZK coprocessor (RiscZero or Succinct)
-     * @return ZkCoProcessorConfig Configuration parameters including program IDs and verifier address
-     */
+    /// @dev Retrieves the configuration for a specific coprocessor
+    /// @param zkCoProcessor Type of ZK coprocessor (RiscZero or Succinct)
+    /// @return ZkCoProcessorConfig Configuration parameters including program IDs and verifier address
     function getZkConfig(ZkCoProcessorType zkCoProcessor) external view returns (ZkCoProcessorConfig memory) {
         return zkConfig[zkCoProcessor];
     }
 
-    /**
-     * @dev Gets the verifier address for a specific route
-     * @param zkCoProcessor Type of ZK coprocessor
-     * @param selector Proof selector
-     * @return Verifier address (route-specific or default fallback)
-     */
+    /// @dev Gets the verifier address for a specific route
+    /// @param zkCoProcessor Type of ZK coprocessor
+    /// @param selector Proof selector
+    /// @return Verifier address (route-specific or default fallback)
     function getZkVerifier(ZkCoProcessorType zkCoProcessor, bytes4 selector) external view returns (address) {
         address verifier = _zkVerifierRoutes[zkCoProcessor][selector];
 
@@ -248,29 +240,25 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         return verifier;
     }
 
-    /**
-     * @dev Returns the verifierProofId for a given ZkCoProcessorType
-     * @param zkCoProcessor Type of ZK coprocessor
-     * @return The corresponding verifierProofId
-     */
+    /// @dev Returns the verifierProofId for a given ZkCoProcessorType
+    /// @param zkCoProcessor Type of ZK coprocessor
+    /// @return The corresponding verifierProofId
     function getVerifierProofId(ZkCoProcessorType zkCoProcessor) external view returns (bytes32) {
         return _verifierProofIds[zkCoProcessor];
     }
 
-    /**
-     * @dev Checks the prefix length of trusted certificates in each provided certificate chain for reports
-     * @param reportCerts Array of certificate chains, each containing certificate hashes
-     * @return Array indicating the prefix length of trusted certificates in each chain
-     *
-     * For each certificate chain:
-     * 1. Validates that the first certificate matches the stored root certificate
-     * 2. Counts consecutive trusted certificates starting from the root
-     * 3. Stops counting when an untrusted certificate is encountered
-     *
-     * This function is used to pre-validate certificate chains before generating proofs,
-     * helping to optimize the proving process by determining trusted certificate lengths.
-     * Usually called from off-chain
-     */
+    /// @dev Checks the prefix length of trusted certificates in each provided certificate chain for reports
+    /// @param reportCerts Array of certificate chains, each containing certificate hashes
+    /// @return Array indicating the prefix length of trusted certificates in each chain
+    ///
+    /// For each certificate chain:
+    /// 1. Validates that the first certificate matches the stored root certificate
+    /// 2. Counts consecutive trusted certificates starting from the root
+    /// 3. Stops counting when an untrusted certificate is encountered
+    ///
+    /// This function is used to pre-validate certificate chains before generating proofs,
+    /// helping to optimize the proving process by determining trusted certificate lengths.
+    /// Usually called from offchain
     function checkTrustedIntermediateCerts(bytes32[][] calldata reportCerts) public view returns (uint8[] memory) {
         uint8[] memory results = new uint8[](reportCerts.length);
         bytes32 rootCertHash = rootCert;
@@ -281,7 +269,7 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
                 revert RootCertMismatch(rootCertHash, certs[0]);
             }
             for (uint256 j = 1; j < certs.length; j++) {
-                // Stop counting at any revoked entry so off-chain callers cannot derive a
+                // Stop counting at any revoked entry so offchain callers cannot derive a
                 // prefix-len that walks past a revoked cert and then claim it as the trusted boundary.
                 if (revokedCerts[certs[j]]) {
                     break;
@@ -299,48 +287,42 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
 
     // ============ Admin Functions ============
 
-    /**
-     * @dev Sets the trusted root certificate hash
-     * @param newRootCert Hash of the AWS Nitro Enclave root certificate
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     *
-     * The root certificate serves as the trust anchor for all certificate chain validations.
-     * This should be set to the hash of AWS's root certificate for Nitro Enclaves.
-     */
+    /// @dev Sets the trusted root certificate hash
+    /// @param newRootCert Hash of the AWS Nitro Enclave root certificate
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    ///
+    /// The root certificate serves as the trust anchor for all certificate chain validations.
+    /// This should be set to the hash of AWS's root certificate for Nitro Enclaves.
     function setRootCert(bytes32 newRootCert) external onlyOwner {
         _setRootCert(newRootCert);
     }
 
-    /**
-     * @dev Updates the maximum allowed time difference for attestation timestamp validation
-     * @param newMaxTimeDiff New maximum time difference in seconds
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     * - Must be greater than zero
-     */
+    /// @dev Updates the maximum allowed time difference for attestation timestamp validation
+    /// @param newMaxTimeDiff New maximum time difference in seconds
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    /// - Must be greater than zero
     function setMaxTimeDiff(uint64 newMaxTimeDiff) external onlyOwner {
         if (newMaxTimeDiff == 0) revert ZeroMaxTimeDiff();
         maxTimeDiff = newMaxTimeDiff;
         emit MaxTimeDiffUpdated(newMaxTimeDiff);
     }
 
-    /**
-     * @dev Configures zero-knowledge verification parameters for a specific coprocessor
-     * @param zkCoProcessor Type of ZK coprocessor (RiscZero or Succinct)
-     * @param config Configuration parameters including program IDs and verifier address
-     * @param verifierProofId The verifierProofId corresponding to the verifierId in config
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     *
-     * This function sets up the necessary parameters for ZK proof verification:
-     * - verifierId: Program ID for single attestation verification
-     * - aggregatorId: Program ID for batch/aggregated verification
-     * - zkVerifier: Address of the deployed ZK verifier contract
-     */
+    /// @dev Configures zero-knowledge verification parameters for a specific coprocessor
+    /// @param zkCoProcessor Type of ZK coprocessor (RiscZero or Succinct)
+    /// @param config Configuration parameters including program IDs and verifier address
+    /// @param verifierProofId The verifierProofId corresponding to the verifierId in config
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    ///
+    /// This function sets up the necessary parameters for ZK proof verification:
+    /// - verifierId: Program ID for single attestation verification
+    /// - aggregatorId: Program ID for batch/aggregated verification
+    /// - zkVerifier: Address of the deployed ZK verifier contract
     function setZkConfiguration(
         ZkCoProcessorType zkCoProcessor,
         ZkCoProcessorConfig memory config,
@@ -352,48 +334,44 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         _setZkConfiguration(zkCoProcessor, config, verifierProofId);
     }
 
-    /**
-     * @dev Revokes an intermediate certificate, whether or not it has been cached as trusted.
-     * @param certHash Hash of the certificate to revoke
-     *
-     * Requirements:
-     * - Only callable by contract owner or revoker
-     *
-     * Certificates that have never been seen on-chain can be revoked preemptively; the
-     * persistent `revokedCerts` sentinel blocks them from being trusted on first
-     * verification. This function allows the owner or revoker to revoke compromised
-     * intermediate certificates without affecting the root certificate or other trusted
-     * certificates.
-     *
-     * Durability: in addition to clearing `trustedIntermediateCerts[certHash]`, this
-     * function flips the persistent `revokedCerts[certHash]` sentinel. The sentinel
-     * survives subsequent `_cacheNewCert` overwrites and causes both `_verifyJournal`
-     * and `checkTrustedIntermediateCerts` to reject any chain whose suffix traverses
-     * the revoked hash, regardless of the journal's `trustedCertsPrefixLen`. Reproving
-     * the same chain therefore cannot silently restore trust; re-trust requires an
-     * explicit `unrevokeCert` call by the owner.
-     */
+    /// @dev Revokes an intermediate certificate, whether or not it has been cached as trusted.
+    /// @param certHash Hash of the certificate to revoke
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner or revoker
+    ///
+    /// Certificates that have never been seen onchain can be revoked preemptively; the
+    /// persistent `revokedCerts` sentinel blocks them from being trusted on first
+    /// verification. This function allows the owner or revoker to revoke compromised
+    /// intermediate certificates without affecting the root certificate or other trusted
+    /// certificates.
+    ///
+    /// Durability: in addition to clearing `trustedIntermediateCerts[certHash]`, this
+    /// function flips the persistent `revokedCerts[certHash]` sentinel. The sentinel
+    /// survives subsequent `_cacheNewCert` overwrites and causes both `_verifyJournal`
+    /// and `checkTrustedIntermediateCerts` to reject any chain whose suffix traverses
+    /// the revoked hash, regardless of the journal's `trustedCertsPrefixLen`. Reproving
+    /// the same chain therefore cannot silently restore trust; re-trust requires an
+    /// explicit `unrevokeCert` call by the owner.
     function revokeCert(bytes32 certHash) external onlyOwnerOrRevoker {
         delete trustedIntermediateCerts[certHash];
         revokedCerts[certHash] = true;
         emit CertRevoked(certHash);
     }
 
-    /**
-     * @dev Explicitly re-trusts a previously revoked intermediate certificate.
-     * @param certHash Hash of the certificate to un-revoke
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     * - Certificate must currently be marked as revoked
-     *
-     * Clearing the revocation sentinel does not by itself restore the cached
-     * expiry; the next successful verification whose chain traverses `certHash`
-     * will re-cache it via `_cacheNewCert`. This two-step design (admin clears
-     * the sentinel, verification re-caches the expiry) keeps re-trust an
-     * explicit, owner-only action while still letting the normal cache path
-     * supply the up-to-date `notAfter` timestamp.
-     */
+    /// @dev Explicitly re-trusts a previously revoked intermediate certificate.
+    /// @param certHash Hash of the certificate to un-revoke
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    /// - Certificate must currently be marked as revoked
+    ///
+    /// Clearing the revocation sentinel does not by itself restore the cached
+    /// expiry; the next successful verification whose chain traverses `certHash`
+    /// will re-cache it via `_cacheNewCert`. This two-step design (admin clears
+    /// the sentinel, verification re-caches the expiry) keeps re-trust an
+    /// explicit, owner-only action while still letting the normal cache path
+    /// supply the up-to-date `notAfter` timestamp.
     function unrevokeCert(bytes32 certHash) external onlyOwner {
         if (!revokedCerts[certHash]) {
             revert CertificateNotRevoked(certHash);
@@ -402,12 +380,10 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         emit CertUnrevoked(certHash);
     }
 
-    /**
-     * @dev Updates the verifier program ID, adding the new version to the supported set
-     * @param zkCoProcessor Type of ZK coprocessor
-     * @param newVerifierId New verifier program ID to set as latest
-     * @param newVerifierProofId New verifier proof ID (stored in mapping, used in batch verification)
-     */
+    /// @dev Updates the verifier program ID, adding the new version to the supported set
+    /// @param zkCoProcessor Type of ZK coprocessor
+    /// @param newVerifierId New verifier program ID to set as latest
+    /// @param newVerifierProofId New verifier proof ID (stored in mapping, used in batch verification)
     function updateVerifierId(
         ZkCoProcessorType zkCoProcessor,
         bytes32 newVerifierId,
@@ -427,11 +403,9 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         emit VerifierIdUpdated(zkCoProcessor, newVerifierId, newVerifierProofId);
     }
 
-    /**
-     * @dev Updates the aggregator program ID, adding the new version to the supported set
-     * @param zkCoProcessor Type of ZK coprocessor
-     * @param newAggregatorId New aggregator program ID to set as latest
-     */
+    /// @dev Updates the aggregator program ID, adding the new version to the supported set
+    /// @param zkCoProcessor Type of ZK coprocessor
+    /// @param newAggregatorId New aggregator program ID to set as latest
     function updateAggregatorId(ZkCoProcessorType zkCoProcessor, bytes32 newAggregatorId) external onlyOwner {
         if (newAggregatorId == bytes32(0)) revert ZeroProgramId();
         if (zkConfig[zkCoProcessor].aggregatorId == newAggregatorId) {
@@ -443,12 +417,10 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         emit AggregatorIdUpdated(zkCoProcessor, newAggregatorId);
     }
 
-    /**
-     * @dev Adds a route-specific verifier override
-     * @param zkCoProcessor Type of ZK coprocessor
-     * @param selector Proof selector (first 4 bytes of proof data)
-     * @param verifier Address of the verifier contract for this route
-     */
+    /// @dev Adds a route-specific verifier override
+    /// @param zkCoProcessor Type of ZK coprocessor
+    /// @param selector Proof selector (first 4 bytes of proof data)
+    /// @param verifier Address of the verifier contract for this route
     function addVerifyRoute(ZkCoProcessorType zkCoProcessor, bytes4 selector, address verifier) external onlyOwner {
         if (verifier == address(0)) revert ZeroVerifierAddress();
         if (verifier == FROZEN) revert InvalidVerifierAddress();
@@ -461,13 +433,11 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         emit ZkRouteAdded(zkCoProcessor, selector, verifier);
     }
 
-    /**
-     * @dev Permanently freezes a verification route
-     * @param zkCoProcessor Type of ZK coprocessor
-     * @param selector Proof selector to freeze
-     *
-     * WARNING: This action is IRREVERSIBLE
-     */
+    /// @dev Permanently freezes a verification route
+    /// @param zkCoProcessor Type of ZK coprocessor
+    /// @param selector Proof selector to freeze
+    ///
+    /// WARNING: This action is IRREVERSIBLE
     function freezeVerifyRoute(ZkCoProcessorType zkCoProcessor, bytes4 selector) external onlyOwner {
         address currentVerifier = _zkVerifierRoutes[zkCoProcessor][selector];
 
@@ -479,25 +449,21 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         emit ZkRouteWasFrozen(zkCoProcessor, selector);
     }
 
-    /**
-     * @dev Sets the proof submitter address
-     * @param submitter The address of the proof submitter
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     * - Address must not be zero
-     */
+    /// @dev Sets the proof submitter address
+    /// @param submitter The address of the proof submitter
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
+    /// - Address must not be zero
     function setProofSubmitter(address submitter) external onlyOwner {
         _setProofSubmitter(submitter);
     }
 
-    /**
-     * @dev Updates the revoker address
-     * @param newRevoker New revoker address (can be address(0) to disable the revoker role)
-     *
-     * Requirements:
-     * - Only callable by contract owner
-     */
+    /// @dev Updates the revoker address
+    /// @param newRevoker New revoker address (can be address(0) to disable the revoker role)
+    ///
+    /// Requirements:
+    /// - Only callable by contract owner
     function setRevoker(address newRevoker) external onlyOwner {
         revoker = newRevoker;
         emit RevokerUpdated(newRevoker);
@@ -505,27 +471,25 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
 
     // ============ Verification Functions ============
 
-    /**
-     * @dev Verifies a single attestation report using zero-knowledge proof
-     * @param output Encoded VerifierJournal containing the verification result
-     * @param zkCoprocessor Type of ZK coprocessor used to generate the proof
-     * @param proofBytes Zero-knowledge proof data for the attestation
-     * @return journal VerifierJournal containing the verification result and extracted data
-     *
-     * This function performs end-to-end verification of a single attestation:
-     * 1. Retrieves the single verification program ID from configuration
-     * 2. Verifies the zero-knowledge proof using the specified coprocessor
-     * 3. Decodes the verification journal from the output
-     * 4. Validates the journal through comprehensive checks
-     * 5. Returns the final verification result
-     *
-     * The returned journal contains all extracted attestation data including:
-     * - Verification status and any error conditions
-     * - Certificate chain information and trust levels
-     * - User data, nonce, and public key from the attestation
-     * - Platform Configuration Registers (PCRs) for integrity measurement
-     * - Module ID and timestamp information
-     */
+    /// @dev Verifies a single attestation report using zero-knowledge proof
+    /// @param output Encoded VerifierJournal containing the verification result
+    /// @param zkCoprocessor Type of ZK coprocessor used to generate the proof
+    /// @param proofBytes Zero-knowledge proof data for the attestation
+    /// @return journal VerifierJournal containing the verification result and extracted data
+    ///
+    /// This function performs end-to-end verification of a single attestation:
+    /// 1. Retrieves the single verification program ID from configuration
+    /// 2. Verifies the zero-knowledge proof using the specified coprocessor
+    /// 3. Decodes the verification journal from the output
+    /// 4. Validates the journal through comprehensive checks
+    /// 5. Returns the final verification result
+    ///
+    /// The returned journal contains all extracted attestation data including:
+    /// - Verification status and any error conditions
+    /// - Certificate chain information and trust levels
+    /// - User data, nonce, and public key from the attestation
+    /// - Platform Configuration Registers (PCRs) for integrity measurement
+    /// - Module ID and timestamp information
     function verify(
         bytes calldata output,
         ZkCoProcessorType zkCoprocessor,
@@ -542,22 +506,20 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         emit AttestationSubmitted(journal.result, zkCoprocessor, abi.encode(journal));
     }
 
-    /**
-     * @dev Verifies multiple attestation reports in a single batch operation
-     * @param output Encoded BatchVerifierJournal containing aggregated verification results
-     * @param zkCoprocessor Type of ZK coprocessor used to generate the proof
-     * @param proofBytes Zero-knowledge proof data for batch verification
-     * @return results Array of VerifierJournal results, one for each attestation in the batch
-     *
-     * This function provides gas-efficient batch verification by:
-     * 1. Using the aggregator program ID for ZK proof verification
-     * 2. Validating the batch verifier key matches the expected value
-     * 3. Processing each individual attestation through standard validation
-     * 4. Returning comprehensive results for all attestations
-     *
-     * Batch verification is recommended when processing multiple attestations
-     * as it significantly reduces gas costs compared to individual verifications.
-     */
+    /// @dev Verifies multiple attestation reports in a single batch operation
+    /// @param output Encoded BatchVerifierJournal containing aggregated verification results
+    /// @param zkCoprocessor Type of ZK coprocessor used to generate the proof
+    /// @param proofBytes Zero-knowledge proof data for batch verification
+    /// @return results Array of VerifierJournal results, one for each attestation in the batch
+    ///
+    /// This function provides gas-efficient batch verification by:
+    /// 1. Using the aggregator program ID for ZK proof verification
+    /// 2. Validating the batch verifier key matches the expected value
+    /// 3. Processing each individual attestation through standard validation
+    /// 4. Returning comprehensive results for all attestations
+    ///
+    /// Batch verification is recommended when processing multiple attestations
+    /// as it significantly reduces gas costs compared to individual verifications.
     function batchVerify(
         bytes calldata output,
         ZkCoProcessorType zkCoprocessor,
@@ -613,26 +575,24 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         emit ZKConfigurationUpdated(zkCoProcessor, config, verifierProofId);
     }
 
-    /**
-     * @dev Internal function to cache newly discovered trusted certificates
-     * @param journal Verification journal containing certificate chain information
-     *
-     * This function automatically adds any certificates beyond the trusted length
-     * to the trusted intermediate certificates set. This optimizes future verifications
-     * by expanding the known trusted certificate set based on successful verifications.
-     *
-     * Revoked entries terminate caching: once `revokedCerts[certHash]` is set by
-     * `revokeCert`, no successful verification will silently restore the cache,
-     * regardless of the journal's `trustedCertsPrefixLen`. Because `certs[i+1]` is
-     * signed by `certs[i]`, every descendant of a revoked cert inherits its trust
-     * from a revoked parent and must not be cached either — so we `break` rather
-     * than `continue` on the first revoked entry, matching `checkTrustedIntermediateCerts`.
-     *
-     * Note: in current control flow this guard is unreachable because `_verifyJournal`
-     * Pass 2 already rejects any journal whose suffix contains a revoked digest before
-     * `_cacheNewCert` is invoked. The check is retained as defense-in-depth against
-     * future refactors. Re-trust requires an explicit `unrevokeCert`.
-     */
+    /// @dev Internal function to cache newly discovered trusted certificates
+    /// @param journal Verification journal containing certificate chain information
+    ///
+    /// This function automatically adds any certificates beyond the trusted length
+    /// to the trusted intermediate certificates set. This optimizes future verifications
+    /// by expanding the known trusted certificate set based on successful verifications.
+    ///
+    /// Revoked entries terminate caching: once `revokedCerts[certHash]` is set by
+    /// `revokeCert`, no successful verification will silently restore the cache,
+    /// regardless of the journal's `trustedCertsPrefixLen`. Because `certs[i+1]` is
+    /// signed by `certs[i]`, every descendant of a revoked cert inherits its trust
+    /// from a revoked parent and must not be cached either — so we `break` rather
+    /// than `continue` on the first revoked entry, matching `checkTrustedIntermediateCerts`.
+    ///
+    /// Note: in current control flow this guard is unreachable because `_verifyJournal`
+    /// Pass 2 already rejects any journal whose suffix contains a revoked digest before
+    /// `_cacheNewCert` is invoked. The check is retained as defense-in-depth against
+    /// future refactors. Re-trust requires an explicit `unrevokeCert`.
     function _cacheNewCert(VerifierJournal memory journal) internal {
         for (uint256 i = journal.trustedCertsPrefixLen; i < journal.certs.length; i++) {
             bytes32 certHash = journal.certs[i];
@@ -643,35 +603,33 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         }
     }
 
-    /**
-     * @dev Internal function to verify and validate a journal entry
-     * @param journal Verification journal to validate
-     * @return Updated journal with final verification result
-     *
-     * This function performs comprehensive validation:
-     * 1. Checks if the initial ZK verification was successful
-     * 2. Validates the root certificate matches the trusted root
-     * 3. Ensures all trusted certificates in the prefix are still valid (not revoked, not expired)
-     * 4. Ensures no certificate in the suffix has been revoked, regardless of `trustedCertsPrefixLen`
-     * 5. Validates the attestation timestamp is within acceptable range
-     * 6. Caches newly discovered certificates for future use
-     *
-     * The suffix-side revocation check (step 4) is the load-bearing fix for the
-     * `revokeCert` durability gap exposed under the production
-     * `trustedCertsPrefixLen = 1` configuration. Without it, Pass 1 only walks
-     * the root and a journal whose chain traverses a revoked intermediate in
-     * the suffix would succeed and then re-cache the revoked entry via
-     * `_cacheNewCert`. Rejecting any suffix entry present in `revokedCerts`
-     * makes revocation durable independently of the journal-supplied prefix
-     * length.
-     *
-     * The timestamp validation converts milliseconds to seconds and checks:
-     * - Attestation is not too old (timestamp + maxTimeDiff > block.timestamp)
-     * - Attestation is not from the future (timestamp < block.timestamp)
-     * Note that due to truncating timestamp from milliseconds, to seconds,
-     * some valid attestations may be rejected. However, this ensures all invalid
-     * timestamps are rejected.
-     */
+    /// @dev Internal function to verify and validate a journal entry
+    /// @param journal Verification journal to validate
+    /// @return Updated journal with final verification result
+    ///
+    /// This function performs comprehensive validation:
+    /// 1. Checks if the initial ZK verification was successful
+    /// 2. Validates the root certificate matches the trusted root
+    /// 3. Ensures all trusted certificates in the prefix are still valid (not revoked, not expired)
+    /// 4. Ensures no certificate in the suffix has been revoked, regardless of `trustedCertsPrefixLen`
+    /// 5. Validates the attestation timestamp is within acceptable range
+    /// 6. Caches newly discovered certificates for future use
+    ///
+    /// The suffix-side revocation check (step 4) is the load-bearing fix for the
+    /// `revokeCert` durability gap exposed under the production
+    /// `trustedCertsPrefixLen = 1` configuration. Without it, Pass 1 only walks
+    /// the root and a journal whose chain traverses a revoked intermediate in
+    /// the suffix would succeed and then re-cache the revoked entry via
+    /// `_cacheNewCert`. Rejecting any suffix entry present in `revokedCerts`
+    /// makes revocation durable independently of the journal-supplied prefix
+    /// length.
+    ///
+    /// The timestamp validation converts milliseconds to seconds and checks:
+    /// - Attestation is not too old (timestamp + maxTimeDiff > block.timestamp)
+    /// - Attestation is not from the future (timestamp < block.timestamp)
+    /// Note that due to truncating timestamp from milliseconds, to seconds,
+    /// some valid attestations may be rejected. However, this ensures all invalid
+    /// timestamps are rejected.
     function _verifyJournal(VerifierJournal memory journal) internal returns (VerifierJournal memory) {
         if (journal.result != VerificationResult.Success) {
             return journal;
@@ -680,7 +638,7 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
             journal.result = VerificationResult.RootCertNotTrusted;
             return journal;
         }
-        // Pass 1: trusted prefix — root must match the on-chain root, and every
+        // Pass 1: trusted prefix — root must match the onchain root, and every
         // intermediate must still hold a non-expired cached entry.
         for (uint256 i = 0; i < journal.trustedCertsPrefixLen; i++) {
             bytes32 certHash = journal.certs[i];
@@ -731,13 +689,11 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         return journal;
     }
 
-    /**
-     * @dev Internal function to verify zero-knowledge proofs using the appropriate coprocessor
-     * @param zkCoprocessor Type of ZK coprocessor (RiscZero or Succinct)
-     * @param programId Program identifier for the verification program
-     * @param output Encoded output data to verify
-     * @param proofBytes Zero-knowledge proof data
-     */
+    /// @dev Internal function to verify zero-knowledge proofs using the appropriate coprocessor
+    /// @param zkCoprocessor Type of ZK coprocessor (RiscZero or Succinct)
+    /// @param programId Program identifier for the verification program
+    /// @param output Encoded output data to verify
+    /// @param proofBytes Zero-knowledge proof data
     function _verifyZk(
         ZkCoProcessorType zkCoprocessor,
         bytes32 programId,
@@ -759,12 +715,10 @@ contract NitroEnclaveVerifier is Ownable, INitroEnclaveVerifier, ISemver {
         }
     }
 
-    /**
-     * @dev Internal function to resolve the ZK verifier address based on route configuration
-     * @param zkCoprocessor Type of ZK coprocessor
-     * @param proofBytes Proof data (selector extracted from first 4 bytes)
-     * @return Resolved verifier address
-     */
+    /// @dev Internal function to resolve the ZK verifier address based on route configuration
+    /// @param zkCoprocessor Type of ZK coprocessor
+    /// @param proofBytes Proof data (selector extracted from first 4 bytes)
+    /// @return Resolved verifier address
     function _resolveZkVerifier(
         ZkCoProcessorType zkCoprocessor,
         bytes calldata proofBytes


### PR DESCRIPTION
### What changed? Why?

Backports #330 to `releases/v8.2.1`. This replaces block NatSpec comments in `NitroEnclaveVerifier` and `INitroEnclaveVerifier` with `///` line comments to match the convention used by nearby contracts.

The backport also carries over the touched comment wording updates for repo language rules and the generated semver snapshot update. No Solidity behavior changes are intended.

### Notes to reviewers

Cherry-picked the two commits from #330 on top of the current `releases/v8.2.1`, which already includes #334. The diff is limited to the Nitro enclave verifier contract/interface comments and `snapshots/semver-lock.json`.

### How has it been tested?

- `forge fmt --check src/L1/proofs/tee/NitroEnclaveVerifier.sol interfaces/L1/proofs/tee/INitroEnclaveVerifier.sol`
- `git diff --check origin/releases/v8.2.1..HEAD`
- `just test-dev --match-path test/L1/proofs/NitroEnclaveVerifier.t.sol`

Result: 80 passed, 0 failed, 0 skipped.