### PR TITLE
Lower min base fee

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -16,7 +16,7 @@
     "sourceCodeHash": "0xd9f576a79e97bc541b3d7a2ee928f34223edaaecb074eeb9e6e2ecee857ce6a0"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0x2c01bc6c0a55a1a27263224e05c1b28703ff85c61075bae7ab384b3043820ed2",
+    "initCodeHash": "0xdd5d13b03c015d45d0cdda512795c4fe8bbd60557e3848fed53260ee887b2df4",
     "sourceCodeHash": "0xa1281f5da03fa0431eabad33da23f51a8d835b0dd04554603fd59e11efe9fa51"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {

--- a/src/L1/ResourceMetering.sol
+++ b/src/L1/ResourceMetering.sol
@@ -139,7 +139,7 @@ abstract contract ResourceMetering is Initializable {
         // division by zero for L1s that don't support 1559 or to avoid excessive gas burns during
         // periods of extremely low L1 demand. One-day average gas fee hasn't dipped below 1 gwei
         // during any 1 day period in the last 5 years, so should be fine.
-        uint256 gasCost = resourceCost / Math.max(block.basefee, 1 gwei);
+        uint256 gasCost = resourceCost / Math.max(block.basefee, 0.01 gwei);
 
         // Give the user a refund based on the amount of gas they used to do all of the work up to
         // this point. Since we're at the end of the modifier, this should be pretty accurate. Acts

--- a/src/L1/ResourceMetering.sol
+++ b/src/L1/ResourceMetering.sol
@@ -135,10 +135,10 @@ abstract contract ResourceMetering is Initializable {
         uint256 resourceCost = uint256(_amount) * uint256(params.prevBaseFee);
 
         // We currently charge for this ETH amount as an L1 gas burn, so we convert the ETH amount
-        // into gas by dividing by the L1 base fee. We assume a minimum base fee of 1 gwei to avoid
-        // division by zero for L1s that don't support 1559 or to avoid excessive gas burns during
-        // periods of extremely low L1 demand. One-day average gas fee hasn't dipped below 1 gwei
-        // during any 1 day period in the last 5 years, so should be fine.
+        // into gas by dividing by the L1 base fee. We clamp to a minimum of 0.01 gwei to avoid
+        // division by zero on L1s without EIP-1559 and to cap gas-burn requirements when L1 demand
+        // is extremely low. A higher floor reduces the gas burned per deposit but undercharges
+        // relative to the deposit fee market when L1 base fee is below that floor.
         uint256 gasCost = resourceCost / Math.max(block.basefee, 0.01 gwei);
 
         // Give the user a refund based on the amount of gas they used to do all of the work up to

--- a/test/L1/ResourceMetering.t.sol
+++ b/test/L1/ResourceMetering.t.sol
@@ -74,6 +74,7 @@ abstract contract ResourceMetering_TestInit is Test {
 contract ResourceMetering_Metered_Test is ResourceMetering_TestInit {
     /// @dev Gas overhead from the metering logic and `measuredUse` wrapper, excluding the burn loop.
     uint256 internal constant METERING_GAS_OVERHEAD = 1000;
+
     /// @notice Tests that updating the resource params to the same values works correctly.
     function test_metered_updateParamsNoChange_succeeds() external {
         meter.use(0); // equivalent to just updating the base fee and block number

--- a/test/L1/ResourceMetering.t.sol
+++ b/test/L1/ResourceMetering.t.sol
@@ -72,6 +72,8 @@ abstract contract ResourceMetering_TestInit is Test {
 /// @dev Tests are based on the default config values. It is expected that these config values are
 ///      used in production.
 contract ResourceMetering_Metered_Test is ResourceMetering_TestInit {
+    /// @dev Gas overhead from the metering logic and `measuredUse` wrapper, excluding the burn loop.
+    uint256 internal constant METERING_GAS_OVERHEAD = 1000;
     /// @notice Tests that updating the resource params to the same values works correctly.
     function test_metered_updateParamsNoChange_succeeds() external {
         meter.use(0); // equivalent to just updating the base fee and block number
@@ -188,6 +190,42 @@ contract ResourceMetering_Metered_Test is ResourceMetering_TestInit {
         (uint128 prevBaseFee, uint64 prevBoughtGas,) = meter.params();
         assertEq(prevBoughtGas, target / 2);
         assertGt(prevBaseFee, 0);
+    }
+
+    /// @notice Tests that deposits are charged the full resource cost when L1 base fee is below
+    ///         1 gwei but above the 0.01 gwei floor.
+    function test_metered_subGweiBaseFee_collectsFullResourceCost_succeeds() external {
+        uint64 amount = 100_000;
+        uint128 prevBaseFee = 1 gwei;
+        uint256 l1BaseFee = 0.1 gwei;
+        uint256 resourceCost = uint256(amount) * uint256(prevBaseFee);
+        uint256 expectedGasCost = resourceCost / l1BaseFee;
+
+        meter.set(prevBaseFee, 0, uint64(block.number));
+        vm.fee(l1BaseFee);
+
+        uint256 gasConsumed = meter.measuredUse(amount);
+
+        assertApproxEqAbs(gasConsumed, expectedGasCost, METERING_GAS_OVERHEAD);
+        assertApproxEqAbs(gasConsumed * l1BaseFee, resourceCost, METERING_GAS_OVERHEAD * l1BaseFee);
+    }
+
+    /// @notice Tests that the 0.01 gwei floor is applied when L1 base fee falls below it.
+    function test_metered_belowFloorBaseFee_usesFloor_succeeds() external {
+        uint64 amount = 100_000;
+        uint128 prevBaseFee = 1 gwei;
+        uint256 l1BaseFee = 0.005 gwei;
+        uint256 floor = 0.01 gwei;
+        uint256 resourceCost = uint256(amount) * uint256(prevBaseFee);
+        uint256 expectedGasCost = resourceCost / floor;
+
+        meter.set(prevBaseFee, 0, uint64(block.number));
+        vm.fee(l1BaseFee);
+
+        uint256 gasConsumed = meter.measuredUse(amount);
+
+        assertApproxEqAbs(gasConsumed, expectedGasCost, METERING_GAS_OVERHEAD);
+        assertApproxEqAbs(gasConsumed * l1BaseFee, resourceCost / 2, METERING_GAS_OVERHEAD * l1BaseFee);
     }
 
     /// @notice Tests that base fee decreases when gas usage is below target.


### PR DESCRIPTION
## Summary

- Lowers the L1 base fee floor in `ResourceMetering` from `1 gwei` to `0.01 gwei` when converting deposit resource cost into an L1 gas burn.
- Ethereum mainnet `block.basefee` has been below `1 gwei` for a sustained period, which caused deposits to be **undercharged** relative to the deposit fee market (`prevBaseFee`, which still has a `1 gwei` minimum via `minimumBaseFee`).
- With the new floor, when L1 base fee is between `0.01 gwei` and `1 gwei`, deposit txs burn enough L1 gas to collect the intended `resourceCost` (`_gasLimit * prevBaseFee`).

## Operational notes

- **Requires an `OptimismPortal2` upgrade** on L1 to take effect; `OptimismPortal2` inherits `ResourceMetering`.
- **Large deposits need more L1 tx gas** when L1 base fee is low. Extra gas burned scales as `_gasLimit * (prevBaseFee / block.basefee)`. For example, at `prevBaseFee = 1 gwei` and L1 base fee `0.1 gwei`, a `2M` gas-limit deposit burns ~`20M` L1 gas for metering alone. Wallets and bridges should account for this when estimating deposit tx gas.
- When L1 base fee drops below `0.01 gwei`, the floor still applies and deposits remain partially undercharged (but less so than with the old `1 gwei` floor).

## Test plan

- [x] `test_metered_subGweiBaseFee_collectsFullResourceCost_succeeds` — verifies full fee collection at `0.1 gwei` L1 base fee
- [x] `test_metered_belowFloorBaseFee_usesFloor_succeeds` — verifies `0.01 gwei` floor at `0.005 gwei` L1 base fee
- [x] Existing `ResourceMetering` and `OptimismPortal2` deposit tests pass