### PR TITLE
fix(L1): validate Nitro validator address

### DIFF
--- a/scripts/multiproof/DeployDevNoNitro.s.sol
+++ b/scripts/multiproof/DeployDevNoNitro.s.sol
@@ -6,6 +6,7 @@ import { console2 as console } from "lib/forge-std/src/console2.sol";
 import { IDisputeGameFactory } from "interfaces/L1/proofs/IDisputeGameFactory.sol";
 import { INitroValidator } from "interfaces/L1/proofs/tee/INitroValidator.sol";
 import { DevTEEProverRegistry } from "test/mocks/MockDevTEEProverRegistry.sol";
+import { MockNitroValidator } from "test/mocks/MockNitroValidator.sol";
 
 import { DeployDevBase } from "./DeployDevBase.s.sol";
 
@@ -34,9 +35,11 @@ contract DeployDevNoNitro is DeployDevBase {
     }
 
     function _deployTEERegistryImpl() internal override returns (address) {
+        MockNitroValidator mockNitroValidator = new MockNitroValidator();
         return address(
             new DevTEEProverRegistry({
-                nitroValidator: INitroValidator(address(0)), factory: IDisputeGameFactory(disputeGameFactory)
+                nitroValidator: INitroValidator(address(mockNitroValidator)),
+                factory: IDisputeGameFactory(disputeGameFactory)
             })
         );
     }

