### PR TITLE
feat(L3): add attested withdrawal redemption

### DIFF
--- a/interfaces/L1/IOptimismPortal2.sol
+++ b/interfaces/L1/IOptimismPortal2.sol
@@ -38,7 +38,7 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     error OptimismPortal_InvalidAttestedWithdrawalSignature();
     error OptimismPortal_InvalidAttestedWithdrawalSigner(address signer);
     error OptimismPortal_TEEProverRegistryAlreadySet();
-    error OptimismPortal_AttestedWithdrawalTransferFailed();
+    error OptimismPortal_AttestedWithdrawalCallFailed();
     error OutOfGas();
     error UnexpectedList();
     error UnexpectedString();
@@ -49,7 +49,12 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to);
     event WithdrawalProvenExtension1(bytes32 indexed withdrawalHash, address indexed proofSubmitter);
     event AttestedWithdrawalRedeemed(
-        bytes32 indexed authHash, address indexed recipient, uint256 amount, uint256 nonce, address signer
+        bytes32 indexed authHash,
+        address indexed recipient,
+        uint256 amount,
+        uint256 nonce,
+        address signer,
+        bytes data
     );
 
     receive() external payable;
@@ -117,7 +122,11 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
         view
         returns (IDisputeGame disputeGameProxy, uint64 timestamp);
     function redeemAttestedWithdrawal(
-        address _recipient, uint256 _amount, uint256 _nonce, bytes calldata _sig
+        address _recipient,
+        uint256 _amount,
+        uint256 _nonce,
+        bytes calldata _data,
+        bytes calldata _sig
     ) external;
     function respectedGameType() external view returns (GameType);
     function respectedGameTypeUpdatedAt() external view returns (uint64);

--- a/interfaces/L1/IOptimismPortal2.sol
+++ b/interfaces/L1/IOptimismPortal2.sol
@@ -9,6 +9,7 @@ import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IAnchorStateRegistry } from "interfaces/L1/proofs/IAnchorStateRegistry.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
+import { ITEEProverRegistry } from "interfaces/L1/proofs/tee/ITEEProverRegistry.sol";
 
 interface IOptimismPortal2 is IProxyAdminOwnedBase {
     error ContentLengthMismatch();
@@ -33,6 +34,11 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     error OptimismPortal_ProofNotOldEnough();
     error OptimismPortal_Unproven();
     error OptimismPortal_ImmediateFinalityNotEnabled();
+    error OptimismPortal_AttestedWithdrawalAlreadyRedeemed();
+    error OptimismPortal_InvalidAttestedWithdrawalSignature();
+    error OptimismPortal_InvalidAttestedWithdrawalSigner(address signer);
+    error OptimismPortal_TEEProverRegistryAlreadySet();
+    error OptimismPortal_AttestedWithdrawalTransferFailed();
     error OutOfGas();
     error UnexpectedList();
     error UnexpectedString();
@@ -42,10 +48,14 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     event WithdrawalFinalized(bytes32 indexed withdrawalHash, bool success);
     event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to);
     event WithdrawalProvenExtension1(bytes32 indexed withdrawalHash, address indexed proofSubmitter);
+    event AttestedWithdrawalRedeemed(
+        bytes32 indexed authHash, address indexed recipient, uint256 amount, uint256 nonce, address signer
+    );
 
     receive() external payable;
 
     function anchorStateRegistry() external view returns (IAnchorStateRegistry);
+    function attestRedeemed(bytes32) external view returns (bool);
     function checkWithdrawal(bytes32 _withdrawalHash, address _proofSubmitter) external view;
     function depositTransaction(
         address _to,
@@ -106,9 +116,14 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
         external
         view
         returns (IDisputeGame disputeGameProxy, uint64 timestamp);
+    function redeemAttestedWithdrawal(
+        address _recipient, uint256 _amount, uint256 _nonce, bytes calldata _sig
+    ) external;
     function respectedGameType() external view returns (GameType);
     function respectedGameTypeUpdatedAt() external view returns (uint64);
+    function setTEEProverRegistry(ITEEProverRegistry _teeProverRegistry) external;
     function systemConfig() external view returns (ISystemConfig);
+    function teeProverRegistry() external view returns (ITEEProverRegistry);
     function version() external pure returns (string memory);
 
     function __constructor__(uint256 _proofMaturityDelaySeconds) external;

--- a/interfaces/L2/IL2ToL1MessagePasser.sol
+++ b/interfaces/L2/IL2ToL1MessagePasser.sol
@@ -12,10 +12,16 @@ interface IL2ToL1MessagePasser {
         bytes32 withdrawalHash
     );
     event WithdrawerBalanceBurnt(uint256 indexed amount);
+    event AttestedWithdrawalInitiated(
+        bytes32 indexed authHash, address indexed recipient, address indexed token, uint256 amount, uint256 nonce
+    );
 
     receive() external payable;
 
     function MESSAGE_VERSION() external view returns (uint16);
+    function attestNonce() external view returns (uint256);
+    function attestedWithdraw(address _recipient) external payable;
+    function attestedWithdrawals(bytes32) external view returns (bool);
     function burn() external;
     function initiateWithdrawal(address _target, uint256 _gasLimit, bytes memory _data) external payable;
     function messageNonce() external view returns (uint256);

--- a/interfaces/L2/IL2ToL1MessagePasser.sol
+++ b/interfaces/L2/IL2ToL1MessagePasser.sol
@@ -13,14 +13,19 @@ interface IL2ToL1MessagePasser {
     );
     event WithdrawerBalanceBurnt(uint256 indexed amount);
     event AttestedWithdrawalInitiated(
-        bytes32 indexed authHash, address indexed recipient, address indexed token, uint256 amount, uint256 nonce
+        bytes32 indexed authHash,
+        address indexed recipient,
+        address indexed token,
+        uint256 amount,
+        uint256 nonce,
+        bytes data
     );
 
     receive() external payable;
 
     function MESSAGE_VERSION() external view returns (uint16);
     function attestNonce() external view returns (uint256);
-    function attestedWithdraw(address _recipient) external payable;
+    function attestedWithdraw(address _recipient, bytes calldata _data) external payable;
     function attestedWithdrawals(bytes32) external view returns (bool);
     function burn() external;
     function initiateWithdrawal(address _target, uint256 _gasLimit, bytes memory _data) external payable;

--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -654,6 +654,9 @@ contract SystemDeploy is Script {
             output_.zkVerifier = multiproof.zkVerifier;
             output_.nitroEnclaveVerifier = INitroEnclaveVerifier(_implementationsInput.nitroEnclaveVerifier);
             output_.sp1Verifier = _implementationsInput.sp1Verifier;
+
+            vm.broadcast(msg.sender);
+            output_.optimismPortalProxy.setTEEProverRegistry(output_.teeProverRegistryProxy);
         }
 
         _transferOwnership(address(output_.disputeGameFactoryProxy), _input.roles.opChainProxyAdminOwner);
@@ -783,7 +786,7 @@ contract SystemDeploy is Script {
 
         IDisputeGameFactory disputeGameFactory = IDisputeGameFactory(_systemConfigProxy.disputeGameFactory());
         _upgradeTo(proxyAdmin, address(disputeGameFactory), _impls.disputeGameFactoryImpl);
-        _upgradeMultiproofContracts(_systemConfigProxy, disputeGameFactory, _impls);
+        _upgradeMultiproofContracts(_systemConfigProxy, optimismPortal, disputeGameFactory, _impls);
 
         ISystemConfig.Addresses memory opChainAddrs = _systemConfigProxy.getAddresses();
         _upgradeTo(proxyAdmin, opChainAddrs.l1CrossDomainMessenger, _impls.l1CrossDomainMessengerImpl);
@@ -802,6 +805,7 @@ contract SystemDeploy is Script {
 
     function _upgradeMultiproofContracts(
         ISystemConfig _systemConfigProxy,
+        IOptimismPortal _optimismPortal,
         IDisputeGameFactory _disputeGameFactory,
         Types.Implementations memory _impls
     )
@@ -810,10 +814,15 @@ contract SystemDeploy is Script {
         IDisputeGame currentGameImpl = _disputeGameFactory.gameImpls(GameTypes.AGGREGATE_VERIFIER);
         if (address(currentGameImpl) == address(0)) return;
 
+        AggregateVerifier currentAggregateVerifier = AggregateVerifier(address(currentGameImpl));
+        TEEProverRegistry teeProverRegistry =
+            TEEVerifier(address(currentAggregateVerifier.TEE_VERIFIER())).TEE_PROVER_REGISTRY();
+        if (address(_optimismPortal.teeProverRegistry()) == address(0)) {
+            vm.broadcast(msg.sender);
+            _optimismPortal.setTEEProverRegistry(ITEEProverRegistry(address(teeProverRegistry)));
+        }
+
         if (_impls.teeProverRegistryImpl != address(0)) {
-            AggregateVerifier currentAggregateVerifier = AggregateVerifier(address(currentGameImpl));
-            TEEProverRegistry teeProverRegistry =
-                TEEVerifier(address(currentAggregateVerifier.TEE_VERIFIER())).TEE_PROVER_REGISTRY();
             _upgradeTo(_systemConfigProxy.proxyAdmin(), address(teeProverRegistry), _impls.teeProverRegistryImpl);
         }
 

--- a/snapshots/abi/L2ToL1MessagePasser.json
+++ b/snapshots/abi/L2ToL1MessagePasser.json
@@ -18,6 +18,51 @@
   },
   {
     "inputs": [],
+    "name": "attestNonce",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_recipient",
+        "type": "address"
+      }
+    ],
+    "name": "attestedWithdraw",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "attestedWithdrawals",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "burn",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -90,6 +135,43 @@
     ],
     "stateMutability": "pure",
     "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "authHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      }
