### PR TITLE
fix(L1): freeze schedule changes within sequencer drift of activation

### DIFF
--- a/interfaces/L1/IProtocolVersions.sol
+++ b/interfaces/L1/IProtocolVersions.sol
@@ -30,7 +30,7 @@ interface IProtocolVersions is IProxyAdminOwnedBase, ISemver, IReinitializableBa
     error ProtocolVersions_NotInitialized();
     error ProtocolVersions_InsufficientNotice(uint64 timestamp);
 
-    function initialize(address _incidentResponder) external;
+    function initialize(address _incidentResponder, uint64[] calldata _initialSchedule) external;
     function registerUpgrade(uint64 timestamp, uint256 minProtocolVersion) external returns (uint256);
     function setMinimumProtocolVersion(uint256 protocolVersion) external;
     function setTimestamp(uint256 id, uint64 timestamp) external;

--- a/interfaces/L1/IProtocolVersions.sol
+++ b/interfaces/L1/IProtocolVersions.sol
@@ -18,6 +18,7 @@ interface IProtocolVersions is IProxyAdminOwnedBase, ISemver, IReinitializableBa
     error ProtocolVersions_UnknownUpgrade(uint256 id);
     error ProtocolVersions_InvalidProtocolVersion();
     error ProtocolVersions_ActivationAlreadyPassed(uint256 id, uint64 activationTimestamp);
+    error ProtocolVersions_ActivationFrozen(uint256 id, uint64 activationTimestamp);
     error ProtocolVersions_NotIncidentResponder();
     error ProtocolVersions_NotScheduled(uint256 id);
     error ProtocolVersions_DelayMustBeLater(uint64 currentTimestamp, uint64 newTimestamp);
@@ -37,6 +38,7 @@ interface IProtocolVersions is IProxyAdminOwnedBase, ISemver, IReinitializableBa
     function delayTimestamp(uint256 id, uint64 newTimestamp) external;
 
     function MIN_NOTICE() external view returns (uint64);
+    function FREEZE_WINDOW() external view returns (uint64);
     function minimumProtocolVersion() external view returns (uint256);
     function incidentResponder() external view returns (address);
     function scheduleId() external view returns (bytes32);

--- a/scripts/deploy/DeployConfig.s.sol
+++ b/scripts/deploy/DeployConfig.s.sol
@@ -62,6 +62,14 @@ contract DeployConfig is Script {
     uint256 public sequencerFeeVaultMinimumWithdrawalAmount;
     uint256 public sequencerFeeVaultWithdrawalNetwork;
 
+    uint64[] internal _protocolVersionsInitialSchedule;
+
+    /// @notice The chain's existing hardfork activation timestamps, used to seed `ProtocolVersions`.
+    /// @dev Chains with no upgrade history leave this unset and start with an empty registry.
+    function protocolVersionsInitialSchedule() public view returns (uint64[] memory) {
+        return _protocolVersionsInitialSchedule;
+    }
+
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
         string memory _json = vm.readFile(_path);
@@ -116,6 +124,20 @@ contract DeployConfig is Script {
         respectedGameType = _json.readUintOr("$.respectedGameType", 0);
         sequencerFeeVaultMinimumWithdrawalAmount = _json.readUint("$.sequencerFeeVaultMinimumWithdrawalAmount");
         sequencerFeeVaultWithdrawalNetwork = _json.readUint("$.sequencerFeeVaultWithdrawalNetwork");
+
+        _readProtocolVersionsInitialSchedule(_json);
+    }
+
+    /// @dev Read separately so a rerun of `read` replaces the previous schedule rather than appending
+    ///      to it, and so an out-of-range timestamp fails loudly instead of silently truncating.
+    function _readProtocolVersionsInitialSchedule(string memory _json) internal {
+        uint256[] memory schedule = _json.readUintArrayOr("$.protocolVersionsInitialSchedule", new uint256[](0));
+
+        delete _protocolVersionsInitialSchedule;
+        for (uint256 i = 0; i < schedule.length; i++) {
+            require(schedule[i] <= type(uint64).max, "DeployConfig: initial schedule timestamp exceeds uint64");
+            _protocolVersionsInitialSchedule.push(uint64(schedule[i]));
+        }
     }
 
     /// @notice Allow the `useUpgradedFork` config to be overridden in testing environments

--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -307,7 +307,8 @@ contract SystemDeploy is Script {
                 root: Hash.wrap(cfg.multiproofGenesisOutputRoot()), l2SequenceNumber: cfg.multiproofGenesisBlockNumber()
             }),
             saltMixer: "salt mixer",
-            gasLimit: uint64(cfg.l2GenesisBlockGasLimit())
+            gasLimit: uint64(cfg.l2GenesisBlockGasLimit()),
+            initialUpgradeSchedule: cfg.protocolVersionsInitialSchedule()
         });
     }
 
@@ -643,7 +644,9 @@ contract SystemDeploy is Script {
             _output.opChainProxyAdmin,
             address(_output.protocolVersionsProxy),
             _impls.protocolVersionsImpl,
-            abi.encodeCall(IProtocolVersions.initialize, (_input.roles.incidentResponder, new uint64[](0)))
+            abi.encodeCall(
+                IProtocolVersions.initialize, (_input.roles.incidentResponder, _input.initialUpgradeSchedule)
+            )
         );
     }
 

--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -636,11 +636,14 @@ contract SystemDeploy is Script {
             _encodeAnchorStateRegistryInitializer(_input, _output)
         );
 
+        // Fresh systems start with no upgrade history. A chain that already has one imports it by
+        // passing its activation timestamps here, which is the only way to enter activations that
+        // cannot clear MIN_NOTICE.
         _upgradeToAndCall(
             _output.opChainProxyAdmin,
             address(_output.protocolVersionsProxy),
             _impls.protocolVersionsImpl,
-            abi.encodeCall(IProtocolVersions.initialize, (_input.roles.incidentResponder))
+            abi.encodeCall(IProtocolVersions.initialize, (_input.roles.incidentResponder, new uint64[](0)))
         );
     }
 

--- a/scripts/libraries/Types.sol
+++ b/scripts/libraries/Types.sol
@@ -32,6 +32,10 @@ library Types {
     }
 
     /// @notice The full set of inputs to deploy a new OP Stack chain.
