### PR TITLE
feat(L1): add activated ProtocolVersions schedule commitments

### DIFF
--- a/interfaces/L1/IProtocolVersions.sol
+++ b/interfaces/L1/IProtocolVersions.sol
@@ -21,6 +21,11 @@ interface IProtocolVersions is IProxyAdminOwnedBase, ISemver, IReinitializableBa
     error ProtocolVersions_NotIncidentResponder();
     error ProtocolVersions_NotScheduled(uint256 id);
     error ProtocolVersions_DelayMustBeLater(uint64 currentTimestamp, uint64 newTimestamp);
+    error ProtocolVersions_StaticScheduleHole(uint256 id, uint256 nextScheduledId);
+    error ProtocolVersions_TimestampNotAfterPrevious(
+        uint256 id, uint256 previousId, uint64 previousTimestamp, uint64 timestamp
+    );
+    error ProtocolVersions_TimestampNotBeforeNext(uint256 id, uint256 nextId, uint64 timestamp, uint64 nextTimestamp);
     error ProtocolVersions_NotInitialized();
     error ProtocolVersions_InsufficientNotice(uint64 timestamp);
 

--- a/interfaces/L1/IProtocolVersions.sol
+++ b/interfaces/L1/IProtocolVersions.sol
@@ -36,6 +36,7 @@ interface IProtocolVersions is IProxyAdminOwnedBase, ISemver, IReinitializableBa
     function incidentResponder() external view returns (address);
     function scheduleId() external view returns (bytes32);
     function scheduleId(uint256 id) external view returns (bytes32);
+    function activatedScheduleId(uint64 l2Timestamp) external view returns (bytes32);
     function getSchedule() external view returns (uint64[] memory);
 
     function __constructor__() external;

--- a/snapshots/abi/ProtocolVersions.json
+++ b/snapshots/abi/ProtocolVersions.json
@@ -20,6 +20,25 @@
   {
     "inputs": [
       {
+        "internalType": "uint64",
+        "name": "l2Timestamp",
+        "type": "uint64"
+      }
+    ],
+    "name": "activatedScheduleId",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "id",
         "type": "uint256"

--- a/snapshots/abi/ProtocolVersions.json
+++ b/snapshots/abi/ProtocolVersions.json
@@ -423,6 +423,74 @@
         "internalType": "uint256",
         "name": "id",
         "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "nextScheduledId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ProtocolVersions_StaticScheduleHole",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "previousId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "previousTimestamp",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "timestamp",
+        "type": "uint64"
+      }
+    ],
+    "name": "ProtocolVersions_TimestampNotAfterPrevious",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "nextId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "timestamp",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "nextTimestamp",
+        "type": "uint64"
+      }
+    ],
+    "name": "ProtocolVersions_TimestampNotBeforeNext",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
       }
     ],
     "name": "ProtocolVersions_UnknownUpgrade",

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -16,8 +16,8 @@
     "sourceCodeHash": "0x811596e7486cab9ceeeb61405b9ae510d93fcbbdfa11949201a367506c53194a"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
-    "initCodeHash": "0xda7e0fa73757c70a8ec9da7d1ebe5d4ce4ad733eda4ec62b6280ff9ef4a4ab31",
-    "sourceCodeHash": "0x8bf11cc8121c7bd5c89ab7db20a199070a20a6c4d66aafa6df4d2b9709fdbe76"
+    "initCodeHash": "0x876ec89fcdbe230fc10a0dd0c7a54465dfc79640419901f224975ce99dbc342e",
+    "sourceCodeHash": "0xc11f8bafb960a88dabd0a4d60327252cdf2326f784490c64dc45cea072f7b407"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -16,8 +16,8 @@
     "sourceCodeHash": "0x811596e7486cab9ceeeb61405b9ae510d93fcbbdfa11949201a367506c53194a"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