+    ],
+    "name": "AttestedWithdrawalInitiated",
+    "type": "event"
   },
   {
     "anonymous": false,

--- a/snapshots/abi/L2ToL1MessagePasser.json
+++ b/snapshots/abi/L2ToL1MessagePasser.json
@@ -35,6 +35,11 @@
         "internalType": "address",
         "name": "_recipient",
         "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
       }
     ],
     "name": "attestedWithdraw",
@@ -168,6 +173,12 @@
         "internalType": "uint256",
         "name": "nonce",
         "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
       }
     ],
     "name": "AttestedWithdrawalInitiated",

--- a/snapshots/abi/OptimismPortal2.json
+++ b/snapshots/abi/OptimismPortal2.json
@@ -31,6 +31,25 @@
     "inputs": [
       {
         "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "attestRedeemed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
         "name": "_withdrawalHash",
         "type": "bytes32"
       },
@@ -656,6 +675,34 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_nonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_sig",
+        "type": "bytes"
+      }
+    ],
+    "name": "redeemAttestedWithdrawal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "respectedGameType",
     "outputs": [
@@ -679,6 +726,19 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract ITEEProverRegistry",
+        "name": "_teeProverRegistry",
+        "type": "address"
+      }
+    ],
+    "name": "setTEEProverRegistry",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -709,6 +769,19 @@
   },
   {
     "inputs": [],
+    "name": "teeProverRegistry",
+    "outputs": [
+      {
+        "internalType": "contract ITEEProverRegistry",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "version",
     "outputs": [
       {
@@ -719,6 +792,43 @@
     ],
     "stateMutability": "pure",
     "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "authHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "signer",
+        "type": "address"
+      }
+    ],
+    "name": "AttestedWithdrawalRedeemed",
+    "type": "event"
   },
   {
     "anonymous": false,
@@ -854,6 +964,16 @@
   },
   {
     "inputs": [],
+    "name": "OptimismPortal_AttestedWithdrawalAlreadyRedeemed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OptimismPortal_AttestedWithdrawalTransferFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OptimismPortal_BadTarget",
     "type": "error"
   },
@@ -885,6 +1005,22 @@
   {
     "inputs": [],
     "name": "OptimismPortal_ImproperDisputeGame",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OptimismPortal_InvalidAttestedWithdrawalSignature",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "signer",
+        "type": "address"
+      }
+    ],
+    "name": "OptimismPortal_InvalidAttestedWithdrawalSigner",
     "type": "error"
   },
   {
@@ -925,6 +1061,11 @@
   {
     "inputs": [],
     "name": "OptimismPortal_ProofNotOldEnough",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OptimismPortal_TEEProverRegistryAlreadySet",
     "type": "error"
   },
   {

--- a/snapshots/abi/OptimismPortal2.json
+++ b/snapshots/abi/OptimismPortal2.json
@@ -693,6 +693,11 @@
       },
       {
         "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
         "name": "_sig",
         "type": "bytes"
       }
@@ -825,6 +830,12 @@
         "internalType": "address",
         "name": "signer",
         "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
       }
     ],
     "name": "AttestedWithdrawalRedeemed",
