### PR TITLE
fix(protocol-versions): allow equal activation timestamps

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -16,8 +16,8 @@
     "sourceCodeHash": "0x811596e7486cab9ceeeb61405b9ae510d93fcbbdfa11949201a367506c53194a"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
-    "initCodeHash": "0x9ac15db1262966ac7b800c41c3254152410e8eadb661643c5e61ca325bcde5a9",
-    "sourceCodeHash": "0xa84a07676cf99b60d1d12d4d4f97c21fe5869e035ed129ff6363cec77dd3a9c2"
+    "initCodeHash": "0xd762af325410baea14f927f4292ef9ee2bb13b52d72034d6d129eb1e518dfedd",
+    "sourceCodeHash": "0x5a06b3ae5f442f3e3f3dba6f78b9c3e3ce5abd7218ccb13d477c067f61187dc5"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -92,7 +92,7 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     error ProtocolVersions_DelayMustBeLater(uint64 currentTimestamp, uint64 newTimestamp);
     /// @notice Thrown when scheduling a zero-valued static hole below a scheduled successor.
     error ProtocolVersions_StaticScheduleHole(uint256 id, uint256 nextScheduledId);
-    /// @notice Thrown when a non-zero timestamp is not greater than the previous scheduled upgrade.
+    /// @notice Thrown when a non-zero timestamp is less than the previous scheduled upgrade.
     error ProtocolVersions_TimestampNotAfterPrevious(
         uint256 id, uint256 previousId, uint64 previousTimestamp, uint64 timestamp
     );
@@ -323,14 +323,14 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         }
     }
 
-    /// @dev Requires `timestamp` to be greater than the closest lower-id scheduled upgrade.
+    /// @dev Requires `timestamp` to be greater than or equal to the closest lower-id scheduled upgrade.
     function _assertTimestampAfterPrevious(uint256 id, uint64 timestamp) private view {
         if (timestamp == 0) return;
 
         for (uint256 i = id; i > 0; i--) {
             uint64 previous = _timestamps[i - 1];
             if (previous != 0) {
-                if (timestamp <= previous) {
+                if (timestamp < previous) {
                     revert ProtocolVersions_TimestampNotAfterPrevious(id, i - 1, previous, timestamp);
                 }
                 return;

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -185,10 +185,10 @@ contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
         assertEq(protocolVersions.getSchedule()[CANYON], ts);
     }
 
-    /// @notice Tests that a scheduled registration must be after the previous scheduled upgrade.
-    function test_registerUpgrade_timestampAfterPrevious_succeeds() external {
+    /// @notice Tests that a scheduled registration may share the previous scheduled upgrade's timestamp.
+    function test_registerUpgrade_timestampEqualToPrevious_succeeds() external {
         uint64 first = uint64(block.timestamp) + 100;
-        uint64 second = first + 1;
+        uint64 second = first;
 
         vm.prank(_owner);
         assertEq(protocolVersions.registerUpgrade(first, 0), CANYON);
@@ -231,7 +231,7 @@ contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
         assertEq(schedule[2], second);
     }
 
-    /// @notice Tests that registering an out-of-order timestamp reverts.
+    /// @notice Tests that registering a timestamp before the previous scheduled upgrade reverts.
     function test_registerUpgrade_timestampNotAfterPrevious_reverts() external {
         uint64 first = uint64(block.timestamp) + 100;
 
@@ -240,11 +240,11 @@ contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IProtocolVersions.ProtocolVersions_TimestampNotAfterPrevious.selector, ECOTONE, CANYON, first, first
+                IProtocolVersions.ProtocolVersions_TimestampNotAfterPrevious.selector, ECOTONE, CANYON, first, first - 1
             )
         );
         vm.prank(_owner);
-        protocolVersions.registerUpgrade(first, 0);
+        protocolVersions.registerUpgrade(first - 1, 0);
     }
 
     /// @notice Tests that a non-zero minProtocolVersion bumps the minimum during registration.
@@ -484,7 +484,22 @@ contract ProtocolVersions_SetTimestamp_Test is ProtocolVersions_TestInit {
         protocolVersions.setTimestamp(CANYON, ts);
     }
 
-    /// @notice Tests that `setTimestamp` reverts when the timestamp is not after the previous one.
+    /// @notice Tests that `setTimestamp` may share the previous scheduled upgrade's timestamp.
+    function test_setTimestamp_timestampEqualToPrevious_succeeds() external {
+        uint64 previous = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(previous, 0);
+        protocolVersions.registerUpgrade(0, 0);
+        protocolVersions.setTimestamp(ECOTONE, previous);
+        vm.stopPrank();
+
+        uint64[] memory schedule = protocolVersions.getSchedule();
+        assertEq(schedule[CANYON], previous);
+        assertEq(schedule[ECOTONE], previous);
+    }
+
+    /// @notice Tests that `setTimestamp` reverts when the timestamp is before the previous one.
     function test_setTimestamp_timestampNotAfterPrevious_reverts() external {
         uint64 previous = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
 
@@ -499,11 +514,11 @@ contract ProtocolVersions_SetTimestamp_Test is ProtocolVersions_TestInit {
                 ECOTONE,
                 CANYON,
                 previous,
-                previous
+                previous - 1
             )
         );
         vm.prank(_owner);
-        protocolVersions.setTimestamp(ECOTONE, previous);
+        protocolVersions.setTimestamp(ECOTONE, previous - 1);
     }
 
     /// @notice Tests that `setTimestamp` reverts when the timestamp is not before the next one.


### PR DESCRIPTION
 ## Summary

  Loosens `ProtocolVersions` timestamp ordering from strictly increasing to non-
  decreasing for previous scheduled upgrades.

  ## Motivation

  This supports testnets/devnets that activate multiple upgrades at genesis with the
  same timestamp.

  ## Behavior

  - `0` remains the unscheduled value and is skipped by ordering checks.
  - Non-zero timestamps must be `>=` the closest previous scheduled timestamp.
  - Timestamps before the previous scheduled upgrade still revert.
  - The existing strict check against the next scheduled upgrade is unchanged.