### PR TITLE
feat(PRIV-1981): add chain id guard to sandbox l3 options

### DIFF
--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -1124,7 +1124,12 @@ contract SystemDeploy is Script {
         require(_input.teeProposer != address(0), "SystemDeploy: teeProposer not set");
         require(_input.teeChallenger != address(0), "SystemDeploy: teeChallenger not set");
 
-        if (!_isDevMultiproof(_input)) {
+        if (_isDevMultiproof(_input)) {
+            require(
+                block.chainid != 1 && block.chainid != 8453 && block.chainid != 84532,
+                "SystemDeploy: dev multiproof cannot be deployed on production chains"
+            );
+        } else {
             require(_input.zkRangeHash != bytes32(0), "SystemDeploy: zkRangeHash not set");
             require(_input.zkAggregationHash != bytes32(0), "SystemDeploy: zkAggregationHash not set");
             require(address(_input.sp1Verifier) != address(0), "SystemDeploy: sp1Verifier not set");

--- a/test/deploy/SystemDeploy.t.sol
+++ b/test/deploy/SystemDeploy.t.sol
@@ -219,6 +219,30 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
         assertNotEq(address(factory.gameImpls(gameType)), address(0), "game type registered on factory");
     }
 
+    function test_deploy_devMultiproof_onProductionChain_reverts() public {
+        SystemDeploy.DeployInput memory input = _defaultDeployInput();
+        input.implementationsInput.nitroEnclaveVerifier = address(0);
+        input.implementationsInput.sp1Verifier = ISP1Verifier(address(0));
+        input.implementationsInput.zkRangeHash = bytes32(0);
+        input.implementationsInput.zkAggregationHash = bytes32(0);
+        input.implementationsInput.devTeeSigner = makeAddr("devSigner");
+
+        // Ethereum mainnet
+        vm.chainId(1);
+        vm.expectRevert("SystemDeploy: dev multiproof cannot be deployed on production chains");
+        systemDeploy.deploy(input);
+
+        // Base mainnet
+        vm.chainId(8453);
+        vm.expectRevert("SystemDeploy: dev multiproof cannot be deployed on production chains");
+        systemDeploy.deploy(input);
+
+        // Base Sepolia
+        vm.chainId(84532);
+        vm.expectRevert("SystemDeploy: dev multiproof cannot be deployed on production chains");
+        systemDeploy.deploy(input);
+    }
+
     function _defaultDeployInput() internal view returns (SystemDeploy.DeployInput memory input_) {
         input_.saveArtifacts = false;
         input_.superchainInput = SystemDeploy.SuperchainInput({


### PR DESCRIPTION
Added a require in `_assertValidMultiproofInput` that reverts with `"SystemDeploy: dev multiproof cannot be deployed on production chains"` when `_isDevMultiproof` is true and `block.chainid` is 1 (Ethereum mainnet), 8453 (Base mainnet), or 84532 (Base Sepolia)