### PR TITLE
revert: restore 1 gwei ResourceMetering conversion floor

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -12,7 +12,7 @@
     "sourceCodeHash": "0xd9f576a79e97bc541b3d7a2ee928f34223edaaecb074eeb9e6e2ecee857ce6a0"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0xe8145d0c3bd0e35f84086cddd75c73915332c42b40046d52188d822119915c3d",
+    "initCodeHash": "0x1b9441d11e2a206d6b7c018b910502194bfbdcaa75d42f809e6965281f224a2a",
     "sourceCodeHash": "0x811596e7486cab9ceeeb61405b9ae510d93fcbbdfa11949201a367506c53194a"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {

--- a/src/L1/ResourceMetering.sol
+++ b/src/L1/ResourceMetering.sol
@@ -135,11 +135,11 @@ abstract contract ResourceMetering is Initializable {
         uint256 resourceCost = uint256(_amount) * uint256(params.prevBaseFee);
 
         // We currently charge for this ETH amount as an L1 gas burn, so we convert the ETH amount
-        // into gas by dividing by the L1 base fee. We clamp to a minimum of 0.01 gwei to avoid
-        // division by zero on L1s without EIP-1559 and to cap gas-burn requirements when L1 demand
-        // is extremely low. A higher floor reduces the gas burned per deposit but undercharges
-        // relative to the deposit fee market when L1 base fee is below that floor.
-        uint256 gasCost = resourceCost / Math.max(block.basefee, 0.01 gwei);
+        // into gas by dividing by the L1 base fee. We assume a minimum base fee of 1 gwei to avoid
+        // division by zero for L1s that don't support 1559 or to avoid excessive gas burns during
+        // periods of extremely low L1 demand. One-day average gas fee hasn't dipped below 1 gwei
+        // during any 1 day period in the last 5 years, so should be fine.
+        uint256 gasCost = resourceCost / Math.max(block.basefee, 1 gwei);
 
         // Give the user a refund based on the amount of gas they used to do all of the work up to
         // this point. Since we're at the end of the modifier, this should be pretty accurate. Acts

--- a/test/L1/ResourceMetering.t.sol
+++ b/test/L1/ResourceMetering.t.sol
@@ -72,9 +72,6 @@ abstract contract ResourceMetering_TestInit is Test {
 /// @dev Tests are based on the default config values. It is expected that these config values are
 ///      used in production.
 contract ResourceMetering_Metered_Test is ResourceMetering_TestInit {
-    /// @dev Gas overhead from the metering logic and `measuredUse` wrapper, excluding the burn loop.
-    uint256 internal constant METERING_GAS_OVERHEAD = 1000;
-
     /// @notice Tests that updating the resource params to the same values works correctly.
     function test_metered_updateParamsNoChange_succeeds() external {
         meter.use(0); // equivalent to just updating the base fee and block number
@@ -191,42 +188,6 @@ contract ResourceMetering_Metered_Test is ResourceMetering_TestInit {
         (uint128 prevBaseFee, uint64 prevBoughtGas,) = meter.params();
         assertEq(prevBoughtGas, target / 2);
         assertGt(prevBaseFee, 0);
-    }
-
-    /// @notice Tests that deposits are charged the full resource cost when L1 base fee is below
-    ///         1 gwei but above the 0.01 gwei floor.
-    function test_metered_subGweiBaseFee_collectsFullResourceCost_succeeds() external {
-        uint64 amount = 100_000;
-        uint128 prevBaseFee = 1 gwei;
-        uint256 l1BaseFee = 0.1 gwei;
-        uint256 resourceCost = uint256(amount) * uint256(prevBaseFee);
-        uint256 expectedGasCost = resourceCost / l1BaseFee;
-
-        meter.set(prevBaseFee, 0, uint64(block.number));
-        vm.fee(l1BaseFee);
-
-        uint256 gasConsumed = meter.measuredUse(amount);
-
-        assertApproxEqAbs(gasConsumed, expectedGasCost, METERING_GAS_OVERHEAD);
-        assertApproxEqAbs(gasConsumed * l1BaseFee, resourceCost, METERING_GAS_OVERHEAD * l1BaseFee);
-    }
-
-    /// @notice Tests that the 0.01 gwei floor is applied when L1 base fee falls below it.
-    function test_metered_belowFloorBaseFee_usesFloor_succeeds() external {
-        uint64 amount = 100_000;
-        uint128 prevBaseFee = 1 gwei;
-        uint256 l1BaseFee = 0.005 gwei;
-        uint256 floor = 0.01 gwei;
-        uint256 resourceCost = uint256(amount) * uint256(prevBaseFee);
-        uint256 expectedGasCost = resourceCost / floor;
-
-        meter.set(prevBaseFee, 0, uint64(block.number));
-        vm.fee(l1BaseFee);
-
-        uint256 gasConsumed = meter.measuredUse(amount);
-
-        assertApproxEqAbs(gasConsumed, expectedGasCost, METERING_GAS_OVERHEAD);
-        assertApproxEqAbs(gasConsumed * l1BaseFee, resourceCost / 2, METERING_GAS_OVERHEAD * l1BaseFee);
     }
 
     /// @notice Tests that base fee decreases when gas usage is below target.


### PR DESCRIPTION
## Summary
- Reverts [0eff4c2f](https://github.com/base/contracts/commit/0eff4c2f58dd91bc02da5f48f054325635c2dea6) (`Lower min base fee` / #361), restoring `ResourceMetering` to `gasCost = resourceCost / max(block.basefee, 1 gwei)`.
- #361 lowered that conversion floor from 1 gwei to 0.01 gwei so deposits would collect the full resource cost when L1 base fee is below 1 gwei. That is the right ETH-accounting change, but it turns a 1 gwei deposit resource price into a 100× L1 gas burn when parent base fee sits at the 0.01 gwei floor — enough to exceed Fusaka’s 16,777,216 per-tx gas cap and revert portal deposits.
- Fork measurements show the undercharge #361 was meant to close is small at current Ethereum fees, while the 0.01 gwei floor is what makes deposits unusable. Restoring the 1 gwei clamp keeps standard deposits well under the cap.

## Fork tests
Ran against an Ethereum mainnet fork of Base’s live portal (`0x49048044…`), measuring a basic `depositTransaction` with `_gasLimit = 200_000` (typical `L1StandardBridge.depositETH` min gas).

Metering formula:

```
resourceCost = gasLimit × prevBaseFee
gasBurned    = resourceCost / max(L1 basefee, conversionFloor)
```

| Scenario | Conversion floor | `resourceConfig.minimumBaseFee` | `params.prevBaseFee` | Parent base fee | Measured gas | vs Fusaka 16.7M |
|---|---|---|---|---|---|---|
| Unmodified live portal | 1 gwei (deployed) | 1 gwei | 1 gwei | ~0.34 gwei (live) | **~202,558** | under |
| Current contracts (#361) + live resource params | 0.01 gwei | 1 gwei | 1 gwei | 0.01 gwei | **~20,002,555** | **exceeds** |
| Only `minimumBaseFee` → 0.01 gwei | 0.01 gwei | 0.01 gwei | 1 gwei | 0.01 gwei | **~20,002,555** | **exceeds** |
| `minimumBaseFee` and `prevBaseFee` → 0.01 gwei | 0.01 gwei | 0.01 gwei | 0.01 gwei | 0.01 gwei | **~202,530** | under |

Live fork block was 25825407. Changing only `SystemConfig._resourceConfig.minimumBaseFee` does not change same-block burn; `params.prevBaseFee` is the numerator.

At the live ~0.34 gwei parent fee, expected burn with a 0.01 gwei conversion floor is ~584k vs ~203k with the 1 gwei clamp — extra L1 gas, but still far from the cap. The dangerous case is parent at 0.01 gwei with resource price still 1 gwei: 20M gas, which reverts. That is why #361 is reverted rather than keeping the tighter floor and only lowering resource `minimumBaseFee`.

## Test plan
- [ ] Confirm `ResourceMetering` divides by `max(block.basefee, 1 gwei)`
- [ ] `just test --match-path test/L1/ResourceMetering.t.sol`
- [ ] Re-run Ethereum fork deposit measurement against live Base portal and confirm ~200k gas for a 200k `_gasLimit` deposit at current L1 base fee
- [ ] Confirm a 200k deposit at `block.basefee = 0.01 gwei` stays under 16,777,216 with this revert (expected ~200k, not ~20M)


Made with [Cursor](https://cursor.com)