### PR TITLE
docs: use pinned Foundry toolchain for semver-lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,18 @@ If the `semver-lock` CI check fails, regenerate locally and commit:
 just semver-lock
 ```
 
-If CI still rejects it (Foundry version mismatch), update your local Foundry first:
+If CI still rejects it because of a Foundry version mismatch, install and run the repository-pinned toolchain:
 
 ```bash
-foundryup
-just semver-lock
+mise install
+mise exec -- just semver-lock
 ```
+
+The Foundry version is pinned in `.mise.toml`. Use the pinned version when regenerating lock files and snapshots so local output matches CI.
 
 ### setup and testing
 
-- If you don't have foundry installed, run `just install-foundry`.
+- Install the pinned toolchain with `mise install`.
+- If you do not use mise, run `just install-foundry` and verify the installed version matches `.mise.toml`.
 - `just deps`
 - Test contracts: `just test`


### PR DESCRIPTION
## Summary

- Replace the unpinned `foundryup` recovery instruction with the repository-pinned mise toolchain.
- - Document the `.mise.toml` version pin as the source of truth for semver-lock and snapshot reproducibility.
- - Keep a fallback path for contributors who do not use mise, with an explicit version check.
Closes #403 

## Validation

- `git diff --check`