-    "initCodeHash": "0x8ff4bbb0adb8115a3d77e1b706038b0758fdb3a0b183108a794b3cb6200acd83",
-    "sourceCodeHash": "0x2c60b18d14bf9d966e7f852397b02e732f408933261823b42b61633c14613614"
+    "initCodeHash": "0xda7e0fa73757c70a8ec9da7d1ebe5d4ce4ad733eda4ec62b6280ff9ef4a4ab31",
+    "sourceCodeHash": "0x8bf11cc8121c7bd5c89ab7db20a199070a20a6c4d66aafa6df4d2b9709fdbe76"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -87,6 +87,14 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     error ProtocolVersions_NotScheduled(uint256 id);
     /// @notice Thrown when a new timestamp is not sufficiently later than the current one.
     error ProtocolVersions_DelayMustBeLater(uint64 currentTimestamp, uint64 newTimestamp);
+    /// @notice Thrown when scheduling a zero-valued static hole below a scheduled successor.
+    error ProtocolVersions_StaticScheduleHole(uint256 id, uint256 nextScheduledId);
+    /// @notice Thrown when a non-zero timestamp is not greater than the previous scheduled upgrade.
+    error ProtocolVersions_TimestampNotAfterPrevious(
+        uint256 id, uint256 previousId, uint64 previousTimestamp, uint64 timestamp
+    );
+    /// @notice Thrown when a non-zero timestamp is not less than the next scheduled upgrade.
+    error ProtocolVersions_TimestampNotBeforeNext(uint256 id, uint256 nextId, uint64 timestamp, uint64 nextTimestamp);
     /// @notice Thrown when scheduleId is read before initialize has been called.
     error ProtocolVersions_NotInitialized();
     /// @notice Thrown when a non-zero timestamp does not provide at least MIN_NOTICE seconds of notice.
@@ -127,6 +135,7 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         _assertOnlyProxyAdminOwner();
         if (_upgradeScheduleId.length == 0) revert ProtocolVersions_NotInitialized();
         uint256 id = _timestamps.length;
+        _assertTimestampAfterPrevious(id, timestamp);
         _timestamps.push(0);
         // Reserve the link slot for this upgrade at index id + 1.
         _upgradeScheduleId.push();
@@ -172,6 +181,11 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         if (timestamp != 0 && timestamp < uint64(block.timestamp) + MIN_NOTICE) {
             revert ProtocolVersions_InsufficientNotice(timestamp);
         }
+        if (timestamp != 0) {
+            if (current == 0) _assertNoScheduledSuccessor(id);
+            _assertTimestampAfterPrevious(id, timestamp);
+            _assertTimestampBeforeNext(id, timestamp);
+        }
         _writeTimestamp(id, timestamp);
     }
 
@@ -206,6 +220,7 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         // The new timestamp must also provide at least MIN_NOTICE seconds of notice from now.
         uint64 minFloor = uint64(block.timestamp) + MIN_NOTICE;
         if (newTimestamp < minFloor) revert ProtocolVersions_InsufficientNotice(newTimestamp);
+        _assertTimestampBeforeNext(id, newTimestamp);
         _writeTimestamp(id, newTimestamp);
     }
 
@@ -229,8 +244,9 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     /// @notice Returns the schedule commitment through the highest upgrade active at `l2Timestamp`.
     /// @dev Searches from the newest registration downward, returning the cached cumulative link
     ///      for the first active upgrade. Entries above that upgrade are excluded, while every
-    ///      registered entry through it remains committed by the prefix. Zero-valued holes inside
-    ///      the prefix remain part of the positional schedule.
+    ///      registered entry through it remains committed by the prefix. Non-zero timestamps are
+    ///      ordered by id, and zero-valued holes below a scheduled successor cannot be scheduled
+    ///      later, preventing inactive prefix holes from moving activated schedule commitments.
     /// @param l2Timestamp Inclusive L2 activation cutoff.
     /// @return Hash-chain commitment through the highest activated upgrade.
     function activatedScheduleId(uint64 l2Timestamp) external view returns (bytes32) {
@@ -291,6 +307,41 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         }
 
         emit ScheduleIdUpdated(prev);
