### PR TITLE
fix(PRIV-2004): allow dev multiproof on Base Sepolia (84532)

### DIFF
--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -1199,8 +1199,11 @@ contract SystemDeploy is Script {
         require(_input.teeChallenger != address(0), "SystemDeploy: teeChallenger not set");
 
         if (_isDevMultiproof(_input)) {
+            // Block only real value-bearing chains (Ethereum mainnet, Base mainnet). Public
+            // testnets such as Base Sepolia (84532) are valid dev-multiproof settlement targets,
+            // e.g. an L3 devnet that settles to Base Sepolia.
             require(
-                block.chainid != 1 && block.chainid != 8453 && block.chainid != 84532,
+                block.chainid != 1 && block.chainid != 8453,
                 "SystemDeploy: dev multiproof cannot be deployed on production chains"
             );
         } else {


### PR DESCRIPTION
## Summary

- The dev-multiproof production-chain guard in `SystemDeploy` (`_assertValidMultiproofInput`) classified Base Sepolia (`84532`) as a production chain and reverted before any L1 contracts were initialized.
- In the L3 devnet flow, Base Sepolia is the **settlement (L1) chain** the deploy script runs against (`block.chainid == 84532`), and it is a public **testnet**, not a value-bearing chain — so it's a valid dev-multiproof target.
- This drops `84532` from the blocklist while keeping the guard for Ethereum mainnet (`1`) and Base mainnet (`8453`), so mainnet protection is preserved.

## Why this approach

Considered and rejected:
- Removing the guard entirely → loses mainnet / Base mainnet protection (security regression).
- Disabling multiproof in `devnet.json` → loses multiproof devnet coverage.
- Pinning an older commit → only defers the bug.

## Impact this unblocks

`devnet-setup` exit 1 was cascading: downstream containers (builder, client, consensus, batcher, base-rpc, zk-prover) stayed in `Created`, the ALB health check on `:8545` never responded, the ASG terminated the instance, and the deploy halted with `HaltError: Found terminating instances`.

Linear: PRIV-2004

Made with [Cursor](https://cursor.com)