### PR TITLE
fix(L1): sanity-check protocol version fits in 128 bits

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -16,8 +16,8 @@
     "sourceCodeHash": "0x811596e7486cab9ceeeb61405b9ae510d93fcbbdfa11949201a367506c53194a"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
-    "initCodeHash": "0x876ec89fcdbe230fc10a0dd0c7a54465dfc79640419901f224975ce99dbc342e",
-    "sourceCodeHash": "0x28dfc19b119f42ccbecd3bd2f53c60a2b9784ef8b2a6d9bd62cd966daadd7ae7"
+    "initCodeHash": "0x9ac15db1262966ac7b800c41c3254152410e8eadb661643c5e61ca325bcde5a9",
+    "sourceCodeHash": "0xa84a07676cf99b60d1d12d4d4f97c21fe5869e035ed129ff6363cec77dd3a9c2"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -132,7 +132,7 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     ///      scheduleId chain with the new upgrade's link.
     /// @param timestamp Unix activation timestamp, or 0 to leave the upgrade unscheduled.
     /// @param minProtocolVersion New minimum protocol version to set at registration, or 0 to leave
-    ///                  the current minimum unchanged.
+    ///                  the current minimum unchanged. Must fit in 128 bits if non-zero.
     /// @return The ascending id assigned to the newly registered upgrade.
     function registerUpgrade(uint64 timestamp, uint256 minProtocolVersion) external returns (uint256) {
         _assertOnlyProxyAdminOwner();
@@ -151,7 +151,10 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
             _writeTimestamp(id, timestamp);
         }
         // Optionally bump the global minimum protocol version in the same call (0 = leave unchanged).
-        if (minProtocolVersion != 0) _writeMinimumProtocolVersion(minProtocolVersion);
+        if (minProtocolVersion != 0) {
+            if (minProtocolVersion > type(uint128).max) revert ProtocolVersions_InvalidProtocolVersion();
+            _writeMinimumProtocolVersion(minProtocolVersion);
+        }
         return id;
     }
 
@@ -159,10 +162,11 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     /// @dev Informational signal for offchain clients; independent of the upgrade schedule and NOT
     ///      part of the scheduleId commitment, so it can be updated at any time without shifting any
     ///      proof binding.
-    /// @param protocolVersion Packed semver uint256 (must be non-zero).
+    /// @param protocolVersion Packed semver uint256 (must be non-zero and fit in 128 bits).
     function setMinimumProtocolVersion(uint256 protocolVersion) external {
         _assertOnlyProxyAdminOwner();
         if (protocolVersion == 0) revert ProtocolVersions_InvalidProtocolVersion();
+        if (protocolVersion > type(uint128).max) revert ProtocolVersions_InvalidProtocolVersion();
         _writeMinimumProtocolVersion(protocolVersion);
     }
 

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -267,6 +267,20 @@ contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
 
         assertEq(protocolVersions.minimumProtocolVersion(), 7);
     }
+
+    /// @notice Tests that a minProtocolVersion exceeding 128 bits reverts.
+    function test_registerUpgrade_minProtocolVersionTooLarge_reverts() external {
+        vm.expectRevert(IProtocolVersions.ProtocolVersions_InvalidProtocolVersion.selector);
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(0, uint256(type(uint128).max) + 1);
+    }
+
+    /// @notice Tests that the maximum representable minProtocolVersion (128 bits set) succeeds.
+    function test_registerUpgrade_minProtocolVersionMaxValue_succeeds() external {
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(0, type(uint128).max);
+        assertEq(protocolVersions.minimumProtocolVersion(), type(uint128).max);
+    }
 }
 
 /// @title ProtocolVersions_SetMinimumProtocolVersion_Test
@@ -300,6 +314,20 @@ contract ProtocolVersions_SetMinimumProtocolVersion_Test is ProtocolVersions_Tes
         vm.expectRevert(IProtocolVersions.ProtocolVersions_InvalidProtocolVersion.selector);
         vm.prank(_owner);
         protocolVersions.setMinimumProtocolVersion(0);
+    }
+
+    /// @notice Tests that a protocol version exceeding 128 bits reverts.
+    function test_setMinimumProtocolVersion_tooLarge_reverts() external {
+        vm.expectRevert(IProtocolVersions.ProtocolVersions_InvalidProtocolVersion.selector);
+        vm.prank(_owner);
+        protocolVersions.setMinimumProtocolVersion(uint256(type(uint128).max) + 1);
+    }
+
+    /// @notice Tests that the maximum representable protocol version (128 bits set) succeeds.
+    function test_setMinimumProtocolVersion_maxValue_succeeds() external {
+        vm.prank(_owner);
+        protocolVersions.setMinimumProtocolVersion(type(uint128).max);
+        assertEq(protocolVersions.minimumProtocolVersion(), type(uint128).max);
     }
 
     /// @notice Tests that only the owner can call `setMinimumProtocolVersion`.


### PR DESCRIPTION
## Summary
- `registerUpgrade` and `setMinimumProtocolVersion` accepted an unbounded `uint256` protocol version, but the offchain client only packs a protocol version into the lower 128 bits.
- Both now revert with `ProtocolVersions_InvalidProtocolVersion` if the provided value exceeds `type(uint128).max`, preventing a value that would silently lose its upper bits offchain.

## Test plan
- [x] Added `test_setMinimumProtocolVersion_tooLarge_reverts` and `test_setMinimumProtocolVersion_maxValue_succeeds`
- [x] Added `test_registerUpgrade_minProtocolVersionTooLarge_reverts`
- [x] `forge test` — full suite passes
- [x] `just semver-lock` — refreshed `ProtocolVersions` hash in `snapshots/semver-lock.json`