### PR TITLE
support optional dev environment multiproof contracts (TEE bypass) in…

### DIFF
--- a/deploy-config/local-tee.json
+++ b/deploy-config/local-tee.json
@@ -18,7 +18,7 @@
   "l2OutputOracleStartingBlockNumber": 1,
   "l2OutputOracleStartingTimestamp": 1,
   "multiproofBlockInterval": 100,
-  "multiproofConfigHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "multiproofConfigHash": "0x0000000000000000000000000000000000000000000000000000000000000001",
   "multiproofGameType": 621,
   "multiproofGenesisBlockNumber": 0,
   "multiproofIntermediateBlockInterval": 10,

--- a/deploy-config/local-tee.json
+++ b/deploy-config/local-tee.json
@@ -3,6 +3,7 @@
   "baseFeeVaultRecipient": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "baseFeeVaultWithdrawalNetwork": 0,
   "batchSenderAddress": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+  "devTeeSigner": "0x6cebCF805c5191BCf26602E43DECa89AEe092b5d",
   "disputeGameFinalityDelaySeconds": 0,
   "delayedWETHWithdrawalDelay": 0,
   "finalSystemOwner": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",

--- a/scripts/deploy/DeployConfig.s.sol
+++ b/scripts/deploy/DeployConfig.s.sol
@@ -22,6 +22,7 @@ contract DeployConfig is Script {
     address public sp1Verifier;
     address public superchainConfigGuardian;
     address public superchainConfigIncidentResponder;
+    address public devTeeSigner;
     address public teeChallenger;
     address public teeProposer;
 
@@ -79,6 +80,7 @@ contract DeployConfig is Script {
         sp1Verifier = _json.readAddress("$.sp1Verifier");
         superchainConfigGuardian = _json.readAddress("$.superchainConfigGuardian");
         superchainConfigIncidentResponder = _json.readAddress("$.superchainConfigIncidentResponder");
+        devTeeSigner = _json.readAddressOr("$.devTeeSigner", address(0));
         teeChallenger = _json.readAddress("$.teeChallenger");
         teeProposer = _json.readAddress("$.teeProposer");
 

--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -85,6 +85,7 @@ contract SystemDeploy is Script {
         ISP1Verifier sp1Verifier;
         address teeProposer;
         address teeChallenger;
+        address devTeeSigner;
         address guardian;
         address incidentResponder;
         uint64 slowFinalizationDelay;
@@ -274,6 +275,7 @@ contract SystemDeploy is Script {
             sp1Verifier: ISP1Verifier(cfg.sp1Verifier()),
             teeProposer: cfg.teeProposer(),
             teeChallenger: cfg.teeChallenger(),
+            devTeeSigner: cfg.devTeeSigner(),
             guardian: cfg.superchainConfigGuardian(),
             incidentResponder: cfg.superchainConfigIncidentResponder(),
             slowFinalizationDelay: cfg.slowFinalizationDelay(),
@@ -996,6 +998,12 @@ contract SystemDeploy is Script {
                 )
             )
         );
+
+        if (_isDevMultiproof(_input) && _input.devTeeSigner != address(0)) {
+            vm.broadcast(msg.sender);
+            DevTEEProverRegistry(address(output_.teeProverRegistryProxy))
+                .addDevSigner(_input.devTeeSigner, _input.teeImageHash);
+        }
 
         if (!_isDevMultiproof(_input)) {
             INitroEnclaveVerifier nitroVerifier = INitroEnclaveVerifier(_input.nitroEnclaveVerifier);

--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -968,7 +968,7 @@ contract SystemDeploy is Script {
         GameType gameType = GameType.wrap(uint32(_input.multiproofGameType));
 
         vm.broadcast(msg.sender);
-        if (_input.nitroEnclaveVerifier == address(0)) {
+        if (_isDevMultiproof(_input)) {
             output_.teeProverRegistryImpl =
                 new DevTEEProverRegistry(INitroEnclaveVerifier(address(0)), _output.disputeGameFactoryProxy);
         } else {
@@ -997,7 +997,7 @@ contract SystemDeploy is Script {
             )
         );
 
-        if (_input.nitroEnclaveVerifier != address(0)) {
+        if (!_isDevMultiproof(_input)) {
             INitroEnclaveVerifier nitroVerifier = INitroEnclaveVerifier(_input.nitroEnclaveVerifier);
             if (nitroVerifier.proofSubmitter() != address(output_.teeProverRegistryProxy)) {
                 vm.broadcast(msg.sender);
@@ -1009,7 +1009,7 @@ contract SystemDeploy is Script {
         output_.teeVerifier =
             IVerifier(address(new TEEVerifier(output_.teeProverRegistryProxy, _output.anchorStateRegistryProxy)));
         vm.broadcast(msg.sender);
-        if (address(_input.sp1Verifier) == address(0)) {
+        if (_isDevMultiproof(_input)) {
             output_.zkVerifier = IVerifier(address(new MockVerifier(_output.anchorStateRegistryProxy)));
         } else {
             output_.zkVerifier =
@@ -1117,7 +1117,7 @@ contract SystemDeploy is Script {
         require(_input.teeProposer != address(0), "SystemDeploy: teeProposer not set");
         require(_input.teeChallenger != address(0), "SystemDeploy: teeChallenger not set");
 
-        if (_input.nitroEnclaveVerifier != address(0)) {
+        if (!_isDevMultiproof(_input)) {
             require(_input.zkRangeHash != bytes32(0), "SystemDeploy: zkRangeHash not set");
             require(_input.zkAggregationHash != bytes32(0), "SystemDeploy: zkAggregationHash not set");
             require(address(_input.sp1Verifier) != address(0), "SystemDeploy: sp1Verifier not set");

--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -39,6 +39,8 @@ import { TEEVerifier } from "src/L1/proofs/tee/TEEVerifier.sol";
 import { INitroEnclaveVerifier } from "interfaces/L1/proofs/tee/INitroEnclaveVerifier.sol";
 import { ISP1Verifier } from "interfaces/L1/proofs/zk/ISP1Verifier.sol";
 import { ZKVerifier } from "src/L1/proofs/zk/ZKVerifier.sol";
+import { DevTEEProverRegistry } from "test/mocks/MockDevTEEProverRegistry.sol";
+import { MockVerifier } from "test/mocks/MockVerifier.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { SemverComp } from "src/libraries/SemverComp.sol";
 import { GameType, GameTypes, Hash, Proposal } from "src/libraries/bridge/Types.sol";
@@ -966,9 +968,14 @@ contract SystemDeploy is Script {
         GameType gameType = GameType.wrap(uint32(_input.multiproofGameType));
 
         vm.broadcast(msg.sender);
-        output_.teeProverRegistryImpl = new TEEProverRegistry(
-            INitroEnclaveVerifier(_input.nitroEnclaveVerifier), _output.disputeGameFactoryProxy
-        );
+        if (_input.nitroEnclaveVerifier == address(0)) {
+            output_.teeProverRegistryImpl =
+                new DevTEEProverRegistry(INitroEnclaveVerifier(address(0)), _output.disputeGameFactoryProxy);
+        } else {
+            output_.teeProverRegistryImpl = new TEEProverRegistry(
+                INitroEnclaveVerifier(_input.nitroEnclaveVerifier), _output.disputeGameFactoryProxy
+            );
+        }
 
         output_.teeProverRegistryProxy =
             TEEProverRegistry(_deployProxy(_opChainInput, _output.opChainProxyAdmin, "TEEProverRegistry"));
@@ -990,17 +997,24 @@ contract SystemDeploy is Script {
             )
         );
 
-        INitroEnclaveVerifier nitroVerifier = INitroEnclaveVerifier(_input.nitroEnclaveVerifier);
-        if (nitroVerifier.proofSubmitter() != address(output_.teeProverRegistryProxy)) {
-            vm.broadcast(msg.sender);
-            nitroVerifier.setProofSubmitter(address(output_.teeProverRegistryProxy));
+        if (_input.nitroEnclaveVerifier != address(0)) {
+            INitroEnclaveVerifier nitroVerifier = INitroEnclaveVerifier(_input.nitroEnclaveVerifier);
+            if (nitroVerifier.proofSubmitter() != address(output_.teeProverRegistryProxy)) {
+                vm.broadcast(msg.sender);
+                nitroVerifier.setProofSubmitter(address(output_.teeProverRegistryProxy));
+            }
         }
 
         vm.broadcast(msg.sender);
         output_.teeVerifier =
             IVerifier(address(new TEEVerifier(output_.teeProverRegistryProxy, _output.anchorStateRegistryProxy)));
         vm.broadcast(msg.sender);
-        output_.zkVerifier = IVerifier(address(new ZKVerifier(_input.sp1Verifier, _output.anchorStateRegistryProxy)));
+        if (address(_input.sp1Verifier) == address(0)) {
+            output_.zkVerifier = IVerifier(address(new MockVerifier(_output.anchorStateRegistryProxy)));
+        } else {
+            output_.zkVerifier =
+                IVerifier(address(new ZKVerifier(_input.sp1Verifier, _output.anchorStateRegistryProxy)));
+        }
 
         output_.aggregateVerifier = _newAggregateVerifier(
             AggregateVerifierInput({
@@ -1084,16 +1098,14 @@ contract SystemDeploy is Script {
         return _input.multiproofConfigHash != bytes32(0);
     }
 
+    function _isDevMultiproof(ImplementationInput memory _input) internal pure returns (bool) {
+        return _multiproofEnabled(_input) && _input.nitroEnclaveVerifier == address(0);
+    }
+
     function _assertValidMultiproofInput(ImplementationInput memory _input) internal view {
         require(_input.teeImageHash != bytes32(0), "SystemDeploy: teeImageHash not set");
-        require(_input.zkRangeHash != bytes32(0), "SystemDeploy: zkRangeHash not set");
-        require(_input.zkAggregationHash != bytes32(0), "SystemDeploy: zkAggregationHash not set");
         require(_input.multiproofConfigHash != bytes32(0), "SystemDeploy: multiproofConfigHash not set");
         require(_input.multiproofGameType != 0, "SystemDeploy: multiproofGameType not set");
-        require(_input.nitroEnclaveVerifier != address(0), "SystemDeploy: nitroEnclaveVerifier not set");
-        require(address(_input.sp1Verifier) != address(0), "SystemDeploy: sp1Verifier not set");
-        DeployUtils.assertValidContractAddress(_input.nitroEnclaveVerifier);
-        DeployUtils.assertValidContractAddress(address(_input.sp1Verifier));
         require(_input.multiproofBlockInterval != 0, "SystemDeploy: multiproof block interval not set");
         require(
             _input.multiproofIntermediateBlockInterval != 0, "SystemDeploy: multiproof intermediate interval not set"
@@ -1104,6 +1116,14 @@ contract SystemDeploy is Script {
         );
         require(_input.teeProposer != address(0), "SystemDeploy: teeProposer not set");
         require(_input.teeChallenger != address(0), "SystemDeploy: teeChallenger not set");
+
+        if (_input.nitroEnclaveVerifier != address(0)) {
+            require(_input.zkRangeHash != bytes32(0), "SystemDeploy: zkRangeHash not set");
+            require(_input.zkAggregationHash != bytes32(0), "SystemDeploy: zkAggregationHash not set");
+            require(address(_input.sp1Verifier) != address(0), "SystemDeploy: sp1Verifier not set");
+            DeployUtils.assertValidContractAddress(_input.nitroEnclaveVerifier);
+            DeployUtils.assertValidContractAddress(address(_input.sp1Verifier));
+        }
     }
 
     function _assertValidImplementations(Types.Implementations memory _impls) internal view {

--- a/test/deploy/SystemDeploy.t.sol
+++ b/test/deploy/SystemDeploy.t.sol
@@ -8,7 +8,12 @@ import { SystemDeploy } from "scripts/deploy/SystemDeploy.s.sol";
 import { Types } from "scripts/libraries/Types.sol";
 import { SystemDeployAssertions } from "test/deploy/SystemDeployAssertions.sol";
 
+import { IAggregateVerifier } from "interfaces/L1/proofs/IAggregateVerifier.sol";
+import { IDelayedWETH } from "interfaces/L1/proofs/IDelayedWETH.sol";
+import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
+import { IDisputeGameFactory } from "interfaces/L1/proofs/IDisputeGameFactory.sol";
 import { ISP1Verifier } from "interfaces/L1/proofs/zk/ISP1Verifier.sol";
+import { DevTEEProverRegistry } from "test/mocks/MockDevTEEProverRegistry.sol";
 import { TEEProverRegistry } from "src/L1/proofs/tee/TEEProverRegistry.sol";
 import { TEEVerifier } from "src/L1/proofs/tee/TEEVerifier.sol";
 import { ZKVerifier } from "src/L1/proofs/zk/ZKVerifier.sol";
@@ -175,6 +180,43 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
         _assertMultiproofDeployed(reuseOutput, input);
     }
 
+    function test_deploy_devMultiproof_succeeds() public {
+        SystemDeploy.DeployInput memory input = _defaultDeployInput();
+        input.implementationsInput.nitroEnclaveVerifier = address(0);
+        input.implementationsInput.sp1Verifier = ISP1Verifier(address(0));
+        input.implementationsInput.zkRangeHash = bytes32(0);
+        input.implementationsInput.zkAggregationHash = bytes32(0);
+        input.implementationsInput.proofMaturityDelaySeconds = 0;
+        input.implementationsInput.withdrawalDelaySeconds = 0;
+        input.implementationsInput.disputeGameFinalityDelaySeconds = 0;
+        input.implementationsInput.slowFinalizationDelay = 0;
+        input.implementationsInput.fastFinalizationDelay = 0;
+
+        SystemDeploy.DeployOutput memory output = systemDeploy.deploy(input);
+
+        _assertMultiproofDeployed(output, input);
+
+        address teeProverRegistryProxyAddr = address(output.opChain.teeProverRegistryProxy);
+        DevTEEProverRegistry devRegistry = DevTEEProverRegistry(teeProverRegistryProxyAddr);
+        vm.prank(owner);
+        devRegistry.addDevSigner(makeAddr("devSigner"), bytes32(uint256(1)));
+        assertTrue(devRegistry.isRegisteredSigner(makeAddr("devSigner")), "dev signer registered");
+
+        IAggregateVerifier aggVerifier = IAggregateVerifier(address(output.opChain.aggregateVerifier));
+        assertEq(
+            address(aggVerifier.DELAYED_WETH()),
+            address(output.opChain.delayedWETHProxy),
+            "aggregate verifier uses real DelayedWETH"
+        );
+
+        assertEq(address(output.opChain.nitroEnclaveVerifier), address(0), "no nitro verifier in dev mode");
+        assertEq(address(output.opChain.sp1Verifier), address(0), "no sp1 verifier in dev mode");
+
+        IDisputeGameFactory factory = IDisputeGameFactory(address(output.opChain.disputeGameFactoryProxy));
+        GameType gameType = GameType.wrap(uint32(input.implementationsInput.multiproofGameType));
+        assertNotEq(address(factory.gameImpls(gameType)), address(0), "game type registered on factory");
+    }
+
     function _defaultDeployInput() internal view returns (SystemDeploy.DeployInput memory input_) {
         input_.saveArtifacts = false;
         input_.superchainInput = SystemDeploy.SuperchainInput({
@@ -250,11 +292,13 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
         assertEq(teeProverRegistry.manager(), _input.opChainInput.roles.opChainProxyAdminOwner, "tee registry manager");
         assertTrue(teeProverRegistry.isValidProposer(_input.implementationsInput.teeProposer), "tee proposer");
         assertTrue(teeProverRegistry.isValidProposer(_input.implementationsInput.teeChallenger), "tee challenger");
-        assertEq(
-            MockNitroEnclaveVerifier(_input.implementationsInput.nitroEnclaveVerifier).proofSubmitter(),
-            teeProverRegistryProxyAddr,
-            "nitro proof submitter"
-        );
+        if (_input.implementationsInput.nitroEnclaveVerifier != address(0)) {
+            assertEq(
+                MockNitroEnclaveVerifier(_input.implementationsInput.nitroEnclaveVerifier).proofSubmitter(),
+                teeProverRegistryProxyAddr,
+                "nitro proof submitter"
+            );
+        }
         assertEq(
             address(teeProverRegistry.DISPUTE_GAME_FACTORY()),
             address(_output.opChain.disputeGameFactoryProxy),
@@ -266,11 +310,13 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
             teeProverRegistryProxyAddr,
             "tee verifier registry"
         );
-        assertEq(
-            address(ZKVerifier(zkVerifierAddr).SP1_VERIFIER()),
-            address(_input.implementationsInput.sp1Verifier),
-            "zk verifier sp1"
-        );
+        if (address(_input.implementationsInput.sp1Verifier) != address(0)) {
+            assertEq(
+                address(ZKVerifier(zkVerifierAddr).SP1_VERIFIER()),
+                address(_input.implementationsInput.sp1Verifier),
+                "zk verifier sp1"
+            );
+        }
     }
 
     function _expected(

--- a/test/deploy/SystemDeploy.t.sol
+++ b/test/deploy/SystemDeploy.t.sol
@@ -181,11 +181,13 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
     }
 
     function test_deploy_devMultiproof_succeeds() public {
+        address devSigner = 0x6cebCF805c5191BCf26602E43DECa89AEe092b5d;
         SystemDeploy.DeployInput memory input = _defaultDeployInput();
         input.implementationsInput.nitroEnclaveVerifier = address(0);
         input.implementationsInput.sp1Verifier = ISP1Verifier(address(0));
         input.implementationsInput.zkRangeHash = bytes32(0);
         input.implementationsInput.zkAggregationHash = bytes32(0);
+        input.implementationsInput.devTeeSigner = devSigner;
         input.implementationsInput.proofMaturityDelaySeconds = 0;
         input.implementationsInput.withdrawalDelaySeconds = 0;
         input.implementationsInput.disputeGameFinalityDelaySeconds = 0;
@@ -196,11 +198,8 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
 
         _assertMultiproofDeployed(output, input);
 
-        address teeProverRegistryProxyAddr = address(output.opChain.teeProverRegistryProxy);
-        DevTEEProverRegistry devRegistry = DevTEEProverRegistry(teeProverRegistryProxyAddr);
-        vm.prank(owner);
-        devRegistry.addDevSigner(makeAddr("devSigner"), bytes32(uint256(1)));
-        assertTrue(devRegistry.isRegisteredSigner(makeAddr("devSigner")), "dev signer registered");
+        DevTEEProverRegistry devRegistry = DevTEEProverRegistry(address(output.opChain.teeProverRegistryProxy));
+        assertTrue(devRegistry.isRegisteredSigner(devSigner), "dev signer registered at deploy time");
 
         IAggregateVerifier aggVerifier = IAggregateVerifier(address(output.opChain.aggregateVerifier));
         assertEq(
@@ -237,6 +236,7 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
             sp1Verifier: ISP1Verifier(address(sp1Verifier)),
             teeProposer: proposer,
             teeChallenger: challenger,
+            devTeeSigner: address(0),
             guardian: guardian,
             incidentResponder: incidentResponder,
             slowFinalizationDelay: 5 days,


### PR DESCRIPTION
## Problem

The L3 devnet deploys the full OP Stack via `SystemDeploy` but with `multiproofConfigHash = 0`, skipping multiproof entirely. Without an `AggregateVerifier` registered on the `DisputeGameFactory`, dispute games can't be created and TEE instant-finality withdrawals (`proveAndFinalizeWithdrawalTransaction`) don't work. This is the primary gap between the current devnet and a functional L3 with TEE-backed withdrawals.

Enabling multiproof today requires real Nitro enclave and SP1 verifier contracts deployed on-chain, infrastructure we don't have wired in yet. 

## Solution

When `multiproofConfigHash` is non-zero (multiproof enabled) but `nitroEnclaveVerifier` is `address(0)` (no Nitro infra), `SystemDeploy` now deploys:

- `DevTEEProverRegistry` instead of `TEEProverRegistry`; allows `addDevSigner()` without attestation
- `MockVerifier` instead of `ZKVerifier`; auto-accepts any ZK proof (a follow-up PR will deprecate ZK path entirely)

Everything else is unchanged: real `DisputeGameFactory`, `AnchorStateRegistry`, `DelayedWETH`, and the TEEProverRegistry proxy sits behind the chain's `ProxyAdmin` for a clean upgrade to the production impl when Nitro is ready.

No new config fields — the mode is inferred from existing config values.

## Why not a separate deploy script?

- **`DeployDevNoNitro` standalone** — Deploys its own `DisputeGameFactory`/`MockAnchorStateRegistry` — disconnected from the real system
- **This PR** — Single atomic deploy, all real infra, proxy-upgradeable to production

## Testing

- [x] Existing `test_deploy_withoutManagerAddress_succeeds` (production path) still passes
- [x] New `test_deploy_devMultiproof_succeeds` — deploys with zero nitro/sp1, verifies `addDevSigner` works, confirms `AggregateVerifier` references real `DelayedWETH`, game type registered on factory
- [x] All 7 tests pass