@@ -969,7 +980,7 @@
   },
   {
     "inputs": [],
-    "name": "OptimismPortal_AttestedWithdrawalTransferFailed",
+    "name": "OptimismPortal_AttestedWithdrawalCallFailed",
     "type": "error"
   },
   {

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -12,8 +12,8 @@
     "sourceCodeHash": "0xd9f576a79e97bc541b3d7a2ee928f34223edaaecb074eeb9e6e2ecee857ce6a0"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0x3223d48d63cc9e4a6796f2eb343c82c88c1add5289fa66ab72fa2fa4d83d0790",
-    "sourceCodeHash": "0x15cef97e2598ac2ed83fd8662c2f31e61a33e89d9f618b97fdeaa142cf6f9262"
+    "initCodeHash": "0xbaf65d6803fd81d273377af2729c9a092aa814d41b67f50c48b7687fa46b9180",
+    "sourceCodeHash": "0xd8554d8c723eacd9d4e96ffa43f8f4e072150456e366247c3ec223ce9810ca69"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
     "initCodeHash": "0xd762af325410baea14f927f4292ef9ee2bb13b52d72034d6d129eb1e518dfedd",
@@ -96,8 +96,8 @@
     "sourceCodeHash": "0xc53a2f1fc472b15aa2891d48845b078ef12fdae869a4b74bef19b19d9d20ed5f"
   },
   "src/L2/L2ToL1MessagePasser.sol:L2ToL1MessagePasser": {
-    "initCodeHash": "0xe30675ea6623cd7390dd2cd1e9a523c92c66956dfab86d06e318eb410cd1989b",
-    "sourceCodeHash": "0xdc7bd63134eeab163a635950f2afd16b59f40f9cf1306f2ed33ad661cc7b4962"
+    "initCodeHash": "0xad3f490196f6272c5770c6af84806c2c8eb0528490a4125acc45c4914dbeaac4",
+    "sourceCodeHash": "0xc6a4b43f3372fa35cea32adb85217ce4276d8ae670d0a2f394e1d6b7cb83cf2a"
   },
   "src/L2/OperatorFeeVault.sol:OperatorFeeVault": {
     "initCodeHash": "0x2179f8438c980cbd14c354206c1253f5704b9100446cdf91fa537a15bfc094ff",

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -12,8 +12,8 @@
     "sourceCodeHash": "0xd9f576a79e97bc541b3d7a2ee928f34223edaaecb074eeb9e6e2ecee857ce6a0"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0xbaf65d6803fd81d273377af2729c9a092aa814d41b67f50c48b7687fa46b9180",
-    "sourceCodeHash": "0xd8554d8c723eacd9d4e96ffa43f8f4e072150456e366247c3ec223ce9810ca69"
+    "initCodeHash": "0x85abb3c5f8960f4ffa0f80d238510bfe00719cae397c121bd5775a002ee2a609",
+    "sourceCodeHash": "0x259c72decdc4a257d7ce12f0c71602d00e9ebdb82a2fd07a7ee515f95d30ebdb"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
     "initCodeHash": "0xd762af325410baea14f927f4292ef9ee2bb13b52d72034d6d129eb1e518dfedd",
@@ -96,8 +96,8 @@
     "sourceCodeHash": "0xc53a2f1fc472b15aa2891d48845b078ef12fdae869a4b74bef19b19d9d20ed5f"
   },
   "src/L2/L2ToL1MessagePasser.sol:L2ToL1MessagePasser": {
-    "initCodeHash": "0xad3f490196f6272c5770c6af84806c2c8eb0528490a4125acc45c4914dbeaac4",
-    "sourceCodeHash": "0xc6a4b43f3372fa35cea32adb85217ce4276d8ae670d0a2f394e1d6b7cb83cf2a"
+    "initCodeHash": "0x3f8897865d03a864c6abaadcada300dc073385a45e49687d7434d3ae538bdc46",
+    "sourceCodeHash": "0x7e5c271494427cb6cb81bcf2a01f06201da3d27fea6bb1af143654f21035743a"
   },
   "src/L2/OperatorFeeVault.sol:OperatorFeeVault": {
     "initCodeHash": "0x2179f8438c980cbd14c354206c1253f5704b9100446cdf91fa537a15bfc094ff",

--- a/snapshots/storageLayout/L2ToL1MessagePasser.json
+++ b/snapshots/storageLayout/L2ToL1MessagePasser.json
@@ -12,5 +12,19 @@
     "offset": 0,
     "slot": "1",
     "type": "uint240"
+  },
+  {
+    "bytes": "32",
+    "label": "attestedWithdrawals",
+    "offset": 0,
+    "slot": "2",
+    "type": "mapping(bytes32 => bool)"
+  },
+  {
+    "bytes": "32",
+    "label": "attestNonce",
+    "offset": 0,
+    "slot": "3",
+    "type": "uint256"
   }
 ]

--- a/snapshots/storageLayout/OptimismPortal2.json
+++ b/snapshots/storageLayout/OptimismPortal2.json
@@ -145,5 +145,19 @@
     "offset": 20,
     "slot": "63",
     "type": "bool"
+  },
+  {
+    "bytes": "20",
+    "label": "teeProverRegistry",
+    "offset": 0,
+    "slot": "64",
+    "type": "contract ITEEProverRegistry"
+  },
+  {
+    "bytes": "32",
+    "label": "attestRedeemed",
+    "offset": 0,
+    "slot": "65",
+    "type": "mapping(bytes32 => bool)"
   }
 ]

--- a/src/L1/OptimismPortal2.sol
+++ b/src/L1/OptimismPortal2.sol
@@ -167,7 +167,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
 
     /// @notice Emitted when an attested withdrawal is redeemed.
     event AttestedWithdrawalRedeemed(
-        bytes32 indexed authHash, address indexed recipient, uint256 amount, uint256 nonce, address signer
+        bytes32 indexed authHash, address indexed recipient, uint256 amount, uint256 nonce, address signer, bytes data
     );
 
     /// @notice Thrown when a withdrawal has already been finalized.
@@ -235,7 +235,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     error OptimismPortal_TEEProverRegistryAlreadySet();
 
     /// @notice Thrown when an attested withdrawal payout fails.
-    error OptimismPortal_AttestedWithdrawalTransferFailed();
+    error OptimismPortal_AttestedWithdrawalCallFailed();
 
     /// @notice Semantic version.
     /// @custom:semver 5.3.0
@@ -256,11 +256,12 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         teeProverRegistry = _teeProverRegistry;
     }
 
-    /// @notice Redeems an ETH withdrawal authorized by a registered enclave signer.
+    /// @notice Executes an ETH-plus-calldata call authorized by a registered enclave signer.
     function redeemAttestedWithdrawal(
         address _recipient,
         uint256 _amount,
         uint256 _nonce,
+        bytes calldata _data,
         bytes calldata _sig
     )
         external
@@ -268,7 +269,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         _assertNotPaused();
 
         bytes32 authHash =
-            keccak256(abi.encode(uint256(systemConfig.l2ChainId()), _recipient, address(0), _amount, _nonce));
+            keccak256(abi.encode(uint256(systemConfig.l2ChainId()), _recipient, address(0), _amount, _nonce, _data));
         if (attestRedeemed[authHash]) revert OptimismPortal_AttestedWithdrawalAlreadyRedeemed();
 
         bytes32 journal = keccak256(abi.encodePacked(ATTESTED_WITHDRAWAL_DOMAIN_TAG, authHash));
