### PR TITLE
refactor(L1): drop MIN_NOTICE check from registerUpgrade

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0xa1281f5da03fa0431eabad33da23f51a8d835b0dd04554603fd59e11efe9fa51"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
-    "initCodeHash": "0x0d47628779e604e08a8787c299411ca1f9ed411052921aec53047748a5d7e40f",
-    "sourceCodeHash": "0x6bb512df396c0fe7216d160f0a4637cd690b4b5b8515096799d946b6bbcdaa5f"
+    "initCodeHash": "0x8ff4bbb0adb8115a3d77e1b706038b0758fdb3a0b183108a794b3cb6200acd83",
+    "sourceCodeHash": "0x2c60b18d14bf9d966e7f852397b02e732f408933261823b42b61633c14613614"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -38,7 +38,7 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      The contract is deployed behind an OP proxy: the implementation constructor disables
 ///      initializers, and `initialize` (run through the proxy) seeds the hash chain.
 contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, ReinitializableBase, ISemver {
-    /// @notice Minimum notice period required when scheduling or modifying an activation timestamp.
+    /// @notice Minimum notice period required when changing a preexisting activation timestamp.
     uint64 public constant MIN_NOTICE = 1 hours;
 
     /// @notice Activation timestamp for each registered upgrade, indexed by upgrade id (0 = not scheduled).
@@ -117,19 +117,15 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     /// @notice Registers a new upgrade, assigning it the next ascending id, optionally scheduling its
     ///         activation and bumping the minimum protocol version in the same call. Owner only.
     /// @dev Pass `timestamp` 0 to register without scheduling (schedule later via `setTimestamp`), or
-    ///      a value at least MIN_NOTICE seconds in the future to register and schedule at once.
-    ///      Either way registration extends the scheduleId chain with the new upgrade's link.
-    /// @param timestamp Future Unix activation timestamp (>= block.timestamp + MIN_NOTICE), or 0 to
-    ///                  leave the upgrade unscheduled.
+    ///      a non-zero value to register and schedule at once. Either way registration extends the
+    ///      scheduleId chain with the new upgrade's link.
+    /// @param timestamp Unix activation timestamp, or 0 to leave the upgrade unscheduled.
     /// @param minProtocolVersion New minimum protocol version to set at registration, or 0 to leave
     ///                  the current minimum unchanged.
     /// @return The ascending id assigned to the newly registered upgrade.
     function registerUpgrade(uint64 timestamp, uint256 minProtocolVersion) external returns (uint256) {
         _assertOnlyProxyAdminOwner();
         if (_upgradeScheduleId.length == 0) revert ProtocolVersions_NotInitialized();
-        if (timestamp != 0 && timestamp < uint64(block.timestamp) + MIN_NOTICE) {
-            revert ProtocolVersions_InsufficientNotice(timestamp);
-        }
         uint256 id = _timestamps.length;
         _timestamps.push(0);
         // Reserve the link slot for this upgrade at index id + 1.

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -176,12 +176,13 @@ contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
         assertNotEq(protocolVersions.scheduleId(), bytes32(0));
     }
 
-    /// @notice Tests that registering with a timestamp inside the notice window reverts.
-    function test_registerUpgrade_insufficientNotice_reverts() external {
+    /// @notice Tests that registering with a timestamp inside the notice window succeeds — the
+    ///         notice period is not enforced at registration, only via `setTimestamp`/`delayTimestamp`.
+    function test_registerUpgrade_shortNotice_succeeds() external {
         uint64 ts = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() - 1;
-        vm.expectRevert(abi.encodeWithSelector(IProtocolVersions.ProtocolVersions_InsufficientNotice.selector, ts));
         vm.prank(_owner);
         protocolVersions.registerUpgrade(ts, 0);
+        assertEq(protocolVersions.getSchedule()[CANYON], ts);
     }
 
     /// @notice Tests that a non-zero minProtocolVersion bumps the minimum during registration.


### PR DESCRIPTION
## Description

Removes the `MIN_NOTICE` requirement from `ProtocolVersions.registerUpgrade`. The owner can now register an upgrade with any activation timestamp, including one inside the notice window or in the past, in a single call.

The notice period still applies where it matters: changing a timestamp after the fact. `setTimestamp` and the incident responder's `delayTimestamp` are unchanged and keep enforcing `MIN_NOTICE`.

## Rationale

The notice window exists to guarantee offchain nodes lead time when an **existing** schedule entry moves. At registration time there is no existing entry anyone could have relied on, the owner is trusted to pick the activation, and requiring `block.timestamp + 1 hours` only adds friction (e.g. seeding a schedule with already-activated historical forks).

## Changes

- `src/L1/ProtocolVersions.sol`: remove the `ProtocolVersions_InsufficientNotice` check from `registerUpgrade`; update NatSpec on `registerUpgrade` and `MIN_NOTICE`.
- `test/L1/ProtocolVersions.t.sol`: replace `test_registerUpgrade_insufficientNotice_reverts` with `test_registerUpgrade_shortNotice_succeeds`; `setTimestamp` notice/past-timestamp revert tests unchanged.
- `snapshots/semver-lock.json`: regenerated.

No semver bump: `ProtocolVersions` (1.0.0) has not launched yet.