--- a/snapshots/abi/TEEProverRegistry.json
+++ b/snapshots/abi/TEEProverRegistry.json
@@ -489,6 +489,11 @@
   },
   {
     "inputs": [],
+    "name": "NitroValidatorNotSet",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "PCR0NotFound",
     "type": "error"
   }

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -44,8 +44,8 @@
     "sourceCodeHash": "0x62ff0209cffa08e5aaaaac47e0f22d89ea1fa6a0ea8773a162ab7230e50806ee"
   },
   "src/L1/proofs/tee/TEEProverRegistry.sol:TEEProverRegistry": {
-    "initCodeHash": "0xef50e4cd4734c5a7137c9071334fc159a36869744ec2fa25d320c172999c4b3b",
-    "sourceCodeHash": "0xd7aef97975588bb749c24b69f83055f329da06ce1b6b7634e51d0080557fb98e"
+    "initCodeHash": "0x380af47d78626bd0af4bb45769a9c184d6ea22adf60877ea9765129a28a3ffd6",
+    "sourceCodeHash": "0x463d71d1cd9a4e912a936d2e329959c89a2f37e76b8cf9e759a2457f12909c1b"
   },
   "src/L1/proofs/tee/TEEVerifier.sol:TEEVerifier": {
     "initCodeHash": "0x655576cc21cc5c603d55fb4dd2a2f0ef57b11deeaabd3e539b0a70a5f7e2c9af",

--- a/src/L1/proofs/tee/TEEProverRegistry.sol
+++ b/src/L1/proofs/tee/TEEProverRegistry.sol
@@ -90,6 +90,9 @@ contract TEEProverRegistry is OwnableManagedUpgradeable, ISemver {
     /// @notice Thrown when PCR0 is not a 48-byte SHA-384 measurement.
     error InvalidPCR0();
 
+    /// @notice Thrown when the Nitro validator is not configured.
+    error NitroValidatorNotSet();
+
     /// @notice Thrown when the dispute game factory is not configured.
     error DisputeGameFactoryNotSet();
 
@@ -100,6 +103,7 @@ contract TEEProverRegistry is OwnableManagedUpgradeable, ISemver {
     error InvalidGameType();
 
     constructor(INitroValidator nitroValidator, IDisputeGameFactory factory) {
+        if (address(nitroValidator) == address(0)) revert NitroValidatorNotSet();
         if (address(factory) == address(0)) revert DisputeGameFactoryNotSet();
         NITRO_VALIDATOR = nitroValidator;
         DISPUTE_GAME_FACTORY = factory;
@@ -248,9 +252,9 @@ contract TEEProverRegistry is OwnableManagedUpgradeable, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 0.6.0
+    /// @custom:semver 0.6.1
     function version() public pure virtual returns (string memory) {
-        return "0.6.0";
+        return "0.6.1";
     }
 
     /// @dev Reads TEE_IMAGE_HASH from the AggregateVerifier registered in the factory.

--- a/test/L1/proofs/TEEProverRegistry.t.sol
+++ b/test/L1/proofs/TEEProverRegistry.t.sol
@@ -79,9 +79,10 @@ contract TEEProverRegistryTest is Test {
     function _deployRegistry(address[] memory proposers, GameType gameType) internal returns (DevTEEProverRegistry) {
         MockAggregateVerifierForRegistry verifier = new MockAggregateVerifierForRegistry(TEST_IMAGE_HASH);
         MockDisputeGameFactoryForRegistry factory = new MockDisputeGameFactoryForRegistry(address(verifier));
+        MockNitroValidator nitroValidator = new MockNitroValidator();
 
         DevTEEProverRegistry impl = new DevTEEProverRegistry({
-            nitroValidator: INitroValidator(address(0)), factory: IDisputeGameFactory(address(factory))
+            nitroValidator: INitroValidator(address(nitroValidator)), factory: IDisputeGameFactory(address(factory))
         });
 
         proxyAdmin = makeAddr("proxy-admin");
@@ -125,10 +126,16 @@ contract TEEProverRegistryTest is Test {
         fail();
     }
 
+    function test_constructor_zeroNitroValidator_reverts() public {
+        IDisputeGameFactory factory = teeProverRegistry.DISPUTE_GAME_FACTORY();
+        vm.expectRevert(TEEProverRegistry.NitroValidatorNotSet.selector);
+        new TEEProverRegistry({ nitroValidator: INitroValidator(address(0)), factory: factory });
+    }
+
     function testInitialization() public view {
         assertEq(teeProverRegistry.owner(), owner);
         assertEq(teeProverRegistry.manager(), manager);
-        assertEq(teeProverRegistry.version(), "0.6.0");
+        assertEq(teeProverRegistry.version(), "0.6.1");
     }
 
     function testInitializationWithProposers() public {

--- a/test/L1/proofs/TEEVerifier.t.sol
+++ b/test/L1/proofs/TEEVerifier.t.sol
@@ -13,6 +13,7 @@ import { GameType } from "src/libraries/bridge/Types.sol";
 import { IDisputeGame } from "interfaces/L1/proofs/IDisputeGame.sol";
 import { MockAnchorStateRegistry } from "scripts/multiproof/mocks/MockAnchorStateRegistry.sol";
 import { DevTEEProverRegistry } from "test/mocks/MockDevTEEProverRegistry.sol";
+import { MockNitroValidator } from "test/mocks/MockNitroValidator.sol";
 import { TEEProverRegistry } from "src/L1/proofs/tee/TEEProverRegistry.sol";
 import { TEEVerifier } from "src/L1/proofs/tee/TEEVerifier.sol";
 
@@ -50,10 +51,12 @@ contract TEEVerifierTest is Test {
         address signerAddress = vm.addr(SIGNER_PRIVATE_KEY);
         MockAggregateVerifierForVerifier mockVerifier = new MockAggregateVerifierForVerifier(IMAGE_ID);
         MockDisputeGameFactoryForVerifier mockFactory = new MockDisputeGameFactoryForVerifier(address(mockVerifier));
+        MockNitroValidator mockNitroValidator = new MockNitroValidator();
 
         // DevTEEProverRegistry keeps these tests focused on verifier behavior without Nitro attestation setup.
         DevTEEProverRegistry impl = new DevTEEProverRegistry({
-            nitroValidator: INitroValidator(address(0)), factory: IDisputeGameFactory(address(mockFactory))
+            nitroValidator: INitroValidator(address(mockNitroValidator)),
+            factory: IDisputeGameFactory(address(mockFactory))
         });
 
         address proxyAdmin = makeAddr("proxy-admin");

--- a/test/deploy/SystemDeploy.t.sol
+++ b/test/deploy/SystemDeploy.t.sol
@@ -39,6 +39,12 @@ contract MockSP1Verifier {
     function verifyProof(bytes32, bytes calldata, bytes calldata) external pure { }
 }
 
+contract MockInvalidTEEProverRegistry {
+    function NITRO_VALIDATOR() external pure returns (INitroValidator) {
+        return INitroValidator(address(0));
+    }
+}
+
 contract SystemDeploy_Test is Test, SystemDeployAssertions {
     Artifacts internal constant artifacts =
         Artifacts(address(uint160(uint256(keccak256(abi.encode("optimism.artifacts"))))));
@@ -182,11 +188,8 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
     function test_upgrade_registryWithInvalidNitroValidator_reverts() public {
         SystemDeploy.DeployInput memory input = _defaultDeployInput();
         SystemDeploy.DeployOutput memory output = systemDeploy.deploy(input);
-        TEEProverRegistry invalidRegistryImpl = new TEEProverRegistry({
-            nitroValidator: INitroValidator(address(0)), factory: output.opChain.disputeGameFactoryProxy
-        });
         Types.Implementations memory implementations = output.impls;
-        implementations.teeProverRegistryImpl = address(invalidRegistryImpl);
+        implementations.teeProverRegistryImpl = address(new MockInvalidTEEProverRegistry());
 
         vm.expectRevert("DeployUtils: zero address");
         systemDeploy.upgrade(
@@ -266,7 +269,7 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
             address(newImpl),
             "tee registry impl"
         );
-        assertEq(registry.version(), "0.6.0");
+        assertEq(registry.version(), "0.6.1");
         assertEq(registry.owner(), owner);
         assertEq(registry.manager(), owner);
         assertEq(GameType.unwrap(registry.gameType()), uint32(input.implementationsInput.multiproofGameType));


### PR DESCRIPTION
## Summary
- reject a zero `NITRO_VALIDATOR` when deploying `TEEProverRegistry`
- bump the registry patch version to `0.6.1` and regenerate ABI/semver snapshots
- use nonzero mock validators in no-Nitro development and test deployments while retaining SystemDeploy validation coverage

Addresses internal audit finding L-01.

## Testing
- `just test` (1,207 passed, 1 skipped)
- `just test --match-path test/L1/proofs/TEEProverRegistry.t.sol`
- `just test --match-path test/L1/proofs/TEEVerifier.t.sol`
- `just test --match-path test/deploy/SystemDeploy.t.sol`
- `just lint`
- `just snapshots`

## Baseline note
`just pre-pr` is currently blocked by a lite-profile stack-too-deep error while compiling `test/deploy/SystemDeploy.t.sol`; the same failure reproduces on `origin/main`.