### PR TITLE
fix(L1): exclude unscheduled upgrades from the scheduleId commitment

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -16,8 +16,8 @@
     "sourceCodeHash": "0x811596e7486cab9ceeeb61405b9ae510d93fcbbdfa11949201a367506c53194a"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
-    "initCodeHash": "0x8ff4bbb0adb8115a3d77e1b706038b0758fdb3a0b183108a794b3cb6200acd83",
-    "sourceCodeHash": "0x2c60b18d14bf9d966e7f852397b02e732f408933261823b42b61633c14613614"
+    "initCodeHash": "0x2a4fc4d0e56788f3054ffa22cbbf133364c7bfe757e17454b717ff382598771f",
+    "sourceCodeHash": "0xd59dcca436e4fbc5ad6238048397150317869419e9a693214b038de41e02994c"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -20,20 +20,26 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      same upgrade.
 ///
 ///      The canonical schedule commitment (`scheduleId`) is the tail of a hash chain that is
-///      seeded at index 0 and extended by one link per registered upgrade:
+///      seeded at index 0 and extended by one link per *scheduled* registered upgrade:
 ///
 ///        _upgradeScheduleId[0]   = bytes32(0)                                              (seed)
-///        _upgradeScheduleId[i+1] = keccak256(abi.encode(_upgradeScheduleId[i], i, timestamp_i))
+///        _upgradeScheduleId[i+1] = timestamp_i == 0
+///                                    ? _upgradeScheduleId[i]
+///                                    : keccak256(abi.encode(_upgradeScheduleId[i], i, timestamp_i))
 ///        scheduleId              = _upgradeScheduleId[last]
 ///
-///      where timestamp_i is upgrade i's current activation timestamp (0 = not yet scheduled).
-///      Changing any upgrade's timestamp recomputes its link and all subsequent links, making
-///      scheduleId fully reproducible from (upgrade count, current timestamps). Keeping the seed as
-///      the array's first element lets both `scheduleId` and the refresh loop avoid an
-///      empty-registry special case. Proof journals bind to `scheduleId`, pinning every proof in a
-///      dispute game to the schedule in effect at the game's L1 origin block; cross-chain domain
-///      separation is provided by the journal itself, which commits the L2 chain id and registry
-///      address alongside `scheduleId`.
+///      where timestamp_i is upgrade i's current activation timestamp (0 = not scheduled).
+///      Unscheduled upgrades carry the previous link forward, so scheduleId commits only to the
+///      effective schedule — the set of (id, timestamp) pairs that affect L2 execution. This lets
+///      the registry register a new upgrade (timestamp 0) without moving scheduleId, so offchain
+///      provers that derive the same commitment from their rollup config need no lockstep update
+///      when an upgrade is registered but not yet scheduled. Changing any upgrade's timestamp
+///      recomputes its link and all subsequent links, making scheduleId fully reproducible from
+///      (upgrade count, current timestamps). Keeping the seed as the array's first element lets
+///      both `scheduleId` and the refresh loop avoid an empty-registry special case. Proof
+///      journals bind to `scheduleId`, pinning every proof in a dispute game to the schedule in
+///      effect at the game's L1 origin block; cross-chain domain separation is provided by the
+///      journal itself, which commits the L2 chain id and registry address alongside `scheduleId`.
 ///
 ///      The contract is deployed behind an OP proxy: the implementation constructor disables
 ///      initializers, and `initialize` (run through the proxy) seeds the hash chain.
@@ -46,8 +52,9 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     uint64[] private _timestamps;
 
     /// @notice Hash chain links. Element 0 is the seed (`bytes32(0)`), pushed in `initialize`;
