### PR TITLE
fix(multiproof): add anchorGame getter to MockAnchorStateRegistry

### DIFF
--- a/scripts/multiproof/mocks/MockAnchorStateRegistry.sol
+++ b/scripts/multiproof/mocks/MockAnchorStateRegistry.sol
@@ -17,6 +17,7 @@ contract MockAnchorStateRegistry {
     uint256 public anchorL2BlockNumber;
     address public factory;
     GameType public respectedGameType;
+    IDisputeGame public anchorGame;
 
     function initialize(
         address newFactory,
@@ -79,5 +80,7 @@ contract MockAnchorStateRegistry {
         return _game.resolvedAt().raw() != 0;
     }
 
-    function setAnchorState(IDisputeGame) external { }
+    function setAnchorState(IDisputeGame _game) external {
+        anchorGame = _game;
+    }
 }


### PR DESCRIPTION
# fix(multiproof): add `anchorGame` getter to `MockAnchorStateRegistry`

## Motivation

The offchain proposer's anchor recovery reads two things from the registry in one snapshot: `getAnchorRoot()` and `anchorGame()` (pinned to the same block via a joined call). The real `AnchorStateRegistry` exposes `anchorGame`, but the dev mock did not — so on `DeployDevNoNitro` deployments the `anchorGame()` staticcall reverted with empty data and the proposer failed at anchor-snapshot fetch, before it could propose anything.

## Changes

- Add `IDisputeGame public anchorGame;` to `MockAnchorStateRegistry`, giving the mock the same `anchorGame()` view the real registry has.
- `setAnchorState(IDisputeGame _game)` now records the game, so after the first anchor update the getter returns the finalized game that became the anchor.

## Semantics

- On a fresh deployment `anchorGame()` returns `address(0)`. This matches the real registry's pre-first-anchor-update state, and the offchain proposer/challenger explicitly handle the zero address as "genesis-anchored, no parent game".
- After `setAnchorState(game)`, `anchorGame()` returns that game, which anchor recovery uses as the parent for the next proposal.

## Scope / limitations

This mock's `setAnchorState(IDisputeGame)` intentionally stays minimal: it records the anchor game but does not copy the game's root/block into `anchorRoot`/`anchorL2BlockNumber` the way the real registry does. Dev flows that need the root updated use the explicit `setAnchorState(Hash,uint256)` overload.

## Testing

Exercised end-to-end by the base/base `anvil-no-nitro` dev stack (`just anvil-no-nitro up`), which deploys `DeployDevNoNitro.s.sol` against Anvil and runs the offchain proposer's anchor recovery against this mock; recovery previously failed at the snapshot call and now proceeds.

