### PR TITLE
fix(l2genesis): explicitly initialize WETH storage slots after vm.etch

### DIFF
--- a/scripts/L2Genesis.s.sol
+++ b/scripts/L2Genesis.s.sol
@@ -275,10 +275,20 @@ contract L2Genesis is Script {
     }
 
     /// @notice This predeploy is following the safety invariant #1.
-    ///         This contract is NOT proxied and the state that is set
-    ///         in the constructor is set manually.
+    ///         This contract is NOT proxied.
+    ///         The WETH contract (src/L2/WETH.sol) has no constructor side effects:
+    ///          - `name()` and `symbol()` are `pure` functions that read from the
+    ///            L1Block predeploy, not from storage.
+    ///          - `decimals` is a `constant` (no storage slot).
+    ///          - `_balanceOf` (slot 0) and `_allowance` (slot 1) are mappings
+    ///            that correctly start empty.
+    ///         We explicitly zero both storage slots after `vm.etch` for clarity,
+    ///         even though the EVM zero-initializes all storage after `vm.etch`.
     function setWETH() internal {
         vm.etch(Predeploys.WETH, vm.getDeployedCode("WETH.sol:WETH"));
+        // Explicitly zero-initialize storage slots for audit clarity:
+        vm.store(Predeploys.WETH, bytes32(uint256(0)), bytes32(0)); // _balanceOf (slot 0)
+        vm.store(Predeploys.WETH, bytes32(uint256(1)), bytes32(0)); // _allowance (slot 1)
     }
 
     /// @notice This predeploy is following the safety invariant #2.


### PR DESCRIPTION
## Description

The `setWETH()` function deploys the WETH predeploy via `vm.etch`, which skips constructor execution. While the WETH contract:
- Has `pure` `name()`/`symbol()` reading from L1Block (no storage)
- Has `constant` `decimals` (no storage slot)
- Has `_balanceOf` (slot 0) and `_allowance` (slot 1) that correctly start empty

This change adds explicit `vm.store` calls to zero both storage slots for audit clarity and updates the NatSpec to document the safety invariant.

## Changes

1. Added `vm.store` calls for `_balanceOf` (slot 0) and `_allowance` (slot 1)
2. Updated NatSpec comment with detailed storage layout documentation

## Test Plan

- Existing `L2Genesis` tests (L2Genesis.t.sol) already verify WETH bytecode is set: `assertGt(Predeploys.WETH.code.length, 0)`
- Genesis WETH should return correct `name()` / `symbol()` via L1Block
- Genesis WETH should return `decimals = 18`

Closes #357