### PR TITLE
fix: apply CEI pattern in DisputeGameFactory create() and createWithInitData()

### DIFF
--- a/src/L1/proofs/DisputeGameFactory.sol
+++ b/src/L1/proofs/DisputeGameFactory.sol
@@ -150,8 +150,10 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
         returns (IDisputeGame proxy_)
     {
         proxy_ = _createGameImpl(_gameType, _rootClaim, _extraData);
-        proxy_.initialize{ value: msg.value }();
+        // EFFECT: Register state first (CEI pattern)
         _finalizeGameCreation(_gameType, _rootClaim, _extraData, proxy_);
+        // INTERACTION: External call last
+        proxy_.initialize{ value: msg.value }();
     }
 
     function createWithInitData(
@@ -165,8 +167,10 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
         returns (IDisputeGame proxy_)
     {
         proxy_ = _createGameImpl(_gameType, _rootClaim, _extraData);
-        proxy_.initializeWithInitData{ value: msg.value }(_initData);
+        // EFFECT: Register state first (CEI pattern)
         _finalizeGameCreation(_gameType, _rootClaim, _extraData, proxy_);
+        // INTERACTION: External call last
+        proxy_.initializeWithInitData{ value: msg.value }(_initData);
     }
 
     /// @notice Creates a new DisputeGame proxy contract.


### PR DESCRIPTION
## Description

This PR fixes a **Checks-Effects-Interactions (CEI) violation** in `DisputeGameFactory.sol` identified by [Lumi Security Audit (Issue #356)](https://github.com/base/contracts/issues/356).

### Vulnerability

Both `create()` and `createWithInitData()` perform an external call (`proxy_.initialize()` / `proxy_.initializeWithInitData()`) **before** updating the factory's internal state via `_finalizeGameCreation()`. This violates the CEI pattern and exposes the contract to:

- **Reentrancy attack surface**: A malicious `initialize` function could re-enter the factory before the game is registered
- **Integration failures**: If a dispute game implementation expects the factory to recognize it during initialization, the call will fail because `_disputeGames` mapping hasn't been updated yet

### Fix

Swapped the order so `_finalizeGameCreation` (state effect) runs **before** `proxy_.initialize()` (external interaction). The EVM auto-rolls back state if the subsequent call reverts, preserving safety.

### Severity: Medium

Closes #356