### PR TITLE
docs(L1): correct ProtocolVersions owner references and document uncapped iteration

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -17,7 +17,7 @@
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
     "initCodeHash": "0x876ec89fcdbe230fc10a0dd0c7a54465dfc79640419901f224975ce99dbc342e",
-    "sourceCodeHash": "0x64182ee3dae6b4dcf107907722d6312474e5428947c69083bd7f2cac85de7092"
+    "sourceCodeHash": "0x28dfc19b119f42ccbecd3bd2f53c60a2b9784ef8b2a6d9bd62cd966daadd7ae7"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -17,7 +17,7 @@
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
     "initCodeHash": "0x876ec89fcdbe230fc10a0dd0c7a54465dfc79640419901f224975ce99dbc342e",
-    "sourceCodeHash": "0xc11f8bafb960a88dabd0a4d60327252cdf2326f784490c64dc45cea072f7b407"
+    "sourceCodeHash": "0x64182ee3dae6b4dcf107907722d6312474e5428947c69083bd7f2cac85de7092"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -43,6 +43,9 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
 
     /// @notice Activation timestamp for each registered upgrade, indexed by upgrade id (0 = not scheduled).
     ///         An upgrade id is registered iff it is a valid index into this array.
+    /// @dev Every loop in this contract iterates this array. Its length is deliberately uncapped: it only
+    ///      grows via owner-gated `registerUpgrade`, one entry per hardfork, so the unbounded iteration
+    ///      poses no gas exhaustion risk.
     uint64[] private _timestamps;
 
     /// @notice Hash chain links. Element 0 is the seed (`bytes32(0)`), pushed in `initialize`;

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -11,7 +11,7 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 
 /// @custom:proxied true
 /// @title ProtocolVersions
-/// @notice Security Council-controlled upgrade activation schedule contract.
+/// @notice Upgrade activation schedule contract, controlled by the ProxyAdmin owner (2-of-2 multisig).
 /// @dev Maintains an ordered registry of upgrades and their L2 activation timestamps.
 ///      Each upgrade is identified by an ascending numeric `id` equal to its registration
 ///      index (0, 1, 2, ...). Human-readable names are intentionally kept offchain: a client
@@ -123,7 +123,7 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     }
 
     /// @notice Registers a new upgrade, assigning it the next ascending id, optionally scheduling its
-    ///         activation and bumping the minimum protocol version in the same call. Owner only.
+    ///         activation and bumping the minimum protocol version in the same call. ProxyAdmin owner only.
     /// @dev Pass `timestamp` 0 to register without scheduling (schedule later via `setTimestamp`), or
     ///      a non-zero value to register and schedule at once. Either way registration extends the
     ///      scheduleId chain with the new upgrade's link.
@@ -152,7 +152,7 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         return id;
     }
 
-    /// @notice Sets the minimum protocol version clients must run. Owner (Security Council) only.
+    /// @notice Sets the minimum protocol version clients must run. ProxyAdmin owner only.
     /// @dev Informational signal for offchain clients; independent of the upgrade schedule and NOT
     ///      part of the scheduleId commitment, so it can be updated at any time without shifting any
     ///      proof binding.
@@ -189,7 +189,7 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         _writeTimestamp(id, timestamp);
     }
 
-    /// @notice Appoints, replaces, or clears (set to zero) the incidentResponder role. Owner only.
+    /// @notice Appoints, replaces, or clears (set to zero) the incidentResponder role. ProxyAdmin owner only.
     /// @param newIncidentResponder New incidentResponder address, or address(0) to revoke the role.
     function setIncidentResponder(address newIncidentResponder) external {
         _assertOnlyProxyAdminOwner();


### PR DESCRIPTION
## Summary
Comment-only changes to `ProtocolVersions`. No behavior change — `initCodeHash` is
unchanged; only `sourceCodeHash` moves.

**Owner references.** The NatSpec described the contract as Security Council-controlled,
but access control is enforced via `_assertOnlyProxyAdminOwner`, so the controlling party
is the ProxyAdmin owner — in production the 2-of-2 multisig. The contract-level `@notice`
now names that role, and the three owner-gated functions (`registerUpgrade`,
`setMinimumProtocolVersion`, `setIncidentResponder`) read `ProxyAdmin owner only` instead
of a bare `Owner only`.

**Uncapped iteration.** All five loops in this contract iterate `_timestamps`, so each one
reads as unbounded. Rather than repeat the rationale per loop, it is documented once at the
array declaration: the array only grows via owner-gated `registerUpgrade`, one entry per
hardfork, so the unbounded iteration poses no gas exhaustion risk.

## Test plan
- [x] `forge test` — full suite passes
- [x] `forge fmt --check` clean on the changed file
- [x] `just semver-lock` — refreshed `ProtocolVersions` `sourceCodeHash`; `initCodeHash`
      identical, confirming the change is comment-only
