### PR TITLE
Fix broken deploy target in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -186,7 +186,7 @@ genesis:
 
 # Deploys the contracts.
 deploy:
-  ./scripts/deploy/deploy.sh
+  forge script scripts/deploy/SystemDeploy.s.sol:SystemDeploy
 
 
 ########################################################


### PR DESCRIPTION
The deploy target runs ./scripts/deploy/deploy.sh but that file does not exist. It was removed in the cleanup in #266 and the target was left pointing at it, so just deploy fails.

The current deploy script is scripts/deploy/SystemDeploy.s.sol (it replaced the old Deploy.s.sol that deploy.sh used). Pointed the target at it with forge script, matching the genesis target right above it. SystemDeploy has a run() entrypoint so no sig is needed.
