### PR TITLE
fix(proxy): add zero address check to upgradeTo

### DIFF
--- a/src/universal/Proxy.sol
+++ b/src/universal/Proxy.sol
@@ -58,6 +58,7 @@ contract Proxy {
     ///         when this contract is called.
     /// @param _implementation Address of the implementation contract.
     function upgradeTo(address _implementation) public virtual proxyCallIfNotAdmin {
+        require(_implementation != address(0), "Proxy: implementation cannot be address(0)");
         _setImplementation(_implementation);
     }
 


### PR DESCRIPTION
If admin accidentally calls upgradeTo(address(0)), the proxy would
    revert on all non-admin calls. Add a require statement to catch this
    at the upgradeTo call site instead, preventing accidental DOS.