-    ///         element `i + 1` is the cumulative hash through upgrade `i`:
-    ///         _upgradeScheduleId[i + 1] = keccak256(abi.encode(_upgradeScheduleId[i], i, _timestamps[i])).
+    ///         element `i + 1` is the cumulative hash through upgrade `i`: the previous link
+    ///         carried forward when upgrade `i` is unscheduled (timestamp 0), otherwise
+    ///         keccak256(abi.encode(_upgradeScheduleId[i], i, _timestamps[i])).
     ///         Stored per-link so that changing upgrade j's timestamp recomputes only j..n-1 links
     ///         rather than the entire chain. Non-empty iff the contract has been initialized.
     bytes32[] private _upgradeScheduleId;
@@ -117,8 +124,9 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     /// @notice Registers a new upgrade, assigning it the next ascending id, optionally scheduling its
     ///         activation and bumping the minimum protocol version in the same call. Owner only.
     /// @dev Pass `timestamp` 0 to register without scheduling (schedule later via `setTimestamp`), or
-    ///      a non-zero value to register and schedule at once. Either way registration extends the
-    ///      scheduleId chain with the new upgrade's link.
+    ///      a non-zero value to register and schedule at once. Register-only leaves scheduleId
+    ///      unchanged (unscheduled upgrades carry the previous link forward); registering with a
+    ///      timestamp extends the chain with the new upgrade's link.
     /// @param timestamp Unix activation timestamp, or 0 to leave the upgrade unscheduled.
     /// @param minProtocolVersion New minimum protocol version to set at registration, or 0 to leave
     ///                  the current minimum unchanged.