@@ -277,11 +278,11 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         if (!teeProverRegistry.isValidSigner(signer)) revert OptimismPortal_InvalidAttestedWithdrawalSigner(signer);
 
         attestRedeemed[authHash] = true;
-        if (!SafeCall.call(_recipient, gasleft(), _amount, hex"")) {
-            revert OptimismPortal_AttestedWithdrawalTransferFailed();
+        if (!SafeCall.call(_recipient, gasleft(), _amount, _data)) {
+            revert OptimismPortal_AttestedWithdrawalCallFailed();
         }
 
-        emit AttestedWithdrawalRedeemed(authHash, _recipient, _amount, _nonce, signer);
+        emit AttestedWithdrawalRedeemed(authHash, _recipient, _amount, _nonce, signer, _data);
     }
 
     /// @notice Initializer.

--- a/src/L1/OptimismPortal2.sol
+++ b/src/L1/OptimismPortal2.sol
@@ -17,6 +17,7 @@ import { SecureMerkleTrie } from "src/libraries/trie/SecureMerkleTrie.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 import { GameStatus, GameType } from "src/libraries/bridge/Types.sol";
 import { Features } from "src/libraries/Features.sol";
+import { ECDSA } from "lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
@@ -26,6 +27,7 @@ import { IDisputeGameFactory } from "interfaces/L1/proofs/IDisputeGameFactory.so
 import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
 import { IAnchorStateRegistry } from "interfaces/L1/proofs/IAnchorStateRegistry.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { ITEEProverRegistry } from "interfaces/L1/proofs/tee/ITEEProverRegistry.sol";
 
 /// @custom:proxied true
 /// @title OptimismPortal2
@@ -46,6 +48,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
 
     /// @notice Version of the deposit event.
     uint256 internal constant DEPOSIT_VERSION = 0;
+
+    /// @notice Domain separator for attested withdrawal authorizations.
+    bytes32 internal constant ATTESTED_WITHDRAWAL_DOMAIN_TAG = keccak256("BASE_ATTESTED_WITHDRAWAL_V1");
 
     /// @notice The L2 gas limit set when eth is deposited using the receive() function.
     uint64 internal constant RECEIVE_DEFAULT_GAS_LIMIT = 100_000;
@@ -128,6 +133,12 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @custom:spacer superRootsActive
     bool private spacer_63_20_1;
 
+    /// @notice TEE prover registry authorized to attest withdrawals.
+    ITEEProverRegistry public teeProverRegistry;
+
+    /// @notice Tracks attested withdrawals that have been redeemed.
+    mapping(bytes32 => bool) public attestRedeemed;
+
     /// @notice Emitted when a transaction is deposited from L1 to L2. The parameters of this event
     ///         are read by the rollup node and used to derive deposit transactions on L2.
     /// @param from       Address that triggered the deposit transaction.
@@ -153,6 +164,11 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @param withdrawalHash Hash of the withdrawal transaction.
     /// @param success        Whether the withdrawal transaction was successful.
     event WithdrawalFinalized(bytes32 indexed withdrawalHash, bool success);
+
+    /// @notice Emitted when an attested withdrawal is redeemed.
+    event AttestedWithdrawalRedeemed(
+        bytes32 indexed authHash, address indexed recipient, uint256 amount, uint256 nonce, address signer
+    );
 
     /// @notice Thrown when a withdrawal has already been finalized.
     error OptimismPortal_AlreadyFinalized();
@@ -206,16 +222,66 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     ///         not been configured for immediate finality (PROOF_MATURITY_DELAY_SECONDS != 0).
     error OptimismPortal_ImmediateFinalityNotEnabled();
 
+    /// @notice Thrown when an attested withdrawal has already been redeemed.
+    error OptimismPortal_AttestedWithdrawalAlreadyRedeemed();
+
+    /// @notice Thrown when an attested withdrawal signature is invalid.
+    error OptimismPortal_InvalidAttestedWithdrawalSignature();
+
+    /// @notice Thrown when an attested withdrawal signer is not registered.
+    error OptimismPortal_InvalidAttestedWithdrawalSigner(address signer);
+
+    /// @notice Thrown when the TEE prover registry has already been configured.
+    error OptimismPortal_TEEProverRegistryAlreadySet();
+
+    /// @notice Thrown when an attested withdrawal payout fails.
+    error OptimismPortal_AttestedWithdrawalTransferFailed();
+
     /// @notice Semantic version.
-    /// @custom:semver 5.2.0
+    /// @custom:semver 5.3.0
     function version() public pure virtual returns (string memory) {
-        return "5.2.0";
+        return "5.3.0";
     }
 
     /// @param _proofMaturityDelaySeconds The proof maturity delay in seconds.
     constructor(uint256 _proofMaturityDelaySeconds) ReinitializableBase(3) {
         PROOF_MATURITY_DELAY_SECONDS = _proofMaturityDelaySeconds;
         _disableInitializers();
+    }
+
+    /// @notice Sets the registry authorized to attest withdrawals.
+    function setTEEProverRegistry(ITEEProverRegistry _teeProverRegistry) external {
+        _assertOnlyProxyAdminOwner();
+        if (address(teeProverRegistry) != address(0)) revert OptimismPortal_TEEProverRegistryAlreadySet();
+        teeProverRegistry = _teeProverRegistry;
+    }
+
+    /// @notice Redeems an ETH withdrawal authorized by a registered enclave signer.
+    function redeemAttestedWithdrawal(
+        address _recipient,
+        uint256 _amount,
+        uint256 _nonce,
+        bytes calldata _sig
+    )
+        external
+    {
+        _assertNotPaused();
+
+        bytes32 authHash =
+            keccak256(abi.encode(uint256(systemConfig.l2ChainId()), _recipient, address(0), _amount, _nonce));
+        if (attestRedeemed[authHash]) revert OptimismPortal_AttestedWithdrawalAlreadyRedeemed();
+
+        bytes32 journal = keccak256(abi.encodePacked(ATTESTED_WITHDRAWAL_DOMAIN_TAG, authHash));
+        (address signer, ECDSA.RecoverError err) = ECDSA.tryRecover(journal, _sig);
+        if (err != ECDSA.RecoverError.NoError) revert OptimismPortal_InvalidAttestedWithdrawalSignature();
+        if (!teeProverRegistry.isValidSigner(signer)) revert OptimismPortal_InvalidAttestedWithdrawalSigner(signer);
+
+        attestRedeemed[authHash] = true;
+        if (!SafeCall.call(_recipient, gasleft(), _amount, hex"")) {
+            revert OptimismPortal_AttestedWithdrawalTransferFailed();
+        }
+
+        emit AttestedWithdrawalRedeemed(authHash, _recipient, _amount, _nonce, signer);
     }
 
     /// @notice Initializer.

