### PR TITLE
fix(L1): pin AggregateVerifier to a max supported upgrade id

### DIFF
--- a/deploy-config/local.json
+++ b/deploy-config/local.json
@@ -22,6 +22,7 @@
   "multiproofGameType": 621,
   "multiproofGenesisBlockNumber": 0,
   "multiproofIntermediateBlockInterval": 10,
+  "multiproofMaxUpgradeId": 12,
   "multiproofGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000001",
   "nitroEnclaveVerifier": "0x0000000000000000000000000000000000000000",
   "operatorFeeVaultMinimumWithdrawalAmount": "0x8ac7230489e80000",

--- a/deploy-config/mainnet.json
+++ b/deploy-config/mainnet.json
@@ -22,6 +22,7 @@
   "multiproofGenesisBlockNumber": 0,
   "multiproofGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000001",
   "multiproofIntermediateBlockInterval": 30,
+  "multiproofMaxUpgradeId": 12,
   "nitroEnclaveVerifier": "0x0000000000000000000000000000000000000000",
   "operatorFeeVaultMinimumWithdrawalAmount": "0x8ac7230489e80000",
   "operatorFeeVaultRecipient": "0xa3d596EAfaB6B13Ab18D40FaE1A962700C84ADEa",

--- a/deploy-config/sepolia.json
+++ b/deploy-config/sepolia.json
@@ -22,6 +22,7 @@
   "multiproofGenesisBlockNumber": 37223829,
   "multiproofGenesisOutputRoot": "0xbc273d5876d1858ecd5aaf4ce4eaf16c73f0187ca4271b774ed5da7d2254ba79",
   "multiproofIntermediateBlockInterval": 30,
+  "multiproofMaxUpgradeId": 12,
   "nitroEnclaveVerifier": "0x77461a6434fFE3435206B19658F33274f3104e07",
   "operatorFeeVaultMinimumWithdrawalAmount": "0x8ac7230489e80000",
   "operatorFeeVaultRecipient": "0xfd1D2e729aE8eEe2E146c033bf4400fE75284301",

