### PR TITLE
fix: reject extending expired pauses

### DIFF
--- a/src/L1/SuperchainConfig.sol
+++ b/src/L1/SuperchainConfig.sol
@@ -119,8 +119,9 @@ contract SuperchainConfig is ProxyAdminOwnedBase, ISemver {
         // Only the Guardian can extend the pause.
         _assertOnlyGuardian();
 
-        // Cannot extend the pause if not already paused.
-        if (pauseTimestamps[_identifier] == 0) {
+        // An expired pause retains its timestamp but is no longer active. Requiring
+        // paused() here prevents extend() from re-activating it without unpause().
+        if (!paused(_identifier)) {
             revert SuperchainConfig_NotAlreadyPaused(_identifier);
         }
 

--- a/test/L1/SuperchainConfig.t.sol
+++ b/test/L1/SuperchainConfig.t.sol
@@ -195,6 +195,23 @@ contract SuperchainConfig_Extend_Test is SuperchainConfig_TestInit {
         );
         superchainConfig.extend(_identifier);
     }
+
+    /// @notice Tests that `extend` cannot re-activate an expired pause.
+    function test_extend_expiredPause_reverts() external {
+        _pauseAsGuardian(address(this));
+        vm.warp(block.timestamp + PAUSE_EXPIRY + 1);
+
+        assertFalse(superchainConfig.paused(address(this)));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ISuperchainConfig.SuperchainConfig_NotAlreadyPaused.selector,
+                address(this)
+            )
+        );
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.extend(address(this));
+    }
 }
 
 /// @title SuperchainConfig_Pausable_Test


### PR DESCRIPTION
## Summary

- Prevent `SuperchainConfig.extend()` from re-activating an expired pause.
- - Require the identifier to remain actively paused before extending it.
- - Add a regression test covering the expired-pause path.
Closes #391 

## Validation

- `git diff --check`
- - Foundry tests were unavailable in the sandbox because `forge` is not installed.