--- a/src/L2/L2ToL1MessagePasser.sol
+++ b/src/L2/L2ToL1MessagePasser.sol
@@ -59,7 +59,12 @@ contract L2ToL1MessagePasser is ISemver {
 
     /// @notice Emitted when an attested withdrawal is initiated.
     event AttestedWithdrawalInitiated(
-        bytes32 indexed authHash, address indexed recipient, address indexed token, uint256 amount, uint256 nonce
+        bytes32 indexed authHash,
+        address indexed recipient,
+        address indexed token,
+        uint256 amount,
+        uint256 nonce,
+        bytes data
     );
 
     /// @custom:semver 1.3.0
@@ -107,13 +112,14 @@ contract L2ToL1MessagePasser is ISemver {
         }
     }
 
-    /// @notice Initiates an ETH withdrawal that an authorized enclave may attest for L1 redemption.
-    function attestedWithdraw(address _recipient) external payable {
+    /// @notice Initiates an ETH withdrawal with an L1 call authorized for enclave attestation.
+    function attestedWithdraw(address _recipient, bytes calldata _data) external payable {
         uint256 nonce = attestNonce;
-        bytes32 authHash = keccak256(abi.encode(uint256(block.chainid), _recipient, address(0), msg.value, nonce));
+        bytes32 authHash =
+            keccak256(abi.encode(uint256(block.chainid), _recipient, address(0), msg.value, nonce, _data));
 
         attestedWithdrawals[authHash] = true;
-        emit AttestedWithdrawalInitiated(authHash, _recipient, address(0), msg.value, nonce);
+        emit AttestedWithdrawalInitiated(authHash, _recipient, address(0), msg.value, nonce, _data);
 
         unchecked {
             ++attestNonce;

--- a/src/L2/L2ToL1MessagePasser.sol
+++ b/src/L2/L2ToL1MessagePasser.sol
@@ -29,6 +29,12 @@ contract L2ToL1MessagePasser is ISemver {
     /// @notice A unique value hashed with each withdrawal.
     uint240 internal msgNonce;
 
+    /// @notice Records withdrawals authorized for TEE-attested L1 redemption.
+    mapping(bytes32 => bool) public attestedWithdrawals;
+
+    /// @notice A unique value hashed with each attested withdrawal.
+    uint256 public attestNonce;
+
     /// @notice Emitted any time a withdrawal is initiated.
     /// @param nonce          Unique value corresponding to each withdrawal.
     /// @param sender         The L2 account address which initiated the withdrawal.
@@ -51,9 +57,14 @@ contract L2ToL1MessagePasser is ISemver {
     /// @param amount Amount of ETH that was burned.
     event WithdrawerBalanceBurnt(uint256 indexed amount);
 
-    /// @custom:semver 1.2.0
+    /// @notice Emitted when an attested withdrawal is initiated.
+    event AttestedWithdrawalInitiated(
+        bytes32 indexed authHash, address indexed recipient, address indexed token, uint256 amount, uint256 nonce
+    );
+
+    /// @custom:semver 1.3.0
     function version() public pure virtual returns (string memory) {
-        return "1.2.0";
+        return "1.3.0";
     }
 
     /// @notice Allows users to withdraw ETH by sending directly to this contract.
@@ -93,6 +104,19 @@ contract L2ToL1MessagePasser is ISemver {
 
         unchecked {
             ++msgNonce;
+        }
+    }
+
+    /// @notice Initiates an ETH withdrawal that an authorized enclave may attest for L1 redemption.
+    function attestedWithdraw(address _recipient) external payable {
+        uint256 nonce = attestNonce;
+        bytes32 authHash = keccak256(abi.encode(uint256(block.chainid), _recipient, address(0), msg.value, nonce));
+
+        attestedWithdrawals[authHash] = true;
+        emit AttestedWithdrawalInitiated(authHash, _recipient, address(0), msg.value, nonce);
+
+        unchecked {
+            ++attestNonce;
         }
     }
 

--- a/test/L1/OptimismPortal2.t.sol
+++ b/test/L1/OptimismPortal2.t.sol
@@ -33,6 +33,7 @@ import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 import { IVerifier } from "interfaces/L1/proofs/IVerifier.sol";
+import { ITEEProverRegistry } from "interfaces/L1/proofs/tee/ITEEProverRegistry.sol";
 
 abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
     address depositor;
@@ -2102,5 +2103,92 @@ contract OptimismPortal2_Params_Test is CommonTest {
         bytes32 slot21After = vm.load(address(optimismPortal2), bytes32(uint256(21)));
         bytes32 slot21Expected = NextImpl(address(optimismPortal2)).slot21Init();
         assertEq(slot21Expected, slot21After);
+    }
+}
+
+/// @title OptimismPortal2_RedeemAttestedWithdrawal_Test
+/// @notice Tests for `redeemAttestedWithdrawal`.
+contract OptimismPortal2_RedeemAttestedWithdrawal_Test is OptimismPortal2_TestInit {
+    uint256 internal constant SIGNER_PRIVATE_KEY = 0xA11CE;
+
+    event AttestedWithdrawalRedeemed(
+        bytes32 indexed authHash, address indexed recipient, uint256 amount, uint256 nonce, address signer
+    );
+
+    function setUp() public override {
+        super.setUp();
+        if (address(optimismPortal2.teeProverRegistry()) == address(0)) {
+            vm.prank(proxyAdminOwner);
+            optimismPortal2.setTEEProverRegistry(ITEEProverRegistry(address(teeProverRegistry)));
+        }
+    }
+
+    function test_redeemAttestedWithdrawal_succeeds() external {
+        address recipient = makeAddr("attested recipient");
+        uint256 amount = 1 gwei;
+        uint256 nonce = 7;
+        address signer = vm.addr(SIGNER_PRIVATE_KEY);
+        bytes32 authHash = keccak256(abi.encode(deploy.cfg().l2ChainId(), recipient, address(0), amount, nonce));
+        bytes32 journal = keccak256(abi.encodePacked(keccak256("BASE_ATTESTED_WITHDRAWAL_V1"), authHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PRIVATE_KEY, journal);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        vm.mockCall(
+            address(teeProverRegistry), abi.encodeCall(teeProverRegistry.isValidSigner, (signer)), abi.encode(true)
+        );
+        vm.expectEmit(true, true, false, true, address(optimismPortal2));
+        emit AttestedWithdrawalRedeemed(authHash, recipient, amount, nonce, signer);
+
+        uint256 balanceBefore = recipient.balance;
+        optimismPortal2.redeemAttestedWithdrawal(recipient, amount, nonce, signature);
+
+        assertEq(recipient.balance, balanceBefore + amount);
+        assertTrue(optimismPortal2.attestRedeemed(authHash));
+    }
+
+    function test_redeemAttestedWithdrawal_replay_reverts() external {
+        address recipient = makeAddr("attested recipient");
+        uint256 amount = 1 gwei;
+        uint256 nonce = 7;
+        address signer = vm.addr(SIGNER_PRIVATE_KEY);
+        bytes32 authHash = keccak256(abi.encode(deploy.cfg().l2ChainId(), recipient, address(0), amount, nonce));
+        bytes32 journal = keccak256(abi.encodePacked(keccak256("BASE_ATTESTED_WITHDRAWAL_V1"), authHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PRIVATE_KEY, journal);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        vm.mockCall(
+            address(teeProverRegistry), abi.encodeCall(teeProverRegistry.isValidSigner, (signer)), abi.encode(true)
+        );
+
+        optimismPortal2.redeemAttestedWithdrawal(recipient, amount, nonce, signature);
+
+        vm.expectRevert(IOptimismPortal.OptimismPortal_AttestedWithdrawalAlreadyRedeemed.selector);
+        optimismPortal2.redeemAttestedWithdrawal(recipient, amount, nonce, signature);
+    }
+
+    function test_redeemAttestedWithdrawal_paused_reverts() external {
+        vm.prank(optimismPortal2.guardian());
+        superchainConfig.pause(address(0));
+
+        vm.expectRevert(IOptimismPortal.OptimismPortal_CallPaused.selector);
+        optimismPortal2.redeemAttestedWithdrawal(makeAddr("attested recipient"), 1 gwei, 7, hex"");
+    }
+
+    function test_redeemAttestedWithdrawal_invalidSigner_reverts() external {
+        address recipient = makeAddr("attested recipient");
+        uint256 amount = 1 gwei;
+        uint256 nonce = 7;
+        address signer = vm.addr(SIGNER_PRIVATE_KEY);
+        bytes32 authHash = keccak256(abi.encode(deploy.cfg().l2ChainId(), recipient, address(0), amount, nonce));
+        bytes32 journal = keccak256(abi.encodePacked(keccak256("BASE_ATTESTED_WITHDRAWAL_V1"), authHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PRIVATE_KEY, journal);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        vm.mockCall(
+            address(teeProverRegistry), abi.encodeCall(teeProverRegistry.isValidSigner, (signer)), abi.encode(false)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IOptimismPortal.OptimismPortal_InvalidAttestedWithdrawalSigner.selector, signer)
+        );
+        optimismPortal2.redeemAttestedWithdrawal(recipient, amount, nonce, signature);
     }
 }

--- a/test/L1/OptimismPortal2.t.sol
+++ b/test/L1/OptimismPortal2.t.sol
@@ -10,6 +10,7 @@ import { NextImpl } from "test/mocks/NextImpl.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { DisputeGameFactory_TestInit } from "test/L1/proofs/DisputeGameFactory.t.sol";
 import { MockVerifier } from "test/mocks/MockVerifier.sol";
+import { CallRecorder, Reverter } from "test/mocks/Callers.sol";
 
 // Scripts
 import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
@@ -21,6 +22,7 @@ import { Constants } from "src/libraries/Constants.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 import { Features } from "src/libraries/Features.sol";
 import { AggregateVerifier } from "src/L1/proofs/AggregateVerifier.sol";
+import { ECDSA } from "lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
 import "src/libraries/bridge/Types.sol";
 import { Claim, Timestamp } from "src/libraries/bridge/LibUDT.sol";
 
@@ -2110,9 +2112,10 @@ contract OptimismPortal2_Params_Test is CommonTest {
 /// @notice Tests for `redeemAttestedWithdrawal`.
 contract OptimismPortal2_RedeemAttestedWithdrawal_Test is OptimismPortal2_TestInit {
     uint256 internal constant SIGNER_PRIVATE_KEY = 0xA11CE;
+    bytes32 internal constant DOMAIN_TAG = keccak256("BASE_ATTESTED_WITHDRAWAL_V1");
 
     event AttestedWithdrawalRedeemed(
-        bytes32 indexed authHash, address indexed recipient, uint256 amount, uint256 nonce, address signer
+        bytes32 indexed authHash, address indexed recipient, uint256 amount, uint256 nonce, address signer, bytes data
     );
 
     function setUp() public override {
@@ -2123,26 +2126,59 @@ contract OptimismPortal2_RedeemAttestedWithdrawal_Test is OptimismPortal2_TestIn
         }
     }
 
+    function _authHash(
+        address _recipient,
+        uint256 _amount,
+        uint256 _nonce,
+        bytes memory _data
+    )
+        internal
+        view
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(deploy.cfg().l2ChainId(), _recipient, address(0), _amount, _nonce, _data));
+    }
+
+    function _sign(
+        address _recipient,
+        uint256 _amount,
+        uint256 _nonce,
+        bytes memory _data
+    )
+        internal
+        view
+        returns (bytes32 authHash_, bytes memory signature_, address signer_)
+    {
+        authHash_ = _authHash(_recipient, _amount, _nonce, _data);
+        bytes32 journal = keccak256(abi.encodePacked(DOMAIN_TAG, authHash_));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PRIVATE_KEY, journal);
+        signature_ = abi.encodePacked(r, s, v);
+        signer_ = vm.addr(SIGNER_PRIVATE_KEY);
+    }
+
+    function _mockValidSigner(address _signer) internal {
+        vm.mockCall(
+            address(teeProverRegistry), abi.encodeCall(teeProverRegistry.isValidSigner, (_signer)), abi.encode(true)
+        );
+    }
+
     function test_redeemAttestedWithdrawal_succeeds() external {
-        address recipient = makeAddr("attested recipient");
+        CallRecorder recipient = new CallRecorder();
         uint256 amount = 1 gwei;
         uint256 nonce = 7;
-        address signer = vm.addr(SIGNER_PRIVATE_KEY);
-        bytes32 authHash = keccak256(abi.encode(deploy.cfg().l2ChainId(), recipient, address(0), amount, nonce));
-        bytes32 journal = keccak256(abi.encodePacked(keccak256("BASE_ATTESTED_WITHDRAWAL_V1"), authHash));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PRIVATE_KEY, journal);
-        bytes memory signature = abi.encodePacked(r, s, v);
+        bytes memory data = abi.encodeCall(CallRecorder.record, ());
+        (bytes32 authHash, bytes memory signature, address signer) = _sign(address(recipient), amount, nonce, data);
+        _mockValidSigner(signer);
 
-        vm.mockCall(
-            address(teeProverRegistry), abi.encodeCall(teeProverRegistry.isValidSigner, (signer)), abi.encode(true)
-        );
         vm.expectEmit(true, true, false, true, address(optimismPortal2));
-        emit AttestedWithdrawalRedeemed(authHash, recipient, amount, nonce, signer);
+        emit AttestedWithdrawalRedeemed(authHash, address(recipient), amount, nonce, signer, data);
+        optimismPortal2.redeemAttestedWithdrawal(address(recipient), amount, nonce, data, signature);
 
-        uint256 balanceBefore = recipient.balance;
-        optimismPortal2.redeemAttestedWithdrawal(recipient, amount, nonce, signature);
-
-        assertEq(recipient.balance, balanceBefore + amount);
+        CallRecorder.CallInfo memory callInfo = recipient.getLastCall();
+        assertEq(callInfo.sender, address(optimismPortal2));
+        assertEq(callInfo.data, data);
+        assertGt(callInfo.gas, 0);
+        assertEq(callInfo.value, amount);
         assertTrue(optimismPortal2.attestRedeemed(authHash));
     }
 
@@ -2150,19 +2186,15 @@ contract OptimismPortal2_RedeemAttestedWithdrawal_Test is OptimismPortal2_TestIn
         address recipient = makeAddr("attested recipient");
         uint256 amount = 1 gwei;
         uint256 nonce = 7;
-        address signer = vm.addr(SIGNER_PRIVATE_KEY);
-        bytes32 authHash = keccak256(abi.encode(deploy.cfg().l2ChainId(), recipient, address(0), amount, nonce));
-        bytes32 journal = keccak256(abi.encodePacked(keccak256("BASE_ATTESTED_WITHDRAWAL_V1"), authHash));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PRIVATE_KEY, journal);
-        bytes memory signature = abi.encodePacked(r, s, v);
-        vm.mockCall(
-            address(teeProverRegistry), abi.encodeCall(teeProverRegistry.isValidSigner, (signer)), abi.encode(true)
-        );
+        bytes memory data = hex"1234";
+        (bytes32 authHash, bytes memory signature, address signer) = _sign(recipient, amount, nonce, data);
+        _mockValidSigner(signer);
 
-        optimismPortal2.redeemAttestedWithdrawal(recipient, amount, nonce, signature);
+        optimismPortal2.redeemAttestedWithdrawal(recipient, amount, nonce, data, signature);
 
         vm.expectRevert(IOptimismPortal.OptimismPortal_AttestedWithdrawalAlreadyRedeemed.selector);
-        optimismPortal2.redeemAttestedWithdrawal(recipient, amount, nonce, signature);
+        optimismPortal2.redeemAttestedWithdrawal(recipient, amount, nonce, data, signature);
+        assertTrue(optimismPortal2.attestRedeemed(authHash));
     }
 
     function test_redeemAttestedWithdrawal_paused_reverts() external {
@@ -2170,18 +2202,15 @@ contract OptimismPortal2_RedeemAttestedWithdrawal_Test is OptimismPortal2_TestIn
         superchainConfig.pause(address(0));
 
         vm.expectRevert(IOptimismPortal.OptimismPortal_CallPaused.selector);
-        optimismPortal2.redeemAttestedWithdrawal(makeAddr("attested recipient"), 1 gwei, 7, hex"");
+        optimismPortal2.redeemAttestedWithdrawal(makeAddr("attested recipient"), 1 gwei, 7, hex"", hex"");
     }
 
     function test_redeemAttestedWithdrawal_invalidSigner_reverts() external {
         address recipient = makeAddr("attested recipient");
         uint256 amount = 1 gwei;
         uint256 nonce = 7;
-        address signer = vm.addr(SIGNER_PRIVATE_KEY);
-        bytes32 authHash = keccak256(abi.encode(deploy.cfg().l2ChainId(), recipient, address(0), amount, nonce));
-        bytes32 journal = keccak256(abi.encodePacked(keccak256("BASE_ATTESTED_WITHDRAWAL_V1"), authHash));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_PRIVATE_KEY, journal);
-        bytes memory signature = abi.encodePacked(r, s, v);
+        bytes memory data = hex"1234";
+        (, bytes memory signature, address signer) = _sign(recipient, amount, nonce, data);
         vm.mockCall(
             address(teeProverRegistry), abi.encodeCall(teeProverRegistry.isValidSigner, (signer)), abi.encode(false)
         );
@@ -2189,6 +2218,46 @@ contract OptimismPortal2_RedeemAttestedWithdrawal_Test is OptimismPortal2_TestIn
         vm.expectRevert(
             abi.encodeWithSelector(IOptimismPortal.OptimismPortal_InvalidAttestedWithdrawalSigner.selector, signer)
         );
-        optimismPortal2.redeemAttestedWithdrawal(recipient, amount, nonce, signature);
+        optimismPortal2.redeemAttestedWithdrawal(recipient, amount, nonce, data, signature);
+    }
+
+    function test_redeemAttestedWithdrawal_calldataTampered_reverts() external {
+        address recipient = makeAddr("attested recipient");
+        uint256 amount = 1 gwei;
+        uint256 nonce = 7;
+        bytes memory signedData = hex"1234";
+        bytes memory submittedData = hex"5678";
+        (bytes32 signedAuthHash, bytes memory signature,) = _sign(recipient, amount, nonce, signedData);
+        bytes32 submittedAuthHash = _authHash(recipient, amount, nonce, submittedData);
+        address recoveredSigner = ECDSA.recover(keccak256(abi.encodePacked(DOMAIN_TAG, submittedAuthHash)), signature);
+        vm.mockCall(
+            address(teeProverRegistry),
+            abi.encodeCall(teeProverRegistry.isValidSigner, (recoveredSigner)),
+            abi.encode(false)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOptimismPortal.OptimismPortal_InvalidAttestedWithdrawalSigner.selector, recoveredSigner
+            )
+        );
+        optimismPortal2.redeemAttestedWithdrawal(recipient, amount, nonce, submittedData, signature);
+
+        assertFalse(optimismPortal2.attestRedeemed(signedAuthHash));
+        assertFalse(optimismPortal2.attestRedeemed(submittedAuthHash));
+    }
+
+    function test_redeemAttestedWithdrawal_targetReverts_reverts() external {
+        Reverter recipient = new Reverter();
+        uint256 amount = 1 gwei;
+        uint256 nonce = 7;
+        bytes memory data = abi.encodeCall(Reverter.doRevert, ());
+        (bytes32 authHash, bytes memory signature, address signer) = _sign(address(recipient), amount, nonce, data);
+        _mockValidSigner(signer);
+
+        vm.expectRevert(IOptimismPortal.OptimismPortal_AttestedWithdrawalCallFailed.selector);
+        optimismPortal2.redeemAttestedWithdrawal(address(recipient), amount, nonce, data, signature);
+
+        assertFalse(optimismPortal2.attestRedeemed(authHash));
     }
 }