--- a/interfaces/L1/proofs/IAggregateVerifier.sol
+++ b/interfaces/L1/proofs/IAggregateVerifier.sol
@@ -25,6 +25,7 @@ interface IAggregateVerifier is IDisputeGame {
     function ZK_AGGREGATE_HASH() external view returns (bytes32);
     function CONFIG_HASH() external view returns (bytes32);
     function PROTOCOL_VERSIONS() external view returns (IProtocolVersions);
+    function MAX_UPGRADE_ID() external view returns (uint256);
     function L2_CHAIN_ID() external view returns (uint256);
     function BLOCK_INTERVAL() external view returns (uint256);
     function INTERMEDIATE_BLOCK_INTERVAL() external view returns (uint256);

--- a/scripts/deploy/DeployConfig.s.sol
+++ b/scripts/deploy/DeployConfig.s.sol
@@ -52,6 +52,7 @@ contract DeployConfig is Script {
     uint256 public multiproofGameType;
     uint256 public multiproofGenesisBlockNumber;
     uint256 public multiproofIntermediateBlockInterval;
+    uint256 public multiproofMaxUpgradeId;
     uint256 public operatorFeeVaultMinimumWithdrawalAmount;
     uint256 public operatorFeeVaultWithdrawalNetwork;
     uint256 public proofMaturityDelaySeconds;
@@ -104,6 +105,8 @@ contract DeployConfig is Script {
         multiproofGameType = _json.readUintOr("$.multiproofGameType", 621);
         multiproofGenesisBlockNumber = _json.readUintOr("$.multiproofGenesisBlockNumber", 0);
         multiproofIntermediateBlockInterval = _json.readUintOr("$.multiproofIntermediateBlockInterval", 10);
+        // Mandatory: must match the highest upgrade id in the prover image (BaseUpgrade::CONTRACT_VARIANTS).
+        multiproofMaxUpgradeId = _json.readUint("$.multiproofMaxUpgradeId");
         operatorFeeVaultMinimumWithdrawalAmount = _json.readUint("$.operatorFeeVaultMinimumWithdrawalAmount");
         operatorFeeVaultWithdrawalNetwork = _json.readUint("$.operatorFeeVaultWithdrawalNetwork");
         proofMaturityDelaySeconds = _json.readUintOr("$.proofMaturityDelaySeconds", 0);

--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -80,6 +80,7 @@ contract SystemDeploy is Script {
         address nitroEnclaveVerifier;
         uint256 multiproofBlockInterval;
         uint256 multiproofIntermediateBlockInterval;
+        uint256 multiproofMaxUpgradeId;
         ISP1Verifier sp1Verifier;
         address teeProposer;
         address teeChallenger;
@@ -128,6 +129,7 @@ contract SystemDeploy is Script {
         uint256 l2ChainId;
         uint256 multiproofBlockInterval;
         uint256 multiproofIntermediateBlockInterval;
+        uint256 multiproofMaxUpgradeId;
         IProtocolVersions protocolVersions;
     }
 
@@ -267,6 +269,7 @@ contract SystemDeploy is Script {
             nitroEnclaveVerifier: cfg.nitroEnclaveVerifier(),
             multiproofBlockInterval: cfg.multiproofBlockInterval(),
             multiproofIntermediateBlockInterval: cfg.multiproofIntermediateBlockInterval(),
+            multiproofMaxUpgradeId: cfg.multiproofMaxUpgradeId(),
             sp1Verifier: ISP1Verifier(cfg.sp1Verifier()),
             teeProposer: cfg.teeProposer(),
             teeChallenger: cfg.teeChallenger(),
@@ -1013,6 +1016,14 @@ contract SystemDeploy is Script {
         vm.broadcast(msg.sender);
         output_.zkVerifier = IVerifier(address(new ZKVerifier(_input.sp1Verifier, _output.anchorStateRegistryProxy)));
 
+        // Seed unscheduled upgrades through multiproofMaxUpgradeId so the AggregateVerifier
+        // constructor check passes; governance schedules activations later.
+        uint256 registered = _output.protocolVersionsProxy.getSchedule().length;
+        for (uint256 i = registered; i <= _input.multiproofMaxUpgradeId; i++) {
+            vm.broadcast(msg.sender);
+            _output.protocolVersionsProxy.registerUpgrade(0, 0);
+        }
+
         output_.aggregateVerifier = _newAggregateVerifier(
             AggregateVerifierInput({
                 multiproofGameType: gameType,
@@ -1027,6 +1038,7 @@ contract SystemDeploy is Script {
                 l2ChainId: _opChainInput.l2ChainId,
                 multiproofBlockInterval: _input.multiproofBlockInterval,
                 multiproofIntermediateBlockInterval: _input.multiproofIntermediateBlockInterval,
+                multiproofMaxUpgradeId: _input.multiproofMaxUpgradeId,
                 protocolVersions: _output.protocolVersionsProxy
             })
         );
@@ -1057,7 +1069,9 @@ contract SystemDeploy is Script {
                     _input.l2ChainId,
                     _input.multiproofBlockInterval,
                     _input.multiproofIntermediateBlockInterval,
-                    _input.protocolVersions
+                    AggregateVerifier.ScheduleConfig({
+                        protocolVersions: _input.protocolVersions, maxUpgradeId: _input.multiproofMaxUpgradeId
+                    })
                 )
             )
         );

--- a/scripts/multiproof/DeployDevBase.s.sol
+++ b/scripts/multiproof/DeployDevBase.s.sol
@@ -113,6 +113,13 @@ abstract contract DeployDevBase is Script {
         );
         protocolVersionsProxy.changeAdmin(address(proxyAdmin));
 
+        // Seed unscheduled upgrades through multiproofMaxUpgradeId so the AggregateVerifier
+        // constructor check passes; requires finalSystemOwner to be the broadcasting deployer.
+        uint256 maxUpgradeId = cfg.multiproofMaxUpgradeId();
+        for (uint256 i = 0; i <= maxUpgradeId; i++) {
+            IProtocolVersions(address(protocolVersionsProxy)).registerUpgrade(0, 0);
+        }
+
         aggregateVerifier = address(
             new AggregateVerifier(
                 gameType,
@@ -126,7 +133,9 @@ abstract contract DeployDevBase is Script {
                 cfg.l2ChainId(),
                 _blockInterval(),
                 _intermediateBlockInterval(),
-                IProtocolVersions(address(protocolVersionsProxy))
+                AggregateVerifier.ScheduleConfig({
+                    protocolVersions: IProtocolVersions(address(protocolVersionsProxy)), maxUpgradeId: maxUpgradeId
+                })
             )
         );
 

--- a/snapshots/abi/AggregateVerifier.json
+++ b/snapshots/abi/AggregateVerifier.json
@@ -69,9 +69,21 @@
         "type": "uint256"
       },
       {
-        "internalType": "contract IProtocolVersions",
-        "name": "protocolVersions",
-        "type": "address"
+        "components": [
+          {
+            "internalType": "contract IProtocolVersions",
+            "name": "protocolVersions",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxUpgradeId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct AggregateVerifier.ScheduleConfig",
+        "name": "scheduleConfig",
+        "type": "tuple"
       }
     ],
     "stateMutability": "nonpayable",
@@ -197,6 +209,19 @@
   {
     "inputs": [],
     "name": "L2_CHAIN_ID",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_UPGRADE_ID",
     "outputs": [
       {
         "internalType": "uint256",

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -28,8 +28,8 @@
     "sourceCodeHash": "0x780ff372493ba9010bc0d13100ac896f2bf75730a9b17d4bb63aaf694dc3c634"
   },
   "src/L1/proofs/AggregateVerifier.sol:AggregateVerifier": {
-    "initCodeHash": "0x6f3c53245830b9c72c8199695e93959d5ed3b0cb8352e5b50b3dfa28183ac787",
-    "sourceCodeHash": "0x1f2e2b07ebc4359fa31ea7400ace9bab0e4f6099d8ff3ff7b6a2b14cccfb89ca"
+    "initCodeHash": "0x9a61bcf893e3d2f1b9f8972675b97a60a4fcc7b5e791a478b2d45beebdc26b0f",
+    "sourceCodeHash": "0x68cc1b0b9d6c470b265507d15305305978b8c9dc79d091bb9d18278e32697e76"
   },
   "src/L1/proofs/AnchorStateRegistry.sol:AnchorStateRegistry": {
     "initCodeHash": "0x6f3afd2d0ef97a82ca3111976322b99343a270e54cd4a405028f2f29c75f7fb1",

--- a/src/L1/proofs/AggregateVerifier.sol
+++ b/src/L1/proofs/AggregateVerifier.sol
@@ -45,6 +45,12 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
         bytes32 aggregateHash;
     }
 
+    /// @notice The ProtocolVersions registry and the highest upgrade id the prover image supports.
+    struct ScheduleConfig {
+        IProtocolVersions protocolVersions;
+        uint256 maxUpgradeId;
+    }
+
     ////////////////////////////////////////////////////////////////
     //                         Constants                          //
     ////////////////////////////////////////////////////////////////
@@ -117,6 +123,11 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
     /// @notice The ProtocolVersions upgrade schedule contract.
     IProtocolVersions public immutable PROTOCOL_VERSIONS;
 
+    /// @notice The highest ProtocolVersions upgrade id the prover image supports. Games pin the
+    ///         schedule commitment at this id, so later registrations cannot affect this game type.
+    /// @dev    Governance must retire this game type before an upgrade beyond the pin activates.
+    uint256 public immutable MAX_UPGRADE_ID;
+
     ////////////////////////////////////////////////////////////////
     //                         State Vars                         //
     ////////////////////////////////////////////////////////////////
@@ -166,9 +177,8 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
     /// @notice The number of proofs provided.
     uint8 public proofCount;
 
-    /// @notice The ProtocolVersions scheduleId snapshotted at game initialization.
-    /// @dev Pinned once at init; every proof in this game commits to this value, binding it to the
-    ///      upgrade schedule in effect when the game was created.
+    /// @notice The ProtocolVersions schedule commitment through MAX_UPGRADE_ID, pinned at game
+    ///         initialization. Every proof in this game commits to this value.
     bytes32 public scheduleId;
 
     ////////////////////////////////////////////////////////////////
@@ -268,7 +278,7 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
     /// @param l2ChainId The chain ID of the L2 network.
     /// @param blockInterval The block interval.
     /// @param intermediateBlockInterval The intermediate block interval.
-    /// @param protocolVersions The ProtocolVersions upgrade schedule contract.
+    /// @param scheduleConfig The ProtocolVersions registry and the pinned max upgrade id.
     constructor(
         GameType gameType_,
         IAnchorStateRegistry anchorStateRegistry_,
@@ -281,7 +291,7 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
         uint256 l2ChainId,
         uint256 blockInterval,
         uint256 intermediateBlockInterval,
-        IProtocolVersions protocolVersions
+        ScheduleConfig memory scheduleConfig
     ) {
         // Block interval and intermediate block interval must be positive and divisible.
         if (blockInterval == 0 || intermediateBlockInterval == 0 || blockInterval % intermediateBlockInterval != 0) {
@@ -302,7 +312,11 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
         L2_CHAIN_ID = l2ChainId;
         BLOCK_INTERVAL = blockInterval;
         INTERMEDIATE_BLOCK_INTERVAL = intermediateBlockInterval;
-        PROTOCOL_VERSIONS = protocolVersions;
+        PROTOCOL_VERSIONS = scheduleConfig.protocolVersions;
+        MAX_UPGRADE_ID = scheduleConfig.maxUpgradeId;
+
+        // Reverts if the registry has not yet registered upgrade `maxUpgradeId`.
+        scheduleConfig.protocolVersions.scheduleId(scheduleConfig.maxUpgradeId);
 
         INITIALIZE_CALLDATA_SIZE = 0x8E + 0x20 * intermediateOutputRootsCount();
     }
@@ -376,9 +390,9 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
         // Set the game as initialized.
         initialized = true;
 
-        // Snapshot the scheduleId from ProtocolVersions. Every proof in this game commits to this
-        // value, pinning them to the upgrade schedule in effect at the game's creation block.
-        scheduleId = PROTOCOL_VERSIONS.scheduleId();
+        // Pin the schedule commitment through MAX_UPGRADE_ID; every proof in this game commits
+        // to it.
+        scheduleId = PROTOCOL_VERSIONS.scheduleId(MAX_UPGRADE_ID);
 
         // Set the game's starting timestamp.
         createdAt = Timestamp.wrap(uint64(block.timestamp));

--- a/test/L1/OptimismPortal2.t.sol
+++ b/test/L1/OptimismPortal2.t.sol
@@ -79,6 +79,9 @@ abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
         respectedGameType = optimismPortal2.respectedGameType();
         MockVerifier teeVerifier = new MockVerifier(anchorStateRegistry);
         MockVerifier zkVerifier = new MockVerifier(anchorStateRegistry);
+        // The AggregateVerifier constructor requires the pinned upgrade id to be registered.
+        vm.prank(proxyAdminOwner);
+        protocolVersions.registerUpgrade(0, 0);
         AggregateVerifier gameImpl = new AggregateVerifier(
             respectedGameType,
             anchorStateRegistry,
@@ -91,7 +94,9 @@ abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
             deploy.cfg().l2ChainId(),
             100,
             10,
-            protocolVersions
+            AggregateVerifier.ScheduleConfig({
+                protocolVersions: protocolVersions, maxUpgradeId: protocolVersions.getSchedule().length - 1
+            })
         );
         disputeGameFactory.setImplementation(respectedGameType, IDisputeGame(address(gameImpl)));
         disputeGameFactory.setInitBond(respectedGameType, 0);

--- a/test/L1/proofs/AggregateVerifier.t.sol
+++ b/test/L1/proofs/AggregateVerifier.t.sol
@@ -37,15 +37,13 @@ contract AggregateVerifierTest is BaseTest {
         _createAndAssertInitializedGame("zk-proof", AggregateVerifier.ProofType.ZK, ZK_PROVER, address(0), ZK_PROVER);
     }
 
-    /// @notice init snapshots the live scheduleId into storage and pins it: a later schedule change
-    ///         must not alter the game's snapshot (proves it is stored once, not read live).
-    /// @dev Only covers the stored getter. That the snapshot flows into the proof journal is not
-    ///      asserted here — MockVerifier ignores the journal, so journal binding is untestable.
-    function test_initialize_pinsScheduleId_succeeds() public {
-        // Register an upgrade so the schedule commitment is non-trivial (non-zero).
-        protocolVersions.registerUpgrade(uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100, 1);
-        bytes32 pinned = protocolVersions.scheduleId();
+    /// @notice init pins scheduleId(MAX_UPGRADE_ID): upgrades registered beyond the pin affect
+    ///         neither existing snapshots nor what new games snapshot.
+    function test_initialize_pinsScheduleIdAtMaxUpgradeId_succeeds() public {
+        bytes32 pinned = protocolVersions.scheduleId(MAX_UPGRADE_ID);
         assertTrue(pinned != bytes32(0));
+        // Nothing is registered beyond the pin yet, so the pinned link is the live tail.
+        assertEq(protocolVersions.scheduleId(), pinned);
 
         Claim rootClaim = _advanceL2BlockAndClaim();
         bytes memory proof = _generateProof("tee-proof", AggregateVerifier.ProofType.TEE);
@@ -56,10 +54,50 @@ contract AggregateVerifierTest is BaseTest {
 
         assertEq(game.scheduleId(), pinned);
 
-        // Move the live schedule after creation; the game's snapshot must stay pinned.
-        protocolVersions.registerUpgrade(uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 200, 2);
+        // Registering beyond the pin moves the live tail but not the pinned commitment.
+        protocolVersions.registerUpgrade(uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100, 1);
         assertNotEq(protocolVersions.scheduleId(), pinned);
+        assertEq(protocolVersions.scheduleId(MAX_UPGRADE_ID), pinned);
         assertEq(game.scheduleId(), pinned);
+
+        // A game created after the live tail moved still snapshots the pinned commitment.
+        rootClaim = _advanceL2BlockAndClaim();
+        proof = _generateProof("tee-proof-2", AggregateVerifier.ProofType.TEE);
+        AggregateVerifier game2 =
+            _createAggregateVerifierGame(TEE_PROVER, rootClaim, currentL2BlockNumber, address(game), proof);
+        assertEq(game2.scheduleId(), pinned);
+    }
+
+    /// @notice Scheduling an upgrade inside the pinned prefix moves the pinned commitment, so a
+    ///         game created afterwards snapshots the new value.
+    function test_initialize_scheduleChangeWithinPin_movesSnapshot_succeeds() public {
+        bytes32 unscheduled = protocolVersions.scheduleId(MAX_UPGRADE_ID);
+
+        // Schedule the last pinned upgrade; the pinned commitment must move.
+        protocolVersions.setTimestamp(MAX_UPGRADE_ID, uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100);
+        bytes32 scheduled = protocolVersions.scheduleId(MAX_UPGRADE_ID);
+        assertNotEq(scheduled, unscheduled);
+
+        Claim rootClaim = _advanceL2BlockAndClaim();
+        bytes memory proof = _generateProof("tee-proof", AggregateVerifier.ProofType.TEE);
+
+        AggregateVerifier game = _createAggregateVerifierGame(
+            TEE_PROVER, rootClaim, currentL2BlockNumber, address(anchorStateRegistry), proof
+        );
+
+        assertEq(game.scheduleId(), scheduled);
+    }
+
+    /// @notice The constructor stores MAX_UPGRADE_ID and reverts if the registry has not
+    ///         registered up to it.
+    function test_constructor_maxUpgradeId_works() public {
+        AggregateVerifier impl = _deployAggregateVerifierWithMaxUpgradeId(MAX_UPGRADE_ID);
+        assertEq(impl.MAX_UPGRADE_ID(), MAX_UPGRADE_ID);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IProtocolVersions.ProtocolVersions_UnknownUpgrade.selector, MAX_UPGRADE_ID + 1)
+        );
+        _deployAggregateVerifierWithMaxUpgradeId(MAX_UPGRADE_ID + 1);
     }
 
     function testInitializeFailsIfInvalidCallDataSize() public {
@@ -432,6 +470,21 @@ contract AggregateVerifierTest is BaseTest {
         private
         returns (AggregateVerifier)
     {
+        return _deployAggregateVerifier(blockInterval, intermediateBlockInterval, MAX_UPGRADE_ID);
+    }
+
+    function _deployAggregateVerifierWithMaxUpgradeId(uint256 maxUpgradeId) private returns (AggregateVerifier) {
+        return _deployAggregateVerifier(BLOCK_INTERVAL, INTERMEDIATE_BLOCK_INTERVAL, maxUpgradeId);
+    }
+
+    function _deployAggregateVerifier(
+        uint256 blockInterval,
+        uint256 intermediateBlockInterval,
+        uint256 maxUpgradeId
+    )
+        private
+        returns (AggregateVerifier)
+    {
         return new AggregateVerifier(
             GameTypes.AGGREGATE_VERIFIER,
             IAnchorStateRegistry(address(anchorStateRegistry)),
@@ -444,7 +497,9 @@ contract AggregateVerifierTest is BaseTest {
             L2_CHAIN_ID,
             blockInterval,
             intermediateBlockInterval,
-            IProtocolVersions(address(protocolVersions))
+            AggregateVerifier.ScheduleConfig({
+                protocolVersions: IProtocolVersions(address(protocolVersions)), maxUpgradeId: maxUpgradeId
+            })
         );
     }
 }

--- a/test/L1/proofs/BaseTest.t.sol
+++ b/test/L1/proofs/BaseTest.t.sol
@@ -37,6 +37,9 @@ contract BaseTest is Test {
     // Finality delay handled by the AggregateVerifier
     uint256 internal constant FINALITY_DELAY = 0 days;
 
+    // The ProtocolVersions upgrade id the AggregateVerifier under test is pinned to.
+    uint256 internal constant MAX_UPGRADE_ID = 2;
+
     uint256 internal currentL2BlockNumber;
 
     address internal immutable TEE_PROVER = makeAddr("tee-prover");
@@ -110,6 +113,12 @@ contract BaseTest is Test {
         factory.initialize(address(this));
         delayedWETH.initialize(systemConfig);
         protocolVersions.initialize(address(0));
+
+        // Seed unscheduled upgrades through MAX_UPGRADE_ID so the AggregateVerifier constructor
+        // check passes.
+        for (uint256 i = 0; i <= MAX_UPGRADE_ID; i++) {
+            protocolVersions.registerUpgrade(0, 0);
+        }
     }
 
     function _deployAndSetAggregateVerifier() internal {
@@ -125,7 +134,9 @@ contract BaseTest is Test {
             L2_CHAIN_ID,
             BLOCK_INTERVAL,
             INTERMEDIATE_BLOCK_INTERVAL,
-            IProtocolVersions(address(protocolVersions))
+            AggregateVerifier.ScheduleConfig({
+                protocolVersions: IProtocolVersions(address(protocolVersions)), maxUpgradeId: MAX_UPGRADE_ID
+            })
         );
 
         factory.setImplementation(GameTypes.AGGREGATE_VERIFIER, IDisputeGame(address(aggregateVerifierImpl)));

--- a/test/L1/proofs/DisputeGameFactory.t.sol
+++ b/test/L1/proofs/DisputeGameFactory.t.sol
@@ -219,6 +219,9 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
     function test_create_implArgs_succeeds() public {
         MockVerifier teeVerifier = new MockVerifier(anchorStateRegistry);
         MockVerifier zkVerifier = new MockVerifier(anchorStateRegistry);
+        // The AggregateVerifier constructor requires the pinned upgrade id to be registered.
+        vm.prank(proxyAdminOwner);
+        protocolVersions.registerUpgrade(0, 0);
         AggregateVerifier gameImpl = new AggregateVerifier(
             GameTypes.AGGREGATE_VERIFIER,
             anchorStateRegistry,
@@ -231,7 +234,9 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
             L2_CHAIN_ID,
             AGGREGATE_BLOCK_INTERVAL,
             AGGREGATE_INTERMEDIATE_BLOCK_INTERVAL,
-            protocolVersions
+            AggregateVerifier.ScheduleConfig({
+                protocolVersions: protocolVersions, maxUpgradeId: protocolVersions.getSchedule().length - 1
+            })
         );
         _setGame(address(gameImpl), GameTypes.AGGREGATE_VERIFIER);
 

--- a/test/deploy/SystemDeploy.t.sol
+++ b/test/deploy/SystemDeploy.t.sol
@@ -236,6 +236,7 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
             nitroEnclaveVerifier: address(nitroEnclaveVerifier),
             multiproofBlockInterval: 100,
             multiproofIntermediateBlockInterval: 10,
+            multiproofMaxUpgradeId: 12,
             sp1Verifier: ISP1Verifier(address(sp1Verifier)),
             teeProposer: proposer,
             teeChallenger: challenger,


### PR DESCRIPTION
## Problem

The prover image only knows the upgrades compiled into its binary, but
AggregateVerifier snapshotted the live tail `scheduleId()`. Registering a new
upgrade onchain (even unscheduled) moved the tail, so the contract and prover
ScheduleIDs diverged unless both were updated in lockstep.

## Solution

AggregateVerifier now takes a `MAX_UPGRADE_ID` (via a `ScheduleConfig` struct)
and snapshots `scheduleId(MAX_UPGRADE_ID)`, pinning games to the schedule
prefix the prover image supports:

- Registrations beyond the pin no longer affect deployed verifiers, so the
  registry can grow independently of deployed proof contracts.
- Schedule changes *within* the pinned prefix still move the commitment, so
  upgrades the prover must honor still invalidate stale proofs.
- The constructor queries the pinned index, so a deploy reverts if the
  registry has not registered up to it.

Deploy scripts seed the registry with unscheduled (`registerUpgrade(0, 0)`)
entries through `multiproofMaxUpgradeId` so the constructor check passes;
governance schedules activations later. The config value is intentionally
mandatory (no default) since it must match the prover image's
`BaseUpgrade::CONTRACT_VARIANTS`.

## Operational invariant

Nothing onchain ties L2 activation of upgrades beyond a game type's pin to
retiring that game type. Governance must switch the respected game type to an
implementation pinned at or above a new upgrade id before its activation
timestamp passes.