+    /// @custom:field initialUpgradeSchedule The chain's hardfork activation timestamps, one entry per
+    ///              upgrade in the node's fork order, zero for unscheduled ones. Seeds
+    ///              `ProtocolVersions` at initialization, which is the only way to enter
+    ///              activations that are already in the past.
     struct DeployInput {
         Roles roles;
         uint32 basefeeScalar;
@@ -40,6 +44,7 @@ library Types {
         Proposal startingAnchorRoot;
         string saltMixer;
         uint64 gasLimit;
+        uint64[] initialUpgradeSchedule;
     }
 
     /// @notice The full set of outputs from deploying a new OP Stack chain.

--- a/scripts/multiproof/DeployDevBase.s.sol
+++ b/scripts/multiproof/DeployDevBase.s.sol
@@ -109,7 +109,7 @@ abstract contract DeployDevBase is Script {
 
         Proxy protocolVersionsProxy = new Proxy(msg.sender);
         protocolVersionsProxy.upgradeToAndCall(
-            address(new ProtocolVersions()), abi.encodeCall(IProtocolVersions.initialize, (address(0)))
+            address(new ProtocolVersions()), abi.encodeCall(IProtocolVersions.initialize, (address(0), new uint64[](0)))
         );
         protocolVersionsProxy.changeAdmin(address(proxyAdmin));
 

--- a/scripts/multiproof/DeployDevBase.s.sol
+++ b/scripts/multiproof/DeployDevBase.s.sol
@@ -109,7 +109,8 @@ abstract contract DeployDevBase is Script {
 
         Proxy protocolVersionsProxy = new Proxy(msg.sender);
         protocolVersionsProxy.upgradeToAndCall(
-            address(new ProtocolVersions()), abi.encodeCall(IProtocolVersions.initialize, (address(0), new uint64[](0)))
+            address(new ProtocolVersions()),
+            abi.encodeCall(IProtocolVersions.initialize, (address(0), cfg.protocolVersionsInitialSchedule()))
         );
         protocolVersionsProxy.changeAdmin(address(proxyAdmin));
 

--- a/scripts/multiproof/README.md
+++ b/scripts/multiproof/README.md
@@ -47,6 +47,7 @@ Other relevant fields:
 | `multiproofGameType`           | Game type ID for the dispute game                                                 |
 | `multiproofGenesisOutputRoot`  | Initial anchor output root                                                        |
 | `multiproofGenesisBlockNumber` | Initial anchor L2 block number                                                    |
+| `protocolVersionsInitialSchedule` | Hardfork activation timestamps in the node's fork order, `0` for unscheduled forks. Omit for a chain with no history; past activations cannot be added after deployment |
 
 ### Step 2: Deploy contracts
 

--- a/snapshots/abi/ProtocolVersions.json
+++ b/snapshots/abi/ProtocolVersions.json
@@ -112,6 +112,11 @@
         "internalType": "address",
         "name": "_incidentResponder",
         "type": "address"
+      },
+      {
+        "internalType": "uint64[]",
+        "name": "_initialSchedule",
+        "type": "uint64[]"
       }
     ],
     "name": "initialize",

--- a/snapshots/abi/ProtocolVersions.json
+++ b/snapshots/abi/ProtocolVersions.json
@@ -6,6 +6,19 @@
   },
   {
     "inputs": [],
+    "name": "FREEZE_WINDOW",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "MIN_NOTICE",
     "outputs": [
       {
@@ -362,6 +375,22 @@
       }
     ],
     "name": "ProtocolVersions_ActivationAlreadyPassed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "activationTimestamp",
+        "type": "uint64"
+      }
+    ],
+    "name": "ProtocolVersions_ActivationFrozen",
     "type": "error"
   },
   {

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -16,8 +16,8 @@
     "sourceCodeHash": "0x811596e7486cab9ceeeb61405b9ae510d93fcbbdfa11949201a367506c53194a"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
-    "initCodeHash": "0xd762af325410baea14f927f4292ef9ee2bb13b52d72034d6d129eb1e518dfedd",
-    "sourceCodeHash": "0x5a06b3ae5f442f3e3f3dba6f78b9c3e3ce5abd7218ccb13d477c067f61187dc5"
+    "initCodeHash": "0x3571bc9a5b3b18981e42faa5c373bfc8216af8da8c715faa522f76b4f7da1d8e",
+    "sourceCodeHash": "0x768e68644f04cab215e23530bba1916d82647ecd8330c841ac32ee29cf15fde7"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -16,8 +16,8 @@
     "sourceCodeHash": "0x811596e7486cab9ceeeb61405b9ae510d93fcbbdfa11949201a367506c53194a"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
-    "initCodeHash": "0x3571bc9a5b3b18981e42faa5c373bfc8216af8da8c715faa522f76b4f7da1d8e",
-    "sourceCodeHash": "0x768e68644f04cab215e23530bba1916d82647ecd8330c841ac32ee29cf15fde7"
+    "initCodeHash": "0x746f2c953680f6675e13be55678f546e9779b3903b385399cdc8890e7c46ec64",
+    "sourceCodeHash": "0xffe5ecd626c4895d336f696e679063711a2846f1f59c677aff9eb8dc35ac3dfb"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -118,10 +118,26 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         _disableInitializers();
     }
 
-    /// @notice Initializes the registry by seeding the hash chain and appointing the initial
-    ///         incidentResponder. Callable only by the ProxyAdmin or its owner.
+    /// @notice Initializes the registry by seeding the hash chain, importing any preexisting upgrade
+    ///         schedule, and appointing the initial incidentResponder. Callable only by the
+    ///         ProxyAdmin or its owner.
+    /// @dev `_initialSchedule` is the only path that can enter an activation which is not at least
+    ///      MIN_NOTICE in the future. It exists so a chain that already has a hardfork history can be
+    ///      represented faithfully at deployment, while it is still impossible for any proof game to
+    ///      have pinned a commitment from this registry. Every later write goes through
+    ///      `registerUpgrade`, `setTimestamp`, or `delayTimestamp`, which together guarantee that an
+    ///      activation is never created or moved once L1 is within FREEZE_WINDOW of it.
     /// @param _incidentResponder Initial incidentResponder allowed to delay activations, or address(0) to leave unset.