--- a/test/L2/L2ToL1MessagePasser.t.sol
+++ b/test/L2/L2ToL1MessagePasser.t.sol
@@ -184,3 +184,28 @@ contract L2ToL1MessagePasser_MessageNonce_Test is L2ToL1MessagePasser_TestInit {
         assertEq(version, l2ToL1MessagePasser.MESSAGE_VERSION());
     }
 }
+
+/// @title L2ToL1MessagePasser_AttestedWithdraw_Test
+/// @notice Tests for `attestedWithdraw`.
+contract L2ToL1MessagePasser_AttestedWithdraw_Test is L2ToL1MessagePasser_TestInit {
+    event AttestedWithdrawalInitiated(
+        bytes32 indexed authHash, address indexed recipient, address indexed token, uint256 amount, uint256 nonce
+    );
+
+    function test_attestedWithdraw_succeeds() external {
+        address recipient = makeAddr("recipient");
+        uint256 amount = 1 ether;
+        uint256 nonce = l2ToL1MessagePasser.attestNonce();
+        bytes32 authHash = keccak256(abi.encode(block.chainid, recipient, address(0), amount, nonce));
+
+        vm.expectEmit(true, true, true, true, address(l2ToL1MessagePasser));
+        emit AttestedWithdrawalInitiated(authHash, recipient, address(0), amount, nonce);
+
+        vm.deal(address(this), amount);
+        l2ToL1MessagePasser.attestedWithdraw{ value: amount }(recipient);
+
+        assertTrue(l2ToL1MessagePasser.attestedWithdrawals(authHash));
+        assertEq(l2ToL1MessagePasser.attestNonce(), nonce + 1);
+        assertEq(address(l2ToL1MessagePasser).balance, amount);
+    }
+}

