### PR TITLE
feat(L1): deploy hinted nitro validator stack

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -19,6 +19,7 @@ optimizer_runs = 999999
 # entire build directory.
 additional_compiler_profiles = [
   { name = "dispute", optimizer_runs = 5000 },
+  { name = "nitro-validator", optimizer = true, optimizer_runs = 10000 },
 ]
 compilation_restrictions = [
   { paths = "src/L1/proofs/DisputeGameFactory.sol", optimizer_runs = 5000 },
@@ -31,6 +32,8 @@ compilation_restrictions = [
   { paths = "src/universal/Proxy.sol", optimizer_runs = 5000 },
   { paths = "src/L2/OptimismMintableERC721.sol", optimizer_runs = 5000 },
   { paths = "src/L2/OptimismMintableERC721Factory.sol", optimizer_runs = 5000 },
+  { paths = "scripts/multiproof/DeployNitroValidatorStack.s.sol", version = "=0.8.26", optimizer_runs = 10000 },
+  { paths = "test/deploy/DeployNitroValidatorStack.t.sol", version = "=0.8.26", optimizer_runs = 10000 },
 ]
 
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
@@ -135,6 +138,7 @@ depth = 8
 # See the info in the "DEFAULT" profile to understand this section.
 additional_compiler_profiles = [
   { name = "dispute", optimizer_runs = 0 },
+  { name = "nitro-validator", optimizer = true, optimizer_runs = 10000 },
 ]
 compilation_restrictions = [
   { paths = "src/L1/proofs/DisputeGameFactory.sol", optimizer_runs = 0 },
@@ -147,4 +151,6 @@ compilation_restrictions = [
   { paths = "src/universal/Proxy.sol", optimizer_runs = 0 },
   { paths = "src/L2/OptimismMintableERC721.sol", optimizer_runs = 0 },
   { paths = "src/L2/OptimismMintableERC721Factory.sol", optimizer_runs = 0 },
+  { paths = "scripts/multiproof/DeployNitroValidatorStack.s.sol", version = "=0.8.26", optimizer_runs = 10000 },
+  { paths = "test/deploy/DeployNitroValidatorStack.t.sol", version = "=0.8.26", optimizer_runs = 10000 },
 ]

--- a/justfile
+++ b/justfile
@@ -189,6 +189,11 @@ genesis:
 deploy:
   ./scripts/deploy/deploy.sh
 
+# Deploys the hinted Nitro validator stack. Requires RPC and signer arguments.
+deploy-nitro-validator *ARGS:
+  forge script scripts/multiproof/DeployNitroValidatorStack.s.sol:DeployNitroValidatorStack \
+    --sig "run(address,address)" {{ARGS}} --broadcast
+
 
 ########################################################
 #                       SNAPSHOTS                      #

--- a/justfile
+++ b/justfile
@@ -189,12 +189,6 @@ genesis:
 deploy:
   ./scripts/deploy/deploy.sh
 
-# Deploys the hinted Nitro validator stack. Requires RPC and signer arguments.
-deploy-nitro-validator *ARGS:
-  forge script scripts/multiproof/DeployNitroValidatorStack.s.sol:DeployNitroValidatorStack \
-    --sig "run(address,address)" {{ARGS}} --broadcast
-
-
 ########################################################
 #                       SNAPSHOTS                      #
 ########################################################

--- a/scripts/multiproof/DeployNitroValidatorStack.s.sol
+++ b/scripts/multiproof/DeployNitroValidatorStack.s.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
+import { console2 as console } from "lib/forge-std/src/console2.sol";
 import { Script } from "lib/forge-std/src/Script.sol";
 import { VmSafe } from "lib/forge-std/src/Vm.sol";
-import { console2 as console } from "lib/forge-std/src/console2.sol";
 
 import { CertManager } from "lib/nitro-validator/src/CertManager.sol";
 import { NitroValidator } from "lib/nitro-validator/src/NitroValidator.sol";
@@ -38,8 +38,10 @@ contract DeployNitroValidatorStack is Script {
         Deployment memory deployment;
         vm.startBroadcast();
         deployment.p384Verifier = new P384Verifier();
-        deployment.certManager = new CertManager(deployment.p384Verifier, _owner, _revoker);
-        deployment.nitroValidator = new NitroValidator(deployment.certManager, deployment.p384Verifier);
+        deployment.certManager =
+            new CertManager({ p384Verifier_: deployment.p384Verifier, initialOwner: _owner, initialRevoker: _revoker });
+        deployment.nitroValidator =
+            new NitroValidator({ _certManager: deployment.certManager, _p384Verifier: deployment.p384Verifier });
         vm.stopBroadcast();
 
         console.log("P384Verifier:", address(deployment.p384Verifier));

--- a/scripts/multiproof/DeployNitroValidatorStack.s.sol
+++ b/scripts/multiproof/DeployNitroValidatorStack.s.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { Script } from "lib/forge-std/src/Script.sol";
+import { VmSafe } from "lib/forge-std/src/Vm.sol";
+import { console2 as console } from "lib/forge-std/src/console2.sol";
+
+import { CertManager } from "lib/nitro-validator/src/CertManager.sol";
+import { NitroValidator } from "lib/nitro-validator/src/NitroValidator.sol";
+import { P384Verifier } from "lib/nitro-validator/src/P384Verifier.sol";
+
+/// @title DeployNitroValidatorStack
+/// @notice Deploys the hinted Nitro attestation validator stack.
+contract DeployNitroValidatorStack is Script {
+    /// @notice Addresses of a deployed hinted Nitro validator stack.
+    struct Deployment {
+        P384Verifier p384Verifier;
+        CertManager certManager;
+        NitroValidator nitroValidator;
+    }
+
+    /// @notice Thrown when the initial CertManager owner is the zero address.
+    error InvalidOwner();
+
+    /// @notice Thrown when the initial CertManager revoker is the zero address.
+    error InvalidRevoker();
+
+    /// @notice Deploys P384Verifier, CertManager, and NitroValidator in dependency order.
+    ///
+    /// @param _owner Initial CertManager owner.
+    /// @param _revoker Initial CertManager revoker.
+    ///
+    /// @return deployment Addresses of the deployed Nitro validator stack.
+    function run(address _owner, address _revoker) public returns (Deployment memory) {
+        if (_owner == address(0)) revert InvalidOwner();
+        if (_revoker == address(0)) revert InvalidRevoker();
+
+        Deployment memory deployment;
+        vm.startBroadcast();
+        deployment.p384Verifier = new P384Verifier();
+        deployment.certManager = new CertManager(deployment.p384Verifier, _owner, _revoker);
+        deployment.nitroValidator = new NitroValidator(deployment.certManager, deployment.p384Verifier);
+        vm.stopBroadcast();
+
+        console.log("P384Verifier:", address(deployment.p384Verifier));
+        console.log("CertManager:", address(deployment.certManager));
+        console.log("NitroValidator:", address(deployment.nitroValidator));
+
+        if (!vm.isContext(VmSafe.ForgeContext.TestGroup)) {
+            string memory key = "deployment";
+            vm.serializeAddress(key, "P384Verifier", address(deployment.p384Verifier));
+            vm.serializeAddress(key, "CertManager", address(deployment.certManager));
+            string memory json = vm.serializeAddress(key, "NitroValidator", address(deployment.nitroValidator));
+            vm.writeJson(json, string.concat("deployments/", vm.toString(block.chainid), "-nitro-validator.json"));
+        }
+
+        return deployment;
+    }
+}

--- a/test/deploy/DeployNitroValidatorStack.t.sol
+++ b/test/deploy/DeployNitroValidatorStack.t.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { Test } from "lib/forge-std/src/Test.sol";
+
+import { DeployNitroValidatorStack } from "scripts/multiproof/DeployNitroValidatorStack.s.sol";
+
+contract DeployNitroValidatorStackTest is Test {
+    DeployNitroValidatorStack internal deployer;
+
+    function setUp() public {
+        deployer = new DeployNitroValidatorStack();
+    }
+
+    function test_run_succeeds() public {
+        address owner = makeAddr("owner");
+        address revoker = makeAddr("revoker");
+
+        DeployNitroValidatorStack.Deployment memory deployment = deployer.run(owner, revoker);
+
+        assertNotEq(address(deployment.p384Verifier), address(0));
+        assertNotEq(address(deployment.certManager), address(0));
+        assertNotEq(address(deployment.nitroValidator), address(0));
+        assertLe(address(deployment.p384Verifier).code.length, 24_576);
+        assertLe(address(deployment.certManager).code.length, 24_576);
+        assertLe(address(deployment.nitroValidator).code.length, 24_576);
+
+        assertEq(address(deployment.certManager.p384Verifier()), address(deployment.p384Verifier));
+        assertEq(deployment.certManager.owner(), owner);
+        assertEq(deployment.certManager.revoker(), revoker);
+        assertGt(deployment.certManager.verified(deployment.certManager.ROOT_CA_CERT_HASH()).length, 0);
+        assertEq(address(deployment.nitroValidator.certManager()), address(deployment.certManager));
+        assertEq(address(deployment.nitroValidator.p384Verifier()), address(deployment.p384Verifier));
+    }
+
+    function test_run_zeroOwner_reverts() public {
+        vm.expectRevert(DeployNitroValidatorStack.InvalidOwner.selector);
+        deployer.run(address(0), makeAddr("revoker"));
+    }
+
+    function test_run_zeroRevoker_reverts() public {
+        vm.expectRevert(DeployNitroValidatorStack.InvalidRevoker.selector);
+        deployer.run(makeAddr("owner"), address(0));
+    }
+}

--- a/test/deploy/DeployNitroValidatorStack.t.sol
+++ b/test/deploy/DeployNitroValidatorStack.t.sol
@@ -21,9 +21,6 @@ contract DeployNitroValidatorStackTest is Test {
         assertNotEq(address(deployment.p384Verifier), address(0));
         assertNotEq(address(deployment.certManager), address(0));
         assertNotEq(address(deployment.nitroValidator), address(0));
-        assertLe(address(deployment.p384Verifier).code.length, 24_576);
-        assertLe(address(deployment.certManager).code.length, 24_576);
-        assertLe(address(deployment.nitroValidator).code.length, 24_576);
 
         assertEq(address(deployment.certManager.p384Verifier()), address(deployment.p384Verifier));
         assertEq(deployment.certManager.owner(), owner);

--- a/test/deploy/SystemDeploy.t.sol
+++ b/test/deploy/SystemDeploy.t.sol
@@ -329,6 +329,11 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
             "nitro proof submitter"
         );
         assertEq(
+            address(teeProverRegistry.NITRO_VERIFIER()),
+            _input.implementationsInput.nitroEnclaveVerifier,
+            "tee registry nitro verifier"
+        );
+        assertEq(
             address(teeProverRegistry.DISPUTE_GAME_FACTORY()),
             address(_output.opChain.disputeGameFactoryProxy),
             "tee registry dgf"


### PR DESCRIPTION
## Summary
- add a standalone Solidity 0.8.26 deployment script for `P384Verifier -> CertManager -> NitroValidator`
- use named direct `lib/...` imports and scoped 10,000-run compiler restrictions matching upstream
- require explicit nonzero CertManager owner and revoker arguments
- test deployment wiring, root-cache initialization, role assignment, and EIP-170 runtime sizes

## Behavior
The script is opt-in and does not change the standard system deployment. `TEEProverRegistry` continues to use the configured legacy `NitroEnclaveVerifier` until C3.

## Testing
- clean `just test --match-path test/deploy/DeployNitroValidatorStack.t.sol` (3 passed)
- targeted script size build: `CertManager` 23,784 bytes with 792 bytes of EIP-170 margin
- CI-equivalent lint, build, snapshots, and full test workflow (1,268 passed, 1 skipped)
- `just snapshots` with no snapshot diff

## Stack
- depends on #394
- base branch is `feat/nitro-validator-c1`, not `main`