-    function initialize(address _incidentResponder) external reinitializer(initVersion()) {
+    /// @param _initialSchedule   Activation timestamps for already-known upgrades, ordered by ascending
+    ///                           upgrade id, using 0 for an upgrade that is registered but unscheduled.
+    ///                           Pass an empty array for a chain with no upgrade history.
+    function initialize(
+        address _incidentResponder,
+        uint64[] calldata _initialSchedule
+    )
+        external
+        reinitializer(initVersion())
+    {
         // Initialization transactions must come from the ProxyAdmin or its owner.
         _assertOnlyProxyAdminOrProxyAdminOwner();
 
@@ -129,7 +145,20 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         // `scheduleId` and `_refreshScheduleId` avoid an empty-registry special case, and makes a
         // non-empty array double as the "initialized" flag.
         _upgradeScheduleId.push(bytes32(0));
-        emit ScheduleIdUpdated(bytes32(0));
+
+        for (uint256 id = 0; id < _initialSchedule.length; id++) {
+            uint64 timestamp = _initialSchedule[id];
+            // `id` is the index about to be appended, so this reads only the entries already imported.
+            _assertTimestampAfterPrevious(id, timestamp);
+            _timestamps.push(timestamp);
+            _upgradeScheduleId.push();
+            emit UpgradeRegistered(id);
+            if (timestamp != 0) emit TimestampSet(id, timestamp);
+        }
+
+        // Builds the same chain the equivalent sequence of `registerUpgrade` calls would, in one
+        // pass. With an empty import this just re-emits the seed as the current commitment.
+        _refreshScheduleId(0);
 
         incidentResponder = _incidentResponder;
         emit IncidentResponderUpdated(address(0), _incidentResponder);
@@ -139,8 +168,12 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     ///         activation and bumping the minimum protocol version in the same call. ProxyAdmin owner only.
     /// @dev Pass `timestamp` 0 to register without scheduling (schedule later via `setTimestamp`), or
     ///      a non-zero value to register and schedule at once. Either way registration extends the
-    ///      scheduleId chain with the new upgrade's link.
-    /// @param timestamp Unix activation timestamp, or 0 to leave the upgrade unscheduled.
+    ///      scheduleId chain with the new upgrade's link. A non-zero value must clear MIN_NOTICE, the
+    ///      same floor `setTimestamp` applies: appending an activation that L1 is already within
+    ///      FREEZE_WINDOW of would change `activatedScheduleId` for L2 timestamps the sequencer may
+    ///      already have produced, which is exactly what the freeze exists to prevent.
+    /// @param timestamp Unix activation timestamp (must be >= block.timestamp + MIN_NOTICE), or 0 to
+    ///                  leave the upgrade unscheduled.
     /// @param minProtocolVersion New minimum protocol version to set at registration, or 0 to leave
     ///                  the current minimum unchanged. Must fit in 128 bits if non-zero.
     /// @return The ascending id assigned to the newly registered upgrade.
@@ -148,6 +181,9 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         _assertOnlyProxyAdminOwner();
         if (_upgradeScheduleId.length == 0) revert ProtocolVersions_NotInitialized();
         uint256 id = _timestamps.length;
+        if (timestamp != 0 && timestamp < uint64(block.timestamp) + MIN_NOTICE) {
+            revert ProtocolVersions_InsufficientNotice(timestamp);
+        }
         _assertTimestampAfterPrevious(id, timestamp);
         _timestamps.push(0);
         // Reserve the link slot for this upgrade at index id + 1.

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -41,6 +41,14 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     /// @notice Minimum notice period required when changing a preexisting activation timestamp.
     uint64 public constant MIN_NOTICE = 1 hours;
 
+    /// @notice Window before a scheduled activation during which that timestamp can no longer change.
+    /// @dev Sized to the post-Fjord maximum sequencer drift: an L2 block may carry a timestamp up to
+    ///      1800 seconds ahead of its L1 origin, so from L1 time `activation - FREEZE_WINDOW` onwards
+    ///      the sequencer can already have produced the block that activates the upgrade. Freezing at
+    ///      that point makes L1's answer to "was this upgrade active at a given L2 timestamp" final
+    ///      before any L2 block can depend on it, rather than leaving it mutable until activation.
+    uint64 public constant FREEZE_WINDOW = 30 minutes;
+
     /// @notice Activation timestamp for each registered upgrade, indexed by upgrade id (0 = not scheduled).
     ///         An upgrade id is registered iff it is a valid index into this array.
     /// @dev Every loop in this contract iterates this array. Its length is deliberately uncapped: it only
@@ -84,6 +92,8 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     error ProtocolVersions_InvalidProtocolVersion();
     /// @notice Thrown when modifying a timestamp whose activation has already passed.
     error ProtocolVersions_ActivationAlreadyPassed(uint256 id, uint64 activationTimestamp);
+    /// @notice Thrown when modifying a timestamp that is within FREEZE_WINDOW of its activation.
+    error ProtocolVersions_ActivationFrozen(uint256 id, uint64 activationTimestamp);
     /// @notice Thrown when the caller is not the incidentResponder.
     error ProtocolVersions_NotIncidentResponder();
     /// @notice Thrown when delaying an upgrade that has no scheduled activation.
@@ -171,9 +181,10 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     }
 
     /// @notice Sets the activation timestamp for one upgrade by id. Pass 0 to clear.
-    /// @dev The activation timestamp must be at least MIN_NOTICE seconds in the future and the
-    ///      upgrade must not have already activated. Pass 0 to remove a not-yet-activated scheduled
-    ///      timestamp; reverts if the upgrade has already passed its activation time.
+    /// @dev The activation timestamp must be at least MIN_NOTICE seconds in the future, and any
+    ///      preexisting activation must still be more than FREEZE_WINDOW away. Pass 0 to remove a
+    ///      scheduled timestamp; reverts if the upgrade has already activated or is inside its
+    ///      freeze window.
     /// @param id         The upgrade to schedule.
     /// @param timestamp  Future Unix timestamp for L2 activation (must be >= block.timestamp + MIN_NOTICE), or 0 to
     /// clear.
@@ -182,9 +193,7 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         _assertRegistered(id);
         uint64 current = _timestamps[id];
         if (current == timestamp) return;
-        if (current != 0 && uint64(block.timestamp) >= current) {
-            revert ProtocolVersions_ActivationAlreadyPassed(id, current);
-        }
+        if (current != 0) _assertNotFrozen(id, current);
         if (timestamp != 0 && timestamp < uint64(block.timestamp) + MIN_NOTICE) {
             revert ProtocolVersions_InsufficientNotice(timestamp);
         }
@@ -206,11 +215,11 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
 
     /// @notice Pushes an already-scheduled upgrade's activation timestamp further into the future.
     ///         Can only be called by the incidentResponder.
-    /// @dev The upgrade must already have a non-zero activation timestamp that has not yet passed,
-    ///      and `newTimestamp` must be strictly later than the current value. This role can only
-    ///      delay an activation; it cannot pull one earlier, clear it, or schedule a new one — use
-    ///      the owner's `setTimestamp` for those. Because `current` is in the future and `newTimestamp`
-    ///      is later still, the new value is always in the future.
+    /// @dev The upgrade must already have a non-zero activation timestamp that is still more than
+    ///      FREEZE_WINDOW away, and `newTimestamp` must be strictly later than the current value.
+    ///      This role can only delay an activation; it cannot pull one earlier, clear it, or schedule
+    ///      a new one — use the owner's `setTimestamp` for those. Because `current` is in the future
+    ///      and `newTimestamp` is later still, the new value is always in the future.
     /// @param id            The upgrade whose activation to delay.
     /// @param newTimestamp  New activation timestamp, must be strictly later than the current one.
     function delayTimestamp(uint256 id, uint64 newTimestamp) external {
@@ -220,8 +229,8 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
 
         // The upgrade must already have a scheduled activation to delay.
         if (current == 0) revert ProtocolVersions_NotScheduled(id);
-        // Cannot delay an activation that has already passed.
-        if (uint64(block.timestamp) >= current) revert ProtocolVersions_ActivationAlreadyPassed(id, current);
+        // Cannot delay an activation that has passed or is already inside its freeze window.
+        _assertNotFrozen(id, current);
         // The role can only push the activation later, never to the same time or earlier.
         if (newTimestamp <= current) revert ProtocolVersions_DelayMustBeLater(current, newTimestamp);
         // The new timestamp must also provide at least MIN_NOTICE seconds of notice from now.
@@ -314,6 +323,13 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         }
 
         emit ScheduleIdUpdated(prev);
+    }
+
+    /// @dev Requires upgrade `id`'s scheduled activation to still be more than FREEZE_WINDOW away,
+    ///      which is the point past which an L2 block carrying that activation may already exist.
+    function _assertNotFrozen(uint256 id, uint64 current) private view {
+        if (uint64(block.timestamp) >= current) revert ProtocolVersions_ActivationAlreadyPassed(id, current);
+        if (uint64(block.timestamp) + FREEZE_WINDOW >= current) revert ProtocolVersions_ActivationFrozen(id, current);
     }
 
     /// @dev Prevents scheduling a zero-valued hole once a later upgrade has a timestamp.

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -561,6 +561,32 @@ contract ProtocolVersions_SetTimestamp_Test is ProtocolVersions_TestInit {
         protocolVersions.setTimestamp(CANYON, laterTs);
     }
 
