### PR TITLE
fix(PRIV-2006): resolve ASR initialize args before vm.broadcast

### DIFF
--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -269,12 +269,16 @@ contract SystemDeploy is Script {
                 genesisOutputRoot != bytes32(0) && genesisOutputRoot != bytes32(uint256(1)),
                 "SystemDeploy: real multiproofGenesisOutputRoot required for deferred anchor"
             );
+            // Resolve all cheatcode-backed inputs before vm.broadcast: cheatcode staticcalls
+            // (mustGetAddress, cfg.*) are disallowed once a broadcast is armed for the next call.
+            ISystemConfig anchorSystemConfig = ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy"));
+            IDisputeGameFactory anchorDisputeGameFactory =
+                IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
+            Proposal memory startingAnchor =
+                Proposal({ root: Hash.wrap(genesisOutputRoot), l2SequenceNumber: cfg.multiproofGenesisBlockNumber() });
             vm.broadcast(msg.sender);
             anchorStateRegistry.initialize(
-                ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy")),
-                IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy")),
-                Proposal({ root: Hash.wrap(genesisOutputRoot), l2SequenceNumber: cfg.multiproofGenesisBlockNumber() }),
-                GameTypes.AGGREGATE_VERIFIER
+                anchorSystemConfig, anchorDisputeGameFactory, startingAnchor, GameTypes.AGGREGATE_VERIFIER
             );
             console.log("Initialized AnchorStateRegistry with deferred genesis output root");
         }


### PR DESCRIPTION
## Summary
`registerAggregateVerifier` armed `vm.broadcast(msg.sender)` and then passed `artifacts.mustGetAddress(...)` / `cfg.multiproofGenesisBlockNumber()` directly as `anchorStateRegistry.initialize(...)` arguments. Solidity evaluates those cheatcode staticcalls **after** the broadcast is armed, which Foundry forbids:

```
VM::broadcast(0x609a88…)
Artifacts::mustGetAddress("SystemConfigProxy") [staticcall]
  └─ [Revert] `staticcall`s are not allowed after `broadcast`; use `startBroadcast` instead
```

So the post-genesis one-shot reverted and the `AnchorStateRegistry` was never seeded — the anchor stayed uninitialized and the proposer/prover could not generate proofs.

## Fix
Hoist the `SystemConfig`/`DisputeGameFactory` lookups and the starting-anchor `Proposal` into locals **before** `vm.broadcast`, so only the `initialize()` call itself is broadcast. (Locals are `anchor`-prefixed to avoid shadowing the later `disputeGameFactory` in the same function.)

## Evidence
Verified live on `web3-shared-dev` with the deployed image (`Commit hash cd6c8a2d`): the register one-shot correctly computed the **real** genesis output root (`multiproofGenesisOutputRoot() → 0xa53d466c…`, gameType 621) and the ASR was correctly deferred/uninitialized — only the `initialize()` call reverted on this cheatcode ordering.

## Type
Bug fix.

## Risk
Low — reordering of local variable resolution; no behavioral change to the on-chain `initialize` call. `forge build` passes.

## Follow-up
The existing deferred-init unit test calls `ASR.initialize` directly and so didn't exercise the broadcast path; a follow-up could drive `registerAggregateVerifier` end-to-end.

Made with [Cursor](https://cursor.com)