@@ -132,7 +140,8 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         _upgradeScheduleId.push();
         emit UpgradeRegistered(id);
         if (timestamp == 0) {
-            // Register-only: commit the new (id, 0) link.
+            // Register-only: the unscheduled upgrade carries the previous link forward, so
+            // scheduleId is unchanged and offchain provers need no matching update.
             _refreshScheduleId(id);
         } else {
             // Register and schedule at once via the shared pure-write helper.
@@ -259,8 +268,9 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
 
     /// @dev Recomputes the per-upgrade cumulative hash chain starting from upgrade `startIndex` and
     ///      bubbles the result through all subsequent registered upgrades. Cost is O(n-startIndex).
-    ///      Only ever called after a state change (registration, or a timestamp that actually moved),
-    ///      so the resulting tail is always a new scheduleId.
+    ///      Unscheduled upgrades (timestamp 0) carry the previous link forward instead of adding a
+    ///      link, so the tail commits only to the effective schedule. The emitted tail is unchanged
+    ///      when the state change only touched unscheduled entries (register-only).
     function _refreshScheduleId(uint256 startIndex) private {
         uint256 n = _timestamps.length;
 
@@ -268,7 +278,10 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         // startIndex == 0). Recompute from startIndex onward, storing each link at index i + 1.
         bytes32 prev = _upgradeScheduleId[startIndex];
         for (uint256 i = startIndex; i < n; i++) {
-            prev = keccak256(abi.encode(prev, i, _timestamps[i]));
+            uint64 ts = _timestamps[i];
+            if (ts != 0) {
+                prev = keccak256(abi.encode(prev, i, ts));
+            }
             _upgradeScheduleId[i + 1] = prev;
         }
 

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -21,6 +21,7 @@ abstract contract ProtocolVersions_TestInit is CommonTest {
     event MinimumProtocolVersionUpdated(uint256 indexed protocolVersion);
     event IncidentResponderUpdated(address indexed previousIncidentResponder, address indexed newIncidentResponder);
     event TimestampSet(uint256 indexed id, uint256 timestamp);
+    event ScheduleIdUpdated(bytes32 indexed newScheduleId);
 
     /// @dev Ascending ids assigned by registration order in these tests.
     uint256 internal constant CANYON = 0;
@@ -119,15 +120,42 @@ contract ProtocolVersions_Version_Test is ProtocolVersions_TestInit {
 /// @title ProtocolVersions_RegisterUpgrade_Test
 /// @notice Test contract for the `registerUpgrade` function.
 contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
-    /// @notice Tests that registering an upgrade extends the scheduleId chain.
-    function test_registerUpgrade_changesScheduleId_succeeds() external {
+    /// @notice Tests that registering an upgrade without a timestamp leaves the scheduleId
+    ///         unchanged: unscheduled upgrades carry the previous link forward, so the registry
+    ///         and offchain provers can add upgrades asynchronously.
+    function test_registerUpgrade_unscheduled_keepsScheduleId_succeeds() external {
+        // Register-only from the empty registry: scheduleId stays at the bytes32(0) seed.
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(0, 0);
+        assertEq(protocolVersions.scheduleId(), bytes32(0));
+
+        // Schedule the first upgrade, then register another without a timestamp: the new
+        // unscheduled entry must not move the commitment.
+        uint64 ts = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+        vm.prank(_owner);
+        protocolVersions.setTimestamp(CANYON, ts);
         bytes32 idBefore = protocolVersions.scheduleId();
 
         vm.roll(block.number + 1);
         vm.prank(_owner);
         protocolVersions.registerUpgrade(0, 0);
 
-        assertNotEq(protocolVersions.scheduleId(), idBefore);
+        assertEq(protocolVersions.scheduleId(), idBefore);
+    }
+
+    /// @notice Tests that register-only still emits `ScheduleIdUpdated`, carrying the unchanged
+    ///         commitment. Pins the deliberate emit-always semantics so indexers can rely on the
+    ///         event firing for every registration, scheduled or not.
+    function test_registerUpgrade_unscheduled_emitsUnchangedScheduleId_succeeds() external {
+        uint64 ts = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(ts, 0);
+        bytes32 idBefore = protocolVersions.scheduleId();
+
+        vm.expectEmit(true, false, false, false, address(protocolVersions));
+        emit ScheduleIdUpdated(idBefore);
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(0, 0);
     }
 
     /// @notice Tests that `registerUpgrade` assigns ascending ids and returns them.
@@ -289,7 +317,8 @@ contract ProtocolVersions_SetTimestamp_Test is ProtocolVersions_TestInit {
     }
 
     /// @notice Tests that passing 0 clears a scheduled timestamp, changes the scheduleId, and
-    ///         restores it to the value it held immediately after registration (ts=0 link).
+    ///         restores it to the value it held immediately after registration (the cleared entry
+    ///         carries the previous link forward again).
     function test_setTimestamp_clearTimestamp_succeeds() external {
         vm.prank(_owner);
         protocolVersions.registerUpgrade(0, 0);
@@ -346,6 +375,69 @@ contract ProtocolVersions_SetTimestamp_Test is ProtocolVersions_TestInit {
         );
         vm.prank(_owner);
         protocolVersions.setTimestamp(CANYON, 500);
+    }
+
+    /// @notice Tests that `setTimestamp` succeeds at exactly `block.timestamp + MIN_NOTICE`, the
+    ///         boundary of the notice window.
+    function test_setTimestamp_exactMinNotice_succeeds() external {
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(0, 0);
+
+        uint64 ts = uint64(block.timestamp) + protocolVersions.MIN_NOTICE();
+        vm.prank(_owner);
+        protocolVersions.setTimestamp(CANYON, ts);
+
+        assertEq(protocolVersions.getSchedule()[CANYON], ts);
+    }
+
+    /// @notice Tests that `setTimestamp` emits `ScheduleIdUpdated` carrying the exact new
+    ///         commitment tail.
+    function test_setTimestamp_emitsScheduleIdUpdated_succeeds() external {
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(0, 0);
+
+        uint64 ts = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+        bytes32 expectedTail = keccak256(abi.encode(bytes32(0), uint256(0), ts));
+
+        vm.expectEmit(true, false, false, false, address(protocolVersions));
+        emit ScheduleIdUpdated(expectedTail);
+        vm.prank(_owner);
+        protocolVersions.setTimestamp(CANYON, ts);
+
+        assertEq(protocolVersions.scheduleId(), expectedTail);
+    }
+
+    /// @notice Tests that clearing a mid-chain upgrade recomputes all downstream links: the
+    ///         cleared entry carries its predecessor's link forward and every later scheduled
+    ///         entry is rehashed on top, leaving no stale link behind.
+    function test_setTimestamp_clearMidChain_recomputesDownstreamLinks_succeeds() external {
+        // Register and schedule three upgrades.
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(0, 0);
+        protocolVersions.registerUpgrade(0, 0);
+        protocolVersions.registerUpgrade(0, 0);
+
+        uint64 ts1 = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+        uint64 ts2 = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 200;
+        uint64 ts3 = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 300;
+        protocolVersions.setTimestamp(0, ts1);
+        protocolVersions.setTimestamp(1, ts2);
+        protocolVersions.setTimestamp(2, ts3);
+
+        // Clear the middle upgrade, punching a gap into a fully scheduled chain.
+        protocolVersions.setTimestamp(1, 0);
+        vm.stopPrank();
+
+        // The chain now skips id 1: id 0 links directly to id 2.
+        bytes32 link0 = keccak256(abi.encode(bytes32(0), uint256(0), ts1));
+        bytes32 link2 = keccak256(abi.encode(link0, uint256(2), ts3));
+        assertEq(protocolVersions.scheduleId(), link2);
+
+        // Per-id commitments: the cleared id 1 carries id 0's link forward, and id 2 was
+        // recomputed on top of it rather than left holding the stale ts2-inclusive link.
+        assertEq(protocolVersions.scheduleId(0), link0);
+        assertEq(protocolVersions.scheduleId(1), link0);
+        assertEq(protocolVersions.scheduleId(2), link2);
     }
 
     /// @notice Tests that `setTimestamp` reverts when the timestamp is within MIN_NOTICE of now.
@@ -408,6 +500,81 @@ contract ProtocolVersions_SetTimestamp_Test is ProtocolVersions_TestInit {
         bytes32 link1 = keccak256(abi.encode(link0, uint256(1), ts2));
 
         assertEq(protocolVersions.scheduleId(), link1);
+    }
+
+    /// @notice Tests that an unscheduled upgrade in the middle of the registry is skipped by the
+    ///         scheduleId chain: only scheduled (id, timestamp) pairs contribute links, so a
+    ///         permanent gap (e.g. a fork that never activates on this chain) does not shift the
+    ///         commitment.
+    function test_setTimestamp_scheduleIdSkipsUnscheduledGap_succeeds() external {
+        // Register three upgrades; only ids 0 and 2 get scheduled, id 1 stays unscheduled.
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(0, 0);
+        protocolVersions.registerUpgrade(0, 0);
+        protocolVersions.registerUpgrade(0, 0);
+
+        uint64 ts1 = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+        uint64 ts3 = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 300;
+        protocolVersions.setTimestamp(0, ts1);
+        protocolVersions.setTimestamp(2, ts3);
+        vm.stopPrank();
+
+        // The chain links ids 0 and 2 directly; the unscheduled id 1 contributes no link but its
+        // id still pins each scheduled entry to its registration position.
+        bytes32 link0 = keccak256(abi.encode(bytes32(0), uint256(0), ts1));
+        bytes32 link2 = keccak256(abi.encode(link0, uint256(2), ts3));
+
+        assertEq(protocolVersions.scheduleId(), link2);
+    }
+
+    /// @notice Cross-implementation golden value shared with the offchain prover
+    ///         (`ScheduleId::from_upgrades` in base's `crates/proof/proof/src/schedule_id.rs`):
+    ///         ids 0 and 1 scheduled at 10 and 20, ids 2-9 unscheduled, id 10 scheduled at 30.
+    ///         Both sides MUST derive the same commitment for this schedule.
+    function test_scheduleId_matchesProverGoldenValue_succeeds() external {
+        // registerUpgrade does not enforce the notice window, so historical timestamps are fine.
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(10, 0);
+        protocolVersions.registerUpgrade(20, 0);
+        for (uint256 i = 0; i < 8; i++) {
+            protocolVersions.registerUpgrade(0, 0);
+        }
+        protocolVersions.registerUpgrade(30, 0);
+        vm.stopPrank();
+
+        assertEq(protocolVersions.scheduleId(), 0xa24ace1024856cce0f999daface9269cbe7c1a8d1069a0e75196635146ee2058);
+    }
+
+    /// @notice Cross-implementation golden value for the Base mainnet schedule as of Beryl,
+    ///         shared with the offchain prover (`schedule_id_matches_mainnet_golden_value` in
+    ///         base's `crates/proof/proof/src/schedule_id.rs`). Ids follow the node's
+    ///         CONTRACT_VARIANTS registration order. The genesis-active regolith (timestamp 0),
+    ///         the mainnet pectra_blob_schedule gap, and the unscheduled cobalt tail all
+    ///         contribute no link.
+    function test_scheduleId_matchesMainnetGoldenValue_succeeds() external {
+        uint64[13] memory mainnetSchedule = [
+            uint64(0), // regolith: genesis-active, encoded as 0 => no link
+            1_704_992_401, // canyon
+            1_708_560_000, // delta
+            1_710_374_401, // ecotone
+            1_720_627_201, // fjord
+            1_726_070_401, // granite
+            1_736_445_601, // holocene
+            0, // pectra_blob_schedule: never activates on mainnet => no link
+            1_746_806_401, // isthmus
+            1_764_691_201, // jovian
+            1_779_991_200, // azul
+            1_782_410_400, // beryl
+            0 // cobalt: not yet scheduled => no link
+        ];
+
+        vm.startPrank(_owner);
+        for (uint256 i = 0; i < mainnetSchedule.length; i++) {
+            protocolVersions.registerUpgrade(mainnetSchedule[i], 0);
+        }
+        vm.stopPrank();
+
+        assertEq(protocolVersions.scheduleId(), 0xe7ed922ecb2a9d7704cf21e21c62313eabe90f345c212cad1a4706633dcf4efd);
     }
 }
 
@@ -579,7 +746,8 @@ contract ProtocolVersions_Uncategorized_Test is ProtocolVersions_TestInit {
         assertEq(s[ECOTONE], 0);
     }
 
-    /// @notice Tests that `scheduleId(id)` returns each upgrade's cumulative commitment, and that
+    /// @notice Tests that `scheduleId(id)` returns each upgrade's cumulative commitment: scheduled
+    ///         upgrades add a link, unscheduled upgrades carry the previous commitment forward, and
     ///         the last upgrade's commitment equals the current scheduleId.
     function test_scheduleId_byId_succeeds() external {
         vm.prank(_owner);
@@ -587,7 +755,17 @@ contract ProtocolVersions_Uncategorized_Test is ProtocolVersions_TestInit {
         vm.prank(_owner);
         protocolVersions.registerUpgrade(0, 0);
 
-        assertNotEq(protocolVersions.scheduleId(CANYON), protocolVersions.scheduleId(ECOTONE));
+        // Both unscheduled: each per-id commitment is the carried-forward bytes32(0) seed.
+        assertEq(protocolVersions.scheduleId(CANYON), protocolVersions.scheduleId(ECOTONE));
+        assertEq(protocolVersions.scheduleId(ECOTONE), bytes32(0));
+
+        // Scheduling CANYON adds its link; the unscheduled ECOTONE carries it forward as the tail.
+        uint64 ts = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+        vm.prank(_owner);
+        protocolVersions.setTimestamp(CANYON, ts);
+
+        assertNotEq(protocolVersions.scheduleId(CANYON), bytes32(0));
+        assertEq(protocolVersions.scheduleId(ECOTONE), protocolVersions.scheduleId(CANYON));
         assertEq(protocolVersions.scheduleId(ECOTONE), protocolVersions.scheduleId());
     }
 

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -548,12 +548,12 @@ contract ProtocolVersions_SetTimestamp_Test is ProtocolVersions_TestInit {
     /// @notice Cross-implementation golden value for the Base mainnet schedule as of Beryl,
     ///         shared with the offchain prover (`schedule_id_matches_mainnet_golden_value` in
     ///         base's `crates/proof/proof/src/schedule_id.rs`). Ids follow the node's
-    ///         CONTRACT_VARIANTS registration order. The genesis-active regolith (timestamp 0),
-    ///         the mainnet pectra_blob_schedule gap, and the unscheduled cobalt tail all
-    ///         contribute no link.
+    ///         CONTRACT_VARIANTS registration order. Genesis-active regolith is registered at the
+    ///         L2 genesis timestamp (0 is the "not scheduled" sentinel); the mainnet
+    ///         pectra_blob_schedule gap and the unscheduled cobalt tail contribute no link.
     function test_scheduleId_matchesMainnetGoldenValue_succeeds() external {
         uint64[13] memory mainnetSchedule = [
-            uint64(0), // regolith: genesis-active, encoded as 0 => no link
+            uint64(1_686_789_347), // regolith: genesis-active, pinned to the L2 genesis timestamp
             1_704_992_401, // canyon
             1_708_560_000, // delta
             1_710_374_401, // ecotone
@@ -574,7 +574,7 @@ contract ProtocolVersions_SetTimestamp_Test is ProtocolVersions_TestInit {
         }
         vm.stopPrank();
 
-        assertEq(protocolVersions.scheduleId(), 0xe7ed922ecb2a9d7704cf21e21c62313eabe90f345c212cad1a4706633dcf4efd);
+        assertEq(protocolVersions.scheduleId(), 0x689503a0192dda23fbb770faf397d562a78ff4ec69df10b596c94c9a437e0f72);
     }
 }
 


### PR DESCRIPTION
## Problem

`scheduleId` previously linked every registered upgrade into the hash chain, including
unscheduled ones (timestamp 0). Registering a new upgrade on L1 — even with no activation
timestamp — therefore moved `scheduleId`. Since the prover derives its schedule ID from the
rollup config rather than the contract, the contract and prover had to update their upgrade
lists in lockstep or their IDs would diverge and proofs would stop verifying (found during
system testing; internal audit has been given a heads-up).

## Fix

`_refreshScheduleId` now skips entries with timestamp 0 (the "not scheduled" sentinel) by
carrying the previous link forward:

- `link[i+1] = keccak256(abi.encode(link[i], i, timestamp_i))` when `timestamp_i != 0`
- `link[i+1] = link[i]` otherwise

`scheduleId` now commits only to *scheduled* activations, so the contract and prover can
register/learn about new upgrades asynchronously. Register-only calls leave `scheduleId`
unchanged; scheduling, delaying, or clearing a timestamp recomputes the affected link and
everything downstream. Any real schedule mismatch still diverges and fails safe (proofs
are rejected, never wrongly accepted).

## Testing

- Register-only leaves `scheduleId` unchanged; mid-registry gaps; clearing a scheduled
  mid-chain entry recomputes downstream links; per-id commitments; event values
- Toy Rust/Solidity cross-golden plus a 13-entry mainnet-shaped golden
  (`test_scheduleId_matchesMainnetGoldenValue_succeeds`), byte-identical to the prover's
  `schedule_id_matches_mainnet_golden_value` in base (`0x689503a0…`, independently derived
  via `cast`)
- Full suite: 1246 passed, 0 failed
- semver-lock regenerated (`version()` kept at 1.0.0 — contract is unreleased)