--- a/test/L2/L2ToL1MessagePasser.t.sol
+++ b/test/L2/L2ToL1MessagePasser.t.sol
@@ -189,23 +189,40 @@ contract L2ToL1MessagePasser_MessageNonce_Test is L2ToL1MessagePasser_TestInit {
 /// @notice Tests for `attestedWithdraw`.
 contract L2ToL1MessagePasser_AttestedWithdraw_Test is L2ToL1MessagePasser_TestInit {
     event AttestedWithdrawalInitiated(
-        bytes32 indexed authHash, address indexed recipient, address indexed token, uint256 amount, uint256 nonce
+        bytes32 indexed authHash,
+        address indexed recipient,
+        address indexed token,
+        uint256 amount,
+        uint256 nonce,
+        bytes data
     );
 
     function test_attestedWithdraw_succeeds() external {
         address recipient = makeAddr("recipient");
         uint256 amount = 1 ether;
         uint256 nonce = l2ToL1MessagePasser.attestNonce();
-        bytes32 authHash = keccak256(abi.encode(block.chainid, recipient, address(0), amount, nonce));
+        bytes memory data = hex"1234";
+        bytes32 authHash = keccak256(abi.encode(block.chainid, recipient, address(0), amount, nonce, data));
 
         vm.expectEmit(true, true, true, true, address(l2ToL1MessagePasser));
-        emit AttestedWithdrawalInitiated(authHash, recipient, address(0), amount, nonce);
+        emit AttestedWithdrawalInitiated(authHash, recipient, address(0), amount, nonce, data);
 
         vm.deal(address(this), amount);
-        l2ToL1MessagePasser.attestedWithdraw{ value: amount }(recipient);
+        l2ToL1MessagePasser.attestedWithdraw{ value: amount }(recipient, data);
 
         assertTrue(l2ToL1MessagePasser.attestedWithdrawals(authHash));
         assertEq(l2ToL1MessagePasser.attestNonce(), nonce + 1);
         assertEq(address(l2ToL1MessagePasser).balance, amount);
+    }
+
+    function test_attestedWithdraw_calldataChangesAuthorizationHash_succeeds() external {
+        address recipient = makeAddr("recipient");
+        uint256 amount = 1 ether;
+        uint256 nonce = l2ToL1MessagePasser.attestNonce();
+
+        bytes32 firstHash = keccak256(abi.encode(block.chainid, recipient, address(0), amount, nonce, hex"1234"));
+        bytes32 secondHash = keccak256(abi.encode(block.chainid, recipient, address(0), amount, nonce, hex"5678"));
+
+        assertNotEq(firstHash, secondHash);
     }
 }

--- a/test/deploy/SystemDeploy.t.sol
+++ b/test/deploy/SystemDeploy.t.sol
@@ -193,6 +193,7 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
         SystemDeploy.DeployInput memory input = _defaultDeployInput();
         SystemDeploy.DeployOutput memory output = systemDeploy.deploy(input);
         Types.Implementations memory implementations = output.impls;
+        vm.store(address(output.opChain.optimismPortalProxy), bytes32(uint256(64)), bytes32(0));
         ProtocolVersions protocolVersionsImpl = new ProtocolVersions();
         implementations.protocolVersionsImpl = address(protocolVersionsImpl);
 
@@ -208,6 +209,11 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
 
         assertFalse(upgradeOutput.superchainConfigUpgraded, "superchain already current");
         assertTrue(upgradeOutput.chainUpgraded, "chain upgraded");
+        assertEq(
+            address(output.opChain.optimismPortalProxy.teeProverRegistry()),
+            address(output.opChain.teeProverRegistryProxy),
+            "portal tee registry"
+        );
         assertEq(
             output.superchain.superchainProxyAdmin
                 .getProxyImplementation(address(output.superchain.superchainConfigProxy)),

--- a/test/mocks/Callers.sol
+++ b/test/mocks/Callers.sol
@@ -19,6 +19,10 @@ contract CallRecorder {
         lastCall.gas = gasleft();
         lastCall.value = msg.value;
     }
+
+    function getLastCall() external view returns (CallInfo memory) {
+        return lastCall;
+    }
 }
 
 /// @dev Any call will revert


### PR DESCRIPTION
## Summary
- Add `attestedWithdraw` to `L2ToL1MessagePasser`. It records a chain-bound ETH authorization in MessagePasser storage for enclave inclusion checks.
- Add `redeemAttestedWithdrawal` to `OptimismPortal2`. It validates the domain-separated raw signature from a registered TEE signer, prevents replay, honors the Portal pause state, and pays ETH from Portal escrow.
- Wire the TEE registry for new multiproof deployments and Portal upgrades. Update interfaces and generated ABI, storage-layout, and semver snapshots.

## Test plan
- [x] `just test`
- [x] `just snapshots-check-no-build`
- [x] `just semver-lock`
- [x] `forge fmt --check`
- [x] `git diff --check`