### PR TITLE
docs: use pinned Foundry for semver-lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ If the `semver-lock` CI check fails, regenerate locally and commit:
 just semver-lock
 ```
 
-If CI still rejects it (Foundry version mismatch), update your local Foundry first:
+If CI still rejects it because of a Foundry version mismatch, install the repository-pinned toolchain:
 
 ```bash
-foundryup
-just semver-lock
+mise install
+mise exec -- just semver-lock
 ```
 
 ### setup and testing


### PR DESCRIPTION
## Summary

* replace the `foundryup` recovery step for `semver-lock` failures with the repository-pinned `mise` toolchain
* run `semver-lock` through `mise exec` so local tooling matches the version pinned in `.mise.toml`

## Why

`foundryup` can install a Foundry version that differs from the repository's pinned toolchain, which can leave contributors out of sync with CI and reproducibility-sensitive outputs such as semver-lock hashes and snapshots.

Closes #403.

## Validation

* `git diff --check`
* verified the change is limited to `README.md`

Note: `mise` is not installed in the local Windows environment used for this documentation-only change, so the documented command itself was not executed locally.
