### PR TITLE
fix(SuperchainConfig): extend() must check paused() to prevent re-activating expired pauses

### DIFF
--- a/src/L1/SuperchainConfig.sol
+++ b/src/L1/SuperchainConfig.sol
@@ -120,7 +120,7 @@ contract SuperchainConfig is ProxyAdminOwnedBase, ISemver {
         _assertOnlyGuardian();
 
         // Cannot extend the pause if not already paused.
-        if (pauseTimestamps[_identifier] == 0) {
+        if (!paused(_identifier)) {
             revert SuperchainConfig_NotAlreadyPaused(_identifier);
         }
 

--- a/test/L1/SuperchainConfig.t.sol
+++ b/test/L1/SuperchainConfig.t.sol
@@ -221,6 +221,19 @@ contract SuperchainConfig_Extend_Test is SuperchainConfig_TestInit {
         );
         superchainConfig.extend(_identifier);
     }
+
+    /// @notice Tests that `extend` reverts when the pause has already expired.
+    /// @param _identifier The identifier to test.
+    function testFuzz_extend_expiredPause_reverts(address _identifier) external {
+        _pauseAsGuardian(_identifier);
+        vm.warp(block.timestamp + PAUSE_EXPIRY + 1);
+        assertFalse(superchainConfig.paused(_identifier));
+        vm.prank(superchainConfig.guardian());
+        vm.expectRevert(
+            abi.encodeWithSelector(ISuperchainConfig.SuperchainConfig_NotAlreadyPaused.selector, _identifier)
+        );
+        superchainConfig.extend(_identifier);
+    }
 }
 
 /// @title SuperchainConfig_Pausable_Test


### PR DESCRIPTION
Fixes #391

## Problem

`extend()` checked `pauseTimestamps[_identifier] == 0` to detect "not paused", but this only catches the never-paused case. An **expired** pause has `pauseTimestamps != 0` while `paused()` returns `false`, so it silently passed the check and got its timestamp reset — effectively re-pausing the system without the required `unpause() → pause()` cycle.

This bypasses the Stage 1 Decentralization requirement explicitly documented in `pause()`:
> *"this check intentionally prevents re-pausing even after a pause has expired... This is a Stage 1 Decentralization requirement"*

## Fix

```diff
- if (pauseTimestamps[_identifier] == 0) {
+ if (!paused(_identifier)) {
```

`paused()` returns `false` for both never-paused (timestamp == 0) and expired (timestamp != 0 but past PAUSE_EXPIRY), making it the correct guard.

## Missing test (to be added)

```solidity
function test_extend_expiredPause_reverts() external {
    _pauseAsGuardian(address(this));
    vm.warp(block.timestamp + PAUSE_EXPIRY + 1);
    assertFalse(superchainConfig.paused(address(this)));

    vm.prank(superchainConfig.guardian());
    vm.expectRevert(
        abi.encodeWithSelector(
            ISuperchainConfig.SuperchainConfig_NotAlreadyPaused.selector,
            address(this)
        )
    );
    superchainConfig.extend(address(this));
}
```