### PR TITLE
fix(disputegamefactory): apply CEI pattern in create() and createWithInitData()

### DIFF
--- a/src/L1/proofs/DisputeGameFactory.sol
+++ b/src/L1/proofs/DisputeGameFactory.sol
@@ -150,8 +150,10 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
         returns (IDisputeGame proxy_)
     {
         proxy_ = _createGameImpl(_gameType, _rootClaim, _extraData);
-        proxy_.initialize{ value: msg.value }();
+        // EFFECT: Finalize and register state first (CEI pattern)
         _finalizeGameCreation(_gameType, _rootClaim, _extraData, proxy_);
+        // INTERACTION: Perform external initialization call last
+        proxy_.initialize{ value: msg.value }();
     }
 
     function createWithInitData(
@@ -165,8 +167,10 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
         returns (IDisputeGame proxy_)
     {
         proxy_ = _createGameImpl(_gameType, _rootClaim, _extraData);
-        proxy_.initializeWithInitData{ value: msg.value }(_initData);
+        // EFFECT: Finalize and register state first (CEI pattern)
         _finalizeGameCreation(_gameType, _rootClaim, _extraData, proxy_);
+        // INTERACTION: Perform external initialization call last
+        proxy_.initializeWithInitData{ value: msg.value }(_initData);
     }
 
     /// @notice Creates a new DisputeGame proxy contract.


### PR DESCRIPTION
## Description

Fixes a state-desynchronization vulnerability in `DisputeGameFactory.sol` caused by a violation of the Checks-Effects-Interactions (CEI) pattern.

## Vulnerability

In both `create()` and `createWithInitData()`, the factory deploys a clone proxy, performs an external initialization call (`proxy_.initialize()` / `proxy_.initializeWithInitData()`), and only THEN updates its internal state (`_disputeGames` mapping and `_disputeGameList` array).

This creates two risks:
1. **Integration Failure:** If a dispute game initialization sequence queries the factory to verify its own legitimacy, the verification fails because the game is not yet registered.
2. **Stale State:** Downstream components querying the factory during initialization see stale data.

## Fix

Moves `_finalizeGameCreation()` before the external `proxy_.initialize()` call in both functions, following the CEI (Checks-Effects-Interactions) pattern. If initialization fails, the EVM atomically reverts the state registration along with the entire transaction.

## CEI Order (Corrected)
1. ✅ **Checks:** Bond validation, duplicate UUID check (already in `_createGameImpl`)
2. ✅ **Effects:** `_finalizeGameCreation()` — register game in factory state
3. ✅ **Interactions:** `proxy_.initialize()` — external call to the new game proxy

Closes #356