+    /// @notice Tests that a scheduled activation can no longer be cleared once L1 is within
+    ///         FREEZE_WINDOW of it, which is the point from which an L2 block carrying that
+    ///         activation may already exist.
+    function test_setTimestamp_insideFreezeWindow_reverts() external {
+        uint64 ts = _scheduleCanyon(100);
+
+        vm.warp(ts - protocolVersions.FREEZE_WINDOW());
+        vm.expectRevert(
+            abi.encodeWithSelector(IProtocolVersions.ProtocolVersions_ActivationFrozen.selector, CANYON, ts)
+        );
+        vm.prank(_owner);
+        protocolVersions.setTimestamp(CANYON, 0);
+    }
+
+    /// @notice Tests that the freeze boundary is exact: one second before it, the activation is
+    ///         still clearable.
+    function test_setTimestamp_justBeforeFreezeWindow_succeeds() external {
+        uint64 ts = _scheduleCanyon(100);
+
+        vm.warp(ts - protocolVersions.FREEZE_WINDOW() - 1);
+        vm.prank(_owner);
+        protocolVersions.setTimestamp(CANYON, 0);
+
+        assertEq(protocolVersions.getSchedule()[CANYON], 0);
+    }
+
     /// @notice Tests that `setTimestamp` reverts for an unregistered upgrade.
     function test_setTimestamp_unregisteredUpgrade_reverts() external {
         uint64 ts = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
@@ -696,6 +722,22 @@ contract ProtocolVersions_DelayTimestamp_Test is ProtocolVersions_TestInit {
         );
         vm.prank(_incidentResponder);
         protocolVersions.delayTimestamp(CANYON, ts + 100);
+    }
+
+    /// @notice Tests that the incidentResponder also loses the ability to move an activation once
+    ///         L1 is within FREEZE_WINDOW of it.
+    function test_delayTimestamp_insideFreezeWindow_reverts() external {
+        uint64 ts = _scheduleCanyon(100);
+        vm.prank(_owner);
+        protocolVersions.setIncidentResponder(_incidentResponder);
+
+        uint64 later = ts + protocolVersions.MIN_NOTICE();
+        vm.warp(ts - protocolVersions.FREEZE_WINDOW());
+        vm.expectRevert(
+            abi.encodeWithSelector(IProtocolVersions.ProtocolVersions_ActivationFrozen.selector, CANYON, ts)
+        );
+        vm.prank(_incidentResponder);
+        protocolVersions.delayTimestamp(CANYON, later);
     }
 
     /// @notice Tests that `delayTimestamp` reverts for an unregistered upgrade.

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -44,6 +44,20 @@ abstract contract ProtocolVersions_TestInit is CommonTest {
         vm.prank(_owner);
         protocolVersions.setTimestamp(CANYON, ts_);
     }
+
+    /// @dev Deploys a fresh uninitialized proxy over the impl produced by SystemDeploy, for the
+    ///      tests that genuinely need one: the initializer edge cases and any schedule that has to
+    ///      be imported rather than registered. proxyAdminOwner() resolves by calling owner() on the
+    ///      ProxyAdmin stored in the proxy slot, so the mock provides one.
+    function _deployUninitializedProxy() internal returns (IProtocolVersions) {
+        address proxyAdmin = makeAddr("proxy-admin");
+        vm.mockCall(proxyAdmin, abi.encodeWithSignature("owner()"), abi.encode(_owner));
+        Proxy proxy = new Proxy(proxyAdmin);
+        address impl = EIP1967Helper.getImplementation(address(protocolVersions));
+        vm.prank(proxyAdmin);
+        proxy.upgradeTo(impl);
+        return IProtocolVersions(address(proxy));
+    }
 }
 
 /// @title ProtocolVersions_Initialize_Test
@@ -66,7 +80,7 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
         vm.expectEmit(true, true, false, false, address(uninitialized));
         emit IncidentResponderUpdated(address(0), _incidentResponder);
         vm.prank(EIP1967Helper.getAdmin(address(uninitialized)));
-        uninitialized.initialize(_incidentResponder);
+        uninitialized.initialize(_incidentResponder, new uint64[](0));
         assertEq(uninitialized.incidentResponder(), _incidentResponder);
     }
 
@@ -76,34 +90,66 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
         IProtocolVersions uninitialized = _deployUninitializedProxy();
         vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
         vm.prank(_nonOwner);
-        uninitialized.initialize(_incidentResponder);
+        uninitialized.initialize(_incidentResponder, new uint64[](0));
+    }
+
+    /// @notice Tests that the initializer imports a preexisting schedule, building the same hash
+    ///         chain the equivalent sequence of registrations would have.
+    function test_initialize_importsSchedule_succeeds() external {
+        uint64[] memory schedule = new uint64[](3);
+        schedule[0] = 10;
+        schedule[1] = 0;
+        schedule[2] = 30;
+
+        IProtocolVersions imported = _deployUninitializedProxy();
+        vm.prank(EIP1967Helper.getAdmin(address(imported)));
+        imported.initialize(_incidentResponder, schedule);
+
+        uint64[] memory stored = imported.getSchedule();
+        assertEq(stored.length, schedule.length);
+        assertEq(stored[0], schedule[0]);
+        assertEq(stored[1], schedule[1]);
+        assertEq(stored[2], schedule[2]);
+
+        bytes32 link0 = keccak256(abi.encode(bytes32(0), uint256(0), uint64(10)));
+        bytes32 link1 = keccak256(abi.encode(link0, uint256(1), uint64(0)));
+        bytes32 link2 = keccak256(abi.encode(link1, uint256(2), uint64(30)));
+        assertEq(imported.scheduleId(0), link0);
+        assertEq(imported.scheduleId(), link2);
+    }
+
+    /// @notice Tests that an imported schedule is held to the same ordering rule as registration.
+    function test_initialize_importUnorderedSchedule_reverts() external {
+        uint64[] memory schedule = new uint64[](2);
+        schedule[0] = 30;
+        schedule[1] = 10;
+
+        IProtocolVersions imported = _deployUninitializedProxy();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IProtocolVersions.ProtocolVersions_TimestampNotAfterPrevious.selector,
+                ECOTONE,
+                CANYON,
+                uint64(30),
+                uint64(10)
+            )
+        );
+        vm.prank(EIP1967Helper.getAdmin(address(imported)));
+        imported.initialize(address(0), schedule);
     }
 
     /// @notice Tests that the contract cannot be initialized twice.
     function test_initialize_alreadyInitialized_reverts() external {
         vm.expectRevert("Initializable: contract is already initialized");
         vm.prank(EIP1967Helper.getAdmin(address(protocolVersions)));
-        protocolVersions.initialize(address(0));
+        protocolVersions.initialize(address(0), new uint64[](0));
     }
 
     /// @notice Tests that the implementation itself cannot be initialized (initializers disabled).
     function test_initialize_implementationDisabled_reverts() external {
         IProtocolVersions impl = IProtocolVersions(EIP1967Helper.getImplementation(address(protocolVersions)));
         vm.expectRevert("Initializable: contract is already initialized");
-        impl.initialize(address(0));
-    }
-
-    /// @dev Deploys a fresh uninitialized proxy over the impl produced by SystemDeploy for the two
-    ///      initializer tests that genuinely need one. proxyAdminOwner() resolves by calling owner()
-    ///      on the ProxyAdmin stored in the proxy slot, so the mock provides one.
-    function _deployUninitializedProxy() internal returns (IProtocolVersions) {
-        address proxyAdmin = makeAddr("proxy-admin");
-        vm.mockCall(proxyAdmin, abi.encodeWithSignature("owner()"), abi.encode(_owner));
-        Proxy proxy = new Proxy(proxyAdmin);
-        address impl = EIP1967Helper.getImplementation(address(protocolVersions));
-        vm.prank(proxyAdmin);
-        proxy.upgradeTo(impl);
-        return IProtocolVersions(address(proxy));
+        impl.initialize(address(0), new uint64[](0));
     }
 }
 