+    }
+
+    /// @dev Prevents scheduling a zero-valued hole once a later upgrade has a timestamp.
+    function _assertNoScheduledSuccessor(uint256 id) private view {
+        for (uint256 i = id + 1; i < _timestamps.length; i++) {
+            if (_timestamps[i] != 0) revert ProtocolVersions_StaticScheduleHole(id, i);
+        }
+    }
+
+    /// @dev Requires `timestamp` to be greater than the closest lower-id scheduled upgrade.
+    function _assertTimestampAfterPrevious(uint256 id, uint64 timestamp) private view {
+        if (timestamp == 0) return;
+
+        for (uint256 i = id; i > 0; i--) {
+            uint64 previous = _timestamps[i - 1];
+            if (previous != 0) {
+                if (timestamp <= previous) {
+                    revert ProtocolVersions_TimestampNotAfterPrevious(id, i - 1, previous, timestamp);
+                }
+                return;
+            }
+        }
+    }
+
+    /// @dev Requires `timestamp` to be less than the closest higher-id scheduled upgrade.
+    function _assertTimestampBeforeNext(uint256 id, uint64 timestamp) private view {
+        if (timestamp == 0) return;
+
+        for (uint256 i = id + 1; i < _timestamps.length; i++) {
+            uint64 next = _timestamps[i];
+            if (next != 0) {
+                if (timestamp >= next) revert ProtocolVersions_TimestampNotBeforeNext(id, i, timestamp, next);
+                return;
+            }
+        }
     }
 
     /// @dev Reverts if `id` is not a registered upgrade.

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -226,6 +226,24 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         return _upgradeScheduleId[id + 1];
     }
 
+    /// @notice Returns the schedule commitment through the highest upgrade active at `l2Timestamp`.
+    /// @dev Searches from the newest registration downward, returning the cached cumulative link
+    ///      for the first active upgrade. Entries above that upgrade are excluded, while every
+    ///      registered entry through it remains committed by the prefix. Zero-valued holes inside
+    ///      the prefix remain part of the positional schedule.
+    /// @param l2Timestamp Inclusive L2 activation cutoff.
+    /// @return Hash-chain commitment through the highest activated upgrade.
+    function activatedScheduleId(uint64 l2Timestamp) external view returns (bytes32) {
+        if (_upgradeScheduleId.length == 0) revert ProtocolVersions_NotInitialized();
+
+        for (uint256 i = _timestamps.length; i > 0; i--) {
+            uint64 activationTimestamp = _timestamps[i - 1];
+            if (activationTimestamp != 0 && activationTimestamp <= l2Timestamp) return _upgradeScheduleId[i];
+        }
+
+        return _upgradeScheduleId[0];
+    }
+
     /// @notice Returns the activation timestamp for every registered upgrade, ordered by upgrade id
     ///         (0 = not scheduled). The array index equals the upgrade `id`; names are resolved
     ///         offchain, and per-upgrade schedule hashes can be reproduced from these timestamps and

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -185,6 +185,68 @@ contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
         assertEq(protocolVersions.getSchedule()[CANYON], ts);
     }
 
+    /// @notice Tests that a scheduled registration must be after the previous scheduled upgrade.
+    function test_registerUpgrade_timestampAfterPrevious_succeeds() external {
+        uint64 first = uint64(block.timestamp) + 100;
+        uint64 second = first + 1;
+
+        vm.prank(_owner);
+        assertEq(protocolVersions.registerUpgrade(first, 0), CANYON);
+        vm.prank(_owner);
+        assertEq(protocolVersions.registerUpgrade(second, 0), ECOTONE);
+
+        uint64[] memory schedule = protocolVersions.getSchedule();
+        assertEq(schedule[CANYON], first);
+        assertEq(schedule[ECOTONE], second);
+    }
+
+    /// @notice Tests that zero remains the unscheduled/disabled value and is exempt from ordering.
+    function test_registerUpgrade_zeroTimestampAfterScheduledPrevious_succeeds() external {
+        uint64 first = uint64(block.timestamp) + 100;
+
+        vm.prank(_owner);
+        assertEq(protocolVersions.registerUpgrade(first, 0), CANYON);
+        vm.prank(_owner);
+        assertEq(protocolVersions.registerUpgrade(0, 0), ECOTONE);
+
+        uint64[] memory schedule = protocolVersions.getSchedule();
+        assertEq(schedule[CANYON], first);
+        assertEq(schedule[ECOTONE], 0);
+    }
+
+    /// @notice Tests that scheduled registration scans past zero holes to the previous timestamp.
+    function test_registerUpgrade_timestampAfterPreviousSkipsZeroHoles_succeeds() external {
+        uint64 first = uint64(block.timestamp) + 100;
+        uint64 second = first + 1;
+
+        vm.startPrank(_owner);
+        assertEq(protocolVersions.registerUpgrade(first, 0), CANYON);
+        assertEq(protocolVersions.registerUpgrade(0, 0), ECOTONE);
+        assertEq(protocolVersions.registerUpgrade(second, 0), 2);
+        vm.stopPrank();
+
+        uint64[] memory schedule = protocolVersions.getSchedule();
+        assertEq(schedule[CANYON], first);
+        assertEq(schedule[ECOTONE], 0);
+        assertEq(schedule[2], second);
+    }
+
+    /// @notice Tests that registering an out-of-order timestamp reverts.
+    function test_registerUpgrade_timestampNotAfterPrevious_reverts() external {
+        uint64 first = uint64(block.timestamp) + 100;
+
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(first, 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IProtocolVersions.ProtocolVersions_TimestampNotAfterPrevious.selector, ECOTONE, CANYON, first, first
+            )
+        );
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(first, 0);
+    }
+
     /// @notice Tests that a non-zero minProtocolVersion bumps the minimum during registration.
     function test_registerUpgrade_setsMinProtocolVersion_succeeds() external {
         vm.expectEmit(true, false, false, false, address(protocolVersions));
@@ -359,6 +421,82 @@ contract ProtocolVersions_SetTimestamp_Test is ProtocolVersions_TestInit {
         protocolVersions.setTimestamp(CANYON, ts);
     }
 
+    /// @notice Tests that a zero-valued hole below a scheduled successor cannot be scheduled later.
+    function test_setTimestamp_staticScheduleHole_reverts() external {
+        uint64 successor = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 200;
+        uint64 ts = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(0, 0);
+        protocolVersions.registerUpgrade(successor, 0);
+        vm.stopPrank();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IProtocolVersions.ProtocolVersions_StaticScheduleHole.selector, CANYON, ECOTONE)
+        );
+        vm.prank(_owner);
+        protocolVersions.setTimestamp(CANYON, ts);
+    }
+
+    /// @notice Tests that static-hole detection scans past zero holes to the next scheduled upgrade.
+    function test_setTimestamp_staticScheduleHoleSkipsZeroHoles_reverts() external {
+        uint64 successor = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 200;
+        uint64 ts = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(0, 0);
+        protocolVersions.registerUpgrade(0, 0);
+        protocolVersions.registerUpgrade(successor, 0);
+        vm.stopPrank();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IProtocolVersions.ProtocolVersions_StaticScheduleHole.selector, CANYON, uint256(2))
+        );
+        vm.prank(_owner);
+        protocolVersions.setTimestamp(CANYON, ts);
+    }
+
+    /// @notice Tests that `setTimestamp` reverts when the timestamp is not after the previous one.
+    function test_setTimestamp_timestampNotAfterPrevious_reverts() external {
+        uint64 previous = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(previous, 0);
+        protocolVersions.registerUpgrade(0, 0);
+        vm.stopPrank();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IProtocolVersions.ProtocolVersions_TimestampNotAfterPrevious.selector,
+                ECOTONE,
+                CANYON,
+                previous,
+                previous
+            )
+        );
+        vm.prank(_owner);
+        protocolVersions.setTimestamp(ECOTONE, previous);
+    }
+
+    /// @notice Tests that `setTimestamp` reverts when the timestamp is not before the next one.
+    function test_setTimestamp_timestampNotBeforeNext_reverts() external {
+        uint64 current = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+        uint64 next = current + 100;
+
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(current, 0);
+        protocolVersions.registerUpgrade(next, 0);
+        vm.stopPrank();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IProtocolVersions.ProtocolVersions_TimestampNotBeforeNext.selector, CANYON, ECOTONE, next, next
+            )
+        );
+        vm.prank(_owner);
+        protocolVersions.setTimestamp(CANYON, next);
+    }
+
     /// @notice Tests that `setTimestamp` reverts when the upgrade has already activated.
     function test_setTimestamp_afterActivation_reverts() external {
         vm.prank(_owner);
@@ -468,6 +606,26 @@ contract ProtocolVersions_DelayTimestamp_Test is ProtocolVersions_TestInit {
         vm.expectRevert(abi.encodeWithSelector(IProtocolVersions.ProtocolVersions_DelayMustBeLater.selector, ts, ts));
         vm.prank(_incidentResponder);
         protocolVersions.delayTimestamp(CANYON, ts);
+    }
+
+    /// @notice Tests that `delayTimestamp` cannot move an upgrade to or beyond its next scheduled successor.
+    function test_delayTimestamp_timestampNotBeforeNext_reverts() external {
+        uint64 current = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+        uint64 next = current + 100;
+
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(current, 0);
+        protocolVersions.registerUpgrade(next, 0);
+        protocolVersions.setIncidentResponder(_incidentResponder);
+        vm.stopPrank();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IProtocolVersions.ProtocolVersions_TimestampNotBeforeNext.selector, CANYON, ECOTONE, next, next
+            )
+        );
+        vm.prank(_incidentResponder);
+        protocolVersions.delayTimestamp(CANYON, next);
     }
 
     /// @notice Tests that `delayTimestamp` reverts when the upgrade has no scheduled timestamp.
@@ -626,24 +784,24 @@ contract ProtocolVersions_ActivatedScheduleId_Test is ProtocolVersions_TestInit 
     }
 
     /// @notice The commitment includes every registered entry through the highest active upgrade,
-    ///         including an inactive gap below it.
+    ///         including a static zero-valued hole below it.
     function test_activatedScheduleId_commitsPrefixThroughHighestActive_succeeds() external {
         vm.startPrank(_owner);
         protocolVersions.registerUpgrade(10, 0);
-        protocolVersions.registerUpgrade(50, 0);
+        protocolVersions.registerUpgrade(0, 0);
         protocolVersions.registerUpgrade(30, 0);
         vm.stopPrank();
 
         bytes32 link0 = keccak256(abi.encode(bytes32(0), uint256(0), uint64(10)));
-        bytes32 link1 = keccak256(abi.encode(link0, uint256(1), uint64(50)));
+        bytes32 link1 = keccak256(abi.encode(link0, uint256(1), uint64(0)));
         bytes32 link2 = keccak256(abi.encode(link1, uint256(2), uint64(30)));
 
         assertEq(protocolVersions.activatedScheduleId(30), link2);
     }
 
-    /// @notice Appending unscheduled or future upgrades cannot move a historical activated
-    ///         commitment.
-    function test_activatedScheduleId_stableAcrossFutureAppends_succeeds() external {
+    /// @notice Appending unscheduled or future upgrades above the active prefix cannot move the
+    ///         activated commitment selected by that prefix.
+    function test_activatedScheduleId_stableAcrossAppendsAboveActivePrefix_succeeds() external {
         vm.prank(_owner);
         protocolVersions.registerUpgrade(10, 0);
         bytes32 pinned = protocolVersions.activatedScheduleId(10);
@@ -659,7 +817,8 @@ contract ProtocolVersions_ActivatedScheduleId_Test is ProtocolVersions_TestInit 
 
     /// @notice Cross-implementation golden shared with Base's `ScheduleId` tests for the real Base
     ///         mainnet static schedule. The activation cutoff is Beryl, so the commitment contains
-    ///         the prefix through id 11 and excludes the unscheduled Cobalt placeholder at id 12.
+    ///         the prefix through id 11, including the static PectraBlobSchedule hole at id 7, and
+    ///         excludes the unscheduled Cobalt placeholder at id 12.
     function test_activatedScheduleId_matchesBaseMainnetGoldenValue_succeeds() external {
         _registerBaseMainnetStaticSchedule();
 

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -597,3 +597,115 @@ contract ProtocolVersions_Uncategorized_Test is ProtocolVersions_TestInit {
         protocolVersions.scheduleId(0);
     }
 }
+
+/// @title ProtocolVersions_ActivatedScheduleId_Test
+/// @notice Tests for commitments to the upgrades active at a supplied L2 timestamp.
+contract ProtocolVersions_ActivatedScheduleId_Test is ProtocolVersions_TestInit {
+    /// @notice An empty registry and a registry containing only inactive entries both commit to the
+    ///         zero hash-chain seed.
+    function test_activatedScheduleId_noneActivated_returnsSeed() external {
+        assertEq(protocolVersions.activatedScheduleId(uint64(block.timestamp)), bytes32(0));
+
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(0, 0);
+        protocolVersions.registerUpgrade(uint64(block.timestamp + 100), 0);
+        vm.stopPrank();
+
+        assertEq(protocolVersions.activatedScheduleId(uint64(block.timestamp)), bytes32(0));
+    }
+
+    /// @notice Activation is inclusive at the supplied L2 timestamp.
+    function test_activatedScheduleId_boundaryInclusive_succeeds() external {
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(100, 0);
+
+        assertEq(protocolVersions.activatedScheduleId(99), bytes32(0));
+        assertEq(
+            protocolVersions.activatedScheduleId(100), keccak256(abi.encode(bytes32(0), uint256(CANYON), uint64(100)))
+        );
+    }
+
+    /// @notice The commitment includes every registered entry through the highest active upgrade,
+    ///         including an inactive gap below it.
+    function test_activatedScheduleId_commitsPrefixThroughHighestActive_succeeds() external {
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(10, 0);
+        protocolVersions.registerUpgrade(50, 0);
+        protocolVersions.registerUpgrade(30, 0);
+        vm.stopPrank();
+
+        bytes32 link0 = keccak256(abi.encode(bytes32(0), uint256(0), uint64(10)));
+        bytes32 link1 = keccak256(abi.encode(link0, uint256(1), uint64(50)));
+        bytes32 link2 = keccak256(abi.encode(link1, uint256(2), uint64(30)));
+
+        assertEq(protocolVersions.activatedScheduleId(30), link2);
+    }
+
+    /// @notice Appending unscheduled or future upgrades cannot move a historical activated
+    ///         commitment.
+    function test_activatedScheduleId_stableAcrossFutureAppends_succeeds() external {
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(10, 0);
+        bytes32 pinned = protocolVersions.activatedScheduleId(10);
+
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(0, 0);
+        protocolVersions.registerUpgrade(100, 0);
+        vm.stopPrank();
+
+        assertEq(protocolVersions.activatedScheduleId(10), pinned);
+        assertNotEq(protocolVersions.scheduleId(), pinned);
+    }
+
+    /// @notice Cross-implementation golden shared with Base's `ScheduleId` tests for the real Base
+    ///         mainnet static schedule. The activation cutoff is Beryl, so the commitment contains
+    ///         the prefix through id 11 and excludes the unscheduled Cobalt placeholder at id 12.
+    function test_activatedScheduleId_matchesBaseMainnetGoldenValue_succeeds() external {
+        _registerBaseMainnetStaticSchedule();
+
+        assertEq(
+            protocolVersions.activatedScheduleId(BASE_MAINNET_BERYL_TIMESTAMP),
+            0xadd4aa9bd3532969035a9543c16b8c7d71298e15836f0ac731fdd3eea552c6e2
+        );
+    }
+
+    /// @notice Cross-implementation golden for the full real Base mainnet contract-backed schedule.
+    ///         The live tail commits to all 13 entries, including PectraBlobSchedule and Cobalt as
+    ///         unscheduled zero-timestamp entries.
+    function test_scheduleId_matchesBaseMainnetFullScheduleGoldenValue_succeeds() external {
+        _registerBaseMainnetStaticSchedule();
+
+        assertEq(protocolVersions.scheduleId(), 0x5ee41f186b0a439783060587cfbb942f6f1d94ecc76376c9782580c943ff2b6d);
+        assertEq(protocolVersions.scheduleId(12), protocolVersions.scheduleId());
+    }
+
+    uint64 private constant BASE_MAINNET_GENESIS_TIMESTAMP = 1_686_789_347;
+    uint64 private constant BASE_MAINNET_CANYON_TIMESTAMP = 1_704_992_401;
+    uint64 private constant BASE_MAINNET_DELTA_TIMESTAMP = 1_708_560_000;
+    uint64 private constant BASE_MAINNET_ECOTONE_TIMESTAMP = 1_710_374_401;
+    uint64 private constant BASE_MAINNET_FJORD_TIMESTAMP = 1_720_627_201;
+    uint64 private constant BASE_MAINNET_GRANITE_TIMESTAMP = 1_726_070_401;
+    uint64 private constant BASE_MAINNET_HOLOCENE_TIMESTAMP = 1_736_445_601;
+    uint64 private constant BASE_MAINNET_ISTHMUS_TIMESTAMP = 1_746_806_401;
+    uint64 private constant BASE_MAINNET_JOVIAN_TIMESTAMP = 1_764_691_201;
+    uint64 private constant BASE_MAINNET_AZUL_TIMESTAMP = 1_779_991_200;
+    uint64 private constant BASE_MAINNET_BERYL_TIMESTAMP = 1_782_410_400;
+
+    function _registerBaseMainnetStaticSchedule() private {
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(BASE_MAINNET_GENESIS_TIMESTAMP, 0);
+        protocolVersions.registerUpgrade(BASE_MAINNET_CANYON_TIMESTAMP, 0);
+        protocolVersions.registerUpgrade(BASE_MAINNET_DELTA_TIMESTAMP, 0);
+        protocolVersions.registerUpgrade(BASE_MAINNET_ECOTONE_TIMESTAMP, 0);
+        protocolVersions.registerUpgrade(BASE_MAINNET_FJORD_TIMESTAMP, 0);
+        protocolVersions.registerUpgrade(BASE_MAINNET_GRANITE_TIMESTAMP, 0);
+        protocolVersions.registerUpgrade(BASE_MAINNET_HOLOCENE_TIMESTAMP, 0);
+        protocolVersions.registerUpgrade(0, 0); // PectraBlobSchedule is unscheduled on Base mainnet.
+        protocolVersions.registerUpgrade(BASE_MAINNET_ISTHMUS_TIMESTAMP, 0);
+        protocolVersions.registerUpgrade(BASE_MAINNET_JOVIAN_TIMESTAMP, 0);
+        protocolVersions.registerUpgrade(BASE_MAINNET_AZUL_TIMESTAMP, 0);
+        protocolVersions.registerUpgrade(BASE_MAINNET_BERYL_TIMESTAMP, 0);
+        protocolVersions.registerUpgrade(0, 0); // Cobalt is unscheduled on Base mainnet.
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
  ## Summary

  Adds ProtocolVersions.activatedScheduleId(uint64 l2Timestamp), which returns the schedule commitment
  through the highest registered upgrade active at a supplied L2 timestamp.

  This lets proof games bind to the upgrade schedule active at the claimed L2 block instead of the live
  schedule tail, so later appends above the active prefix do not change the commitment selected for that
  L2 timestamp.

  Also adds write-side guards around schedule updates:

  - nonzero timestamps must remain ordered by upgrade id, skipping zero-valued holes
  - zero-valued holes below a scheduled successor cannot later be scheduled
  - delaying an upgrade cannot move it to or beyond the next scheduled successor

  These guards preserve the positional-prefix commitment model while preventing inactive holes inside an
  activated prefix from moving activated schedule commitments.

  ## Details

  - Adds activatedScheduleId(uint64 l2Timestamp) to ProtocolVersions and its interface.
  - Adds real Base mainnet golden tests shared with the Base prover-side schedule-id implementation:
  - Preserves the positional schedule model: zero-valued holes inside an active prefix remain committed by
    the prefix.

  ## Testing
`just test`