@@ -176,18 +222,48 @@ contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
         assertNotEq(protocolVersions.scheduleId(), bytes32(0));
     }
 
-    /// @notice Tests that registering with a timestamp inside the notice window succeeds — the
-    ///         notice period is not enforced at registration, only via `setTimestamp`/`delayTimestamp`.
-    function test_registerUpgrade_shortNotice_succeeds() external {
+    /// @notice Tests that registration is held to the same notice floor as `setTimestamp`. Appending
+    ///         an activation that L1 is already close to would move `activatedScheduleId` for L2
+    ///         timestamps the sequencer may already have produced, which is what FREEZE_WINDOW
+    ///         prevents on the paths that change an existing activation.
+    function test_registerUpgrade_insufficientNotice_reverts() external {
         uint64 ts = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() - 1;
+        vm.expectRevert(abi.encodeWithSelector(IProtocolVersions.ProtocolVersions_InsufficientNotice.selector, ts));
         vm.prank(_owner);
         protocolVersions.registerUpgrade(ts, 0);
-        assertEq(protocolVersions.getSchedule()[CANYON], ts);
+    }
+
+    /// @notice Tests that registering without a timestamp stays unconstrained: a zero entry is
+    ///         skipped by `activatedScheduleId`, so it cannot move an already-reachable answer.
+    function test_registerUpgrade_zeroTimestampSkipsNotice_succeeds() external {
+        vm.prank(_owner);
+        assertEq(protocolVersions.registerUpgrade(0, 0), CANYON);
+        assertEq(protocolVersions.getSchedule()[CANYON], 0);
+    }
+
+    /// @notice Tests the property the notice floor exists to protect: an append cannot change the
+    ///         commitment for an L2 timestamp the sequencer may already have produced, and an
+    ///         append that clears the floor lands above every such timestamp.
+    function test_registerUpgrade_cannotMoveReachableSchedule_reverts() external {
+        uint64 reachable = uint64(block.timestamp) + protocolVersions.FREEZE_WINDOW();
+        uint64 allowed = uint64(block.timestamp) + protocolVersions.MIN_NOTICE();
+        bytes32 settled = protocolVersions.activatedScheduleId(reachable);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IProtocolVersions.ProtocolVersions_InsufficientNotice.selector, reachable)
+        );
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(reachable, 0);
+
+        vm.prank(_owner);
+        protocolVersions.registerUpgrade(allowed, 0);
+
+        assertEq(protocolVersions.activatedScheduleId(reachable), settled);
     }
 
     /// @notice Tests that a scheduled registration may share the previous scheduled upgrade's timestamp.
     function test_registerUpgrade_timestampEqualToPrevious_succeeds() external {
-        uint64 first = uint64(block.timestamp) + 100;
+        uint64 first = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
         uint64 second = first;
 
         vm.prank(_owner);
@@ -202,7 +278,7 @@ contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
 
     /// @notice Tests that zero remains the unscheduled/disabled value and is exempt from ordering.
     function test_registerUpgrade_zeroTimestampAfterScheduledPrevious_succeeds() external {
-        uint64 first = uint64(block.timestamp) + 100;
+        uint64 first = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
 
         vm.prank(_owner);
         assertEq(protocolVersions.registerUpgrade(first, 0), CANYON);
@@ -216,7 +292,7 @@ contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
 
     /// @notice Tests that scheduled registration scans past zero holes to the previous timestamp.
     function test_registerUpgrade_timestampAfterPreviousSkipsZeroHoles_succeeds() external {
-        uint64 first = uint64(block.timestamp) + 100;
+        uint64 first = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
         uint64 second = first + 1;
 
         vm.startPrank(_owner);
@@ -233,7 +309,7 @@ contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
 
     /// @notice Tests that registering a timestamp before the previous scheduled upgrade reverts.
     function test_registerUpgrade_timestampNotAfterPrevious_reverts() external {
-        uint64 first = uint64(block.timestamp) + 100;
+        uint64 first = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
 
         vm.prank(_owner);
         protocolVersions.registerUpgrade(first, 0);
@@ -849,9 +925,10 @@ contract ProtocolVersions_ActivatedScheduleId_Test is ProtocolVersions_TestInit 
     function test_activatedScheduleId_noneActivated_returnsSeed() external {
         assertEq(protocolVersions.activatedScheduleId(uint64(block.timestamp)), bytes32(0));
 
+        uint64 future = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
         vm.startPrank(_owner);
         protocolVersions.registerUpgrade(0, 0);
-        protocolVersions.registerUpgrade(uint64(block.timestamp + 100), 0);
+        protocolVersions.registerUpgrade(future, 0);
         vm.stopPrank();
 
         assertEq(protocolVersions.activatedScheduleId(uint64(block.timestamp)), bytes32(0));
@@ -859,45 +936,46 @@ contract ProtocolVersions_ActivatedScheduleId_Test is ProtocolVersions_TestInit 
 
     /// @notice Activation is inclusive at the supplied L2 timestamp.
     function test_activatedScheduleId_boundaryInclusive_succeeds() external {
-        vm.prank(_owner);
-        protocolVersions.registerUpgrade(100, 0);
+        uint64[] memory schedule = new uint64[](1);
+        schedule[0] = 100;
+        IProtocolVersions imported = _importSchedule(schedule);
 
-        assertEq(protocolVersions.activatedScheduleId(99), bytes32(0));
-        assertEq(
-            protocolVersions.activatedScheduleId(100), keccak256(abi.encode(bytes32(0), uint256(CANYON), uint64(100)))
-        );
+        assertEq(imported.activatedScheduleId(99), bytes32(0));
+        assertEq(imported.activatedScheduleId(100), keccak256(abi.encode(bytes32(0), uint256(CANYON), uint64(100))));
     }
 
     /// @notice The commitment includes every registered entry through the highest active upgrade,
     ///         including a static zero-valued hole below it.
     function test_activatedScheduleId_commitsPrefixThroughHighestActive_succeeds() external {
-        vm.startPrank(_owner);
-        protocolVersions.registerUpgrade(10, 0);
-        protocolVersions.registerUpgrade(0, 0);
-        protocolVersions.registerUpgrade(30, 0);
-        vm.stopPrank();
+        uint64[] memory schedule = new uint64[](3);
+        schedule[0] = 10;
+        schedule[1] = 0;
+        schedule[2] = 30;
+        IProtocolVersions imported = _importSchedule(schedule);
 
         bytes32 link0 = keccak256(abi.encode(bytes32(0), uint256(0), uint64(10)));
         bytes32 link1 = keccak256(abi.encode(link0, uint256(1), uint64(0)));
         bytes32 link2 = keccak256(abi.encode(link1, uint256(2), uint64(30)));
 
-        assertEq(protocolVersions.activatedScheduleId(30), link2);
+        assertEq(imported.activatedScheduleId(30), link2);
     }
 
     /// @notice Appending unscheduled or future upgrades above the active prefix cannot move the
     ///         activated commitment selected by that prefix.
     function test_activatedScheduleId_stableAcrossAppendsAboveActivePrefix_succeeds() external {
-        vm.prank(_owner);
-        protocolVersions.registerUpgrade(10, 0);
-        bytes32 pinned = protocolVersions.activatedScheduleId(10);
+        uint64[] memory schedule = new uint64[](1);
+        schedule[0] = 10;
+        IProtocolVersions imported = _importSchedule(schedule);
+        bytes32 pinned = imported.activatedScheduleId(10);
 
+        uint64 future = uint64(block.timestamp) + imported.MIN_NOTICE();
         vm.startPrank(_owner);
-        protocolVersions.registerUpgrade(0, 0);
-        protocolVersions.registerUpgrade(100, 0);
+        imported.registerUpgrade(0, 0);
+        imported.registerUpgrade(future, 0);
         vm.stopPrank();
 
-        assertEq(protocolVersions.activatedScheduleId(10), pinned);
-        assertNotEq(protocolVersions.scheduleId(), pinned);
+        assertEq(imported.activatedScheduleId(10), pinned);
+        assertNotEq(imported.scheduleId(), pinned);
     }
 
     /// @notice Cross-implementation golden shared with Base's `ScheduleId` tests for the real Base
@@ -905,10 +983,10 @@ contract ProtocolVersions_ActivatedScheduleId_Test is ProtocolVersions_TestInit 
     ///         the prefix through id 11, including the static PectraBlobSchedule hole at id 7, and
     ///         excludes the unscheduled Cobalt placeholder at id 12.
     function test_activatedScheduleId_matchesBaseMainnetGoldenValue_succeeds() external {
-        _registerBaseMainnetStaticSchedule();
+        IProtocolVersions mainnet = _importBaseMainnetStaticSchedule();
 
         assertEq(
-            protocolVersions.activatedScheduleId(BASE_MAINNET_BERYL_TIMESTAMP),
+            mainnet.activatedScheduleId(BASE_MAINNET_BERYL_TIMESTAMP),
             0xadd4aa9bd3532969035a9543c16b8c7d71298e15836f0ac731fdd3eea552c6e2
         );
     }
@@ -917,10 +995,10 @@ contract ProtocolVersions_ActivatedScheduleId_Test is ProtocolVersions_TestInit 
     ///         The live tail commits to all 13 entries, including PectraBlobSchedule and Cobalt as
     ///         unscheduled zero-timestamp entries.
     function test_scheduleId_matchesBaseMainnetFullScheduleGoldenValue_succeeds() external {
-        _registerBaseMainnetStaticSchedule();
+        IProtocolVersions mainnet = _importBaseMainnetStaticSchedule();
 
-        assertEq(protocolVersions.scheduleId(), 0x5ee41f186b0a439783060587cfbb942f6f1d94ecc76376c9782580c943ff2b6d);
-        assertEq(protocolVersions.scheduleId(12), protocolVersions.scheduleId());
+        assertEq(mainnet.scheduleId(), 0x5ee41f186b0a439783060587cfbb942f6f1d94ecc76376c9782580c943ff2b6d);
+        assertEq(mainnet.scheduleId(12), mainnet.scheduleId());
     }
 
     uint64 private constant BASE_MAINNET_GENESIS_TIMESTAMP = 1_686_789_347;
@@ -935,21 +1013,34 @@ contract ProtocolVersions_ActivatedScheduleId_Test is ProtocolVersions_TestInit 
     uint64 private constant BASE_MAINNET_AZUL_TIMESTAMP = 1_779_991_200;
     uint64 private constant BASE_MAINNET_BERYL_TIMESTAMP = 1_782_410_400;
 
-    function _registerBaseMainnetStaticSchedule() private {
-        vm.startPrank(_owner);
-        protocolVersions.registerUpgrade(BASE_MAINNET_GENESIS_TIMESTAMP, 0);
-        protocolVersions.registerUpgrade(BASE_MAINNET_CANYON_TIMESTAMP, 0);
-        protocolVersions.registerUpgrade(BASE_MAINNET_DELTA_TIMESTAMP, 0);
-        protocolVersions.registerUpgrade(BASE_MAINNET_ECOTONE_TIMESTAMP, 0);
-        protocolVersions.registerUpgrade(BASE_MAINNET_FJORD_TIMESTAMP, 0);
-        protocolVersions.registerUpgrade(BASE_MAINNET_GRANITE_TIMESTAMP, 0);
-        protocolVersions.registerUpgrade(BASE_MAINNET_HOLOCENE_TIMESTAMP, 0);
-        protocolVersions.registerUpgrade(0, 0); // PectraBlobSchedule is unscheduled on Base mainnet.
-        protocolVersions.registerUpgrade(BASE_MAINNET_ISTHMUS_TIMESTAMP, 0);
-        protocolVersions.registerUpgrade(BASE_MAINNET_JOVIAN_TIMESTAMP, 0);
-        protocolVersions.registerUpgrade(BASE_MAINNET_AZUL_TIMESTAMP, 0);
-        protocolVersions.registerUpgrade(BASE_MAINNET_BERYL_TIMESTAMP, 0);
-        protocolVersions.registerUpgrade(0, 0); // Cobalt is unscheduled on Base mainnet.
-        vm.stopPrank();
+    /// @dev The real Base mainnet schedule is entirely in the past, so the initializer's import is
+    ///      the only path that can enter it. The resulting chain must match what the equivalent
+    ///      sequence of `registerUpgrade` calls would have produced, which these goldens pin.
+    function _importBaseMainnetStaticSchedule() private returns (IProtocolVersions) {
+        uint64[] memory schedule = new uint64[](13);
+        schedule[0] = BASE_MAINNET_GENESIS_TIMESTAMP;
+        schedule[1] = BASE_MAINNET_CANYON_TIMESTAMP;
+        schedule[2] = BASE_MAINNET_DELTA_TIMESTAMP;
+        schedule[3] = BASE_MAINNET_ECOTONE_TIMESTAMP;
+        schedule[4] = BASE_MAINNET_FJORD_TIMESTAMP;
+        schedule[5] = BASE_MAINNET_GRANITE_TIMESTAMP;
+        schedule[6] = BASE_MAINNET_HOLOCENE_TIMESTAMP;
+        schedule[7] = 0; // PectraBlobSchedule is unscheduled on Base mainnet.
+        schedule[8] = BASE_MAINNET_ISTHMUS_TIMESTAMP;
+        schedule[9] = BASE_MAINNET_JOVIAN_TIMESTAMP;
+        schedule[10] = BASE_MAINNET_AZUL_TIMESTAMP;
+        schedule[11] = BASE_MAINNET_BERYL_TIMESTAMP;
+        schedule[12] = 0; // Cobalt is unscheduled on Base mainnet.
+
+        return _importSchedule(schedule);
+    }
+
+    /// @dev These cases pin `activatedScheduleId` against activations that are already in the past,
+    ///      which only the initializer's import can produce.
+    function _importSchedule(uint64[] memory schedule) private returns (IProtocolVersions) {
+        IProtocolVersions imported = _deployUninitializedProxy();
+        vm.prank(EIP1967Helper.getAdmin(address(imported)));
+        imported.initialize(address(0), schedule);
+        return imported;
     }
 }

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -233,14 +233,6 @@ contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
         protocolVersions.registerUpgrade(ts, 0);
     }
 
-    /// @notice Tests that registering without a timestamp stays unconstrained: a zero entry is
-    ///         skipped by `activatedScheduleId`, so it cannot move an already-reachable answer.
-    function test_registerUpgrade_zeroTimestampSkipsNotice_succeeds() external {
-        vm.prank(_owner);
-        assertEq(protocolVersions.registerUpgrade(0, 0), CANYON);
-        assertEq(protocolVersions.getSchedule()[CANYON], 0);
-    }
-
     /// @notice Tests the property the notice floor exists to protect: an append cannot change the
     ///         commitment for an L2 timestamp the sequencer may already have produced, and an
     ///         append that clears the floor lands above every such timestamp.

--- a/test/L1/proofs/AggregateVerifier.t.sol
+++ b/test/L1/proofs/AggregateVerifier.t.sol
@@ -42,10 +42,13 @@ contract AggregateVerifierTest is BaseTest {
     function test_initialize_pinsScheduleId_succeeds() public {
         // The first game ends at L2 block 100, whose deterministic timestamp is 200. The first
         // upgrade is active there; the second is not.
-        protocolVersions.registerUpgrade(200, 1);
+        uint64[] memory schedule = new uint64[](2);
+        schedule[0] = 200;
+        schedule[1] = 300;
+        _importProtocolVersionsSchedule(schedule);
+
         bytes32 pinned = protocolVersions.activatedScheduleId(200);
         assertTrue(pinned != bytes32(0));
-        protocolVersions.registerUpgrade(300, 2);
         assertNotEq(protocolVersions.scheduleId(), pinned);
 
         // Even though the L1 clock has passed the second activation, the game's schedule is
@@ -61,8 +64,10 @@ contract AggregateVerifierTest is BaseTest {
 
         assertEq(game.scheduleId(), pinned);
 
-        // Move the live schedule after creation; the game's snapshot remains pinned.
-        protocolVersions.registerUpgrade(400, 3);
+        // Move the live schedule after creation; the game's snapshot remains pinned. A fresh
+        // registration now has to clear MIN_NOTICE, which is what keeps it clear of the L2
+        // timestamps the sequencer has already reached.
+        protocolVersions.registerUpgrade(uint64(block.timestamp) + protocolVersions.MIN_NOTICE(), 3);
         assertNotEq(protocolVersions.scheduleId(), pinned);
         assertEq(game.scheduleId(), pinned);
     }
@@ -70,7 +75,9 @@ contract AggregateVerifierTest is BaseTest {
     /// @notice Consecutive games on opposite sides of an L2 activation boundary pin different
     ///         schedule commitments.
     function test_initialize_scheduleChangesAtL2ActivationBoundary_succeeds() public {
-        protocolVersions.registerUpgrade(300, 1);
+        uint64[] memory schedule = new uint64[](1);
+        schedule[0] = 300;
+        _importProtocolVersionsSchedule(schedule);
 
         Claim firstClaim = _advanceL2BlockAndClaim();
         AggregateVerifier firstGame = _createAggregateVerifierGame(
@@ -99,7 +106,9 @@ contract AggregateVerifierTest is BaseTest {
         // The first game ends at L2 block 100, whose deterministic timestamp is 200. Scheduling the
         // upgrade there and leaving the L1 clock short of it is the window the finding exploits.
         uint64 activationTimestamp = uint64(BLOCK_INTERVAL * L2_BLOCK_TIME);
-        protocolVersions.registerUpgrade(activationTimestamp, 1);
+        uint64[] memory schedule = new uint64[](1);
+        schedule[0] = activationTimestamp;
+        _importProtocolVersionsSchedule(schedule);
         assertLt(block.timestamp, activationTimestamp);
 
         // Created straight through the factory, since the shared helper advances L1 to the claim.

--- a/test/L1/proofs/BaseTest.t.sol
+++ b/test/L1/proofs/BaseTest.t.sol
@@ -112,7 +112,17 @@ contract BaseTest is Test {
         );
         factory.initialize(address(this));
         delayedWETH.initialize(systemConfig);
-        protocolVersions.initialize(address(0));
+        protocolVersions.initialize(address(0), new uint64[](0));
+    }
+
+    /// @dev Rebuilds the schedule registry around a preset schedule and rebinds the verifier to it.
+    ///      These tests run on a compressed L2 timescale whose activations can never clear
+    ///      MIN_NOTICE, so a schedule has to be imported at initialization rather than registered.
+    ///      Must be called before any game is created, since games pin the registry they see.
+    function _importProtocolVersionsSchedule(uint64[] memory schedule) internal {
+        protocolVersions = ProtocolVersions(_deployProxy(address(new ProtocolVersions())));
+        protocolVersions.initialize(address(0), schedule);
+        _deployAndSetAggregateVerifier();
     }
 
     function _deployAndSetAggregateVerifier() internal {

--- a/test/deploy/DeployConfig.t.sol
+++ b/test/deploy/DeployConfig.t.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "lib/forge-std/src/Test.sol";
+
+import { DeployConfig } from "scripts/deploy/DeployConfig.s.sol";
+
+contract DeployConfigHarness is DeployConfig {
+    function readSchedule(string memory _json) public {
+        _readProtocolVersionsInitialSchedule(_json);
+    }
+}
+
+contract DeployConfig_Test is Test {
+    DeployConfigHarness internal cfg;
+
+    function setUp() public {
+        cfg = new DeployConfigHarness();
+    }
+
+    /// @notice The imported schedule is the only way a chain with existing hardfork history reaches
+    ///         `ProtocolVersions.initialize`, so a key that silently fails to parse would leave that
+    ///         chain permanently stuck with an empty registry.
+    function test_readSchedule_parsesTimestampsInOrder_succeeds() public {
+        cfg.readSchedule('{"protocolVersionsInitialSchedule":[1686789347,1704992401,0,1710374401]}');
+
+        uint64[] memory schedule = cfg.protocolVersionsInitialSchedule();
+        assertEq(schedule.length, 4);
+        assertEq(schedule[0], 1_686_789_347);
+        assertEq(schedule[1], 1_704_992_401);
+        assertEq(schedule[2], 0);
+        assertEq(schedule[3], 1_710_374_401);
+    }
+
+    function test_readSchedule_omitted_defaultsToEmpty_succeeds() public {
+        cfg.readSchedule('{"l1ChainId":1}');
+
+        assertEq(cfg.protocolVersionsInitialSchedule().length, 0);
+    }
+
+    /// @dev Config state is reused across reads, so a second read must replace rather than append.
+    function test_readSchedule_twice_replacesSchedule_succeeds() public {
+        cfg.readSchedule('{"protocolVersionsInitialSchedule":[1686789347,1704992401]}');
+        cfg.readSchedule('{"protocolVersionsInitialSchedule":[1710374401]}');
+
+        uint64[] memory schedule = cfg.protocolVersionsInitialSchedule();
+        assertEq(schedule.length, 1);
+        assertEq(schedule[0], 1_710_374_401);
+    }
+
+    function test_readSchedule_timestampAboveUint64_reverts() public {
+        vm.expectRevert("DeployConfig: initial schedule timestamp exceeds uint64");
+        cfg.readSchedule('{"protocolVersionsInitialSchedule":[18446744073709551616]}');
+    }
+
+    /// @notice The shipped configs describe chains without a recorded history, so they must keep
+    ///         producing an empty registry.
+    function test_read_localConfig_leavesScheduleEmpty_succeeds() public {
+        cfg.read("deploy-config/local.json");
+
+        assertEq(cfg.protocolVersionsInitialSchedule().length, 0);
+    }
+}

--- a/test/deploy/SystemDeploy.t.sol
+++ b/test/deploy/SystemDeploy.t.sol
@@ -154,6 +154,36 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
         assertValidStandardSystem(_expected(output, input));
     }
 
+    /// @notice A chain that already has a hardfork history has to seed the registry at deploy time.
+    ///         `registerUpgrade` cannot enter activations that are already in the past, and
+    ///         `initialize` runs once, so an empty import here would be permanent.
+    function test_deploy_seedsProtocolVersionsWithInitialSchedule_succeeds() public {
+        vm.warp(1_800_000_000);
+
+        uint64[] memory schedule = new uint64[](4);
+        schedule[0] = 1_686_789_347;
+        schedule[1] = 1_704_992_401;
+        schedule[2] = 0; // Unscheduled on this chain.
+        schedule[3] = 1_710_374_401;
+
+        SystemDeploy.DeployInput memory input = _defaultDeployInput();
+        input.opChainInput.initialUpgradeSchedule = schedule;
+
+        SystemDeploy.DeployOutput memory output = systemDeploy.deploy(input);
+
+        uint64[] memory imported = output.opChain.protocolVersionsProxy.getSchedule();
+        assertEq(imported.length, schedule.length, "schedule length");
+        for (uint256 i = 0; i < schedule.length; i++) {
+            assertEq(imported[i], schedule[i], "schedule entry");
+        }
+
+        assertEq(
+            address(AggregateVerifier(address(output.opChain.aggregateVerifier)).PROTOCOL_VERSIONS()),
+            address(output.opChain.protocolVersionsProxy),
+            "verifier bound to seeded registry"
+        );
+    }
+
     function test_deploy_multiproofDisabled_allowsUnsetL2BlockTime_succeeds() public {
         SystemDeploy.DeployInput memory input = _defaultDeployInput();
         input.implementationsInput.multiproofConfigHash = bytes32(0);
@@ -370,7 +400,8 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
             l2ChainId: l2ChainId,
             startingAnchorRoot: Proposal({ root: Hash.wrap(bytes32(uint256(1))), l2SequenceNumber: 0 }),
             saltMixer: "system-deploy-test",
-            gasLimit: 60_000_000
+            gasLimit: 60_000_000,
+            initialUpgradeSchedule: new uint64[](0)
         });
     }
 

--- a/test/vendor/Initializable.t.sol
+++ b/test/vendor/Initializable.t.sol
@@ -213,7 +213,7 @@ contract Initializer_Test is CommonTest {
         // ProtocolVersions is deployed by the standard deployment script but is absent on older
         // forked chains, so only track it when the proxy is present.
         if (address(protocolVersions) != address(0)) {
-            initCalldata = abi.encodeCall(protocolVersions.initialize, (address(0)));
+            initCalldata = abi.encodeCall(protocolVersions.initialize, (address(0), new uint64[](0)));
             contracts.push(
                 InitializeableContract({
                     name: "ProtocolVersionsImpl",


### PR DESCRIPTION
### What changed? Why?

- Freeze changes to an existing ProtocolVersions activation during the 30-minute post-Fjord sequencer-drift window. `setTimestamp` and `delayTimestamp` now reject mutations at or after `activationTimestamp - FREEZE_WINDOW`, preventing L1 from changing the schedule after an L2 block may already have activated it.
- Apply the existing one-hour `MIN_NOTICE` floor to non-zero `registerUpgrade` timestamps, so appending an upgrade cannot change the activated schedule for L2 timestamps that are already reachable.
- Allow ProtocolVersions to import a chain's existing upgrade schedule only during initialization. Standard and multiproof deployments source the optional `protocolVersionsInitialSchedule` deploy-config field and pass it into the initializer; omitted config retains an empty schedule.
- Update the ProtocolVersions ABI and semver snapshots for the initializer, freeze-window getter, and new frozen-activation error.

### Notes to reviewers

- Initial schedule import preserves the existing schedule-id hash chain and ordering checks, while keeping past activation timestamps unavailable after deployment.
- Base mainnet schedule-id golden tests now exercise the import path.

### How has it been tested?

- ProtocolVersions unit tests cover the exact freeze boundary, both mutation paths, registration notice enforcement, imported schedules, and the Base mainnet schedule-id golden values.
- DeployConfig and SystemDeploy tests cover parsing, defaulting, validation, and deployment with an initial schedule.
- Full suite passed locally (1,220 tests); ABI and semver-lock snapshots were regenerated.