### PR TITLE
fix(L1): prevent clearing upgrades below successors

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -16,8 +16,8 @@
     "sourceCodeHash": "0x811596e7486cab9ceeeb61405b9ae510d93fcbbdfa11949201a367506c53194a"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
-    "initCodeHash": "0x746f2c953680f6675e13be55678f546e9779b3903b385399cdc8890e7c46ec64",
-    "sourceCodeHash": "0xffe5ecd626c4895d336f696e679063711a2846f1f59c677aff9eb8dc35ac3dfb"
+    "initCodeHash": "0x5ef30dbac345fadcde0bafdc22aa2d67d5d8d4c8ec9909b070f3d4d6ca765ac4",
+    "sourceCodeHash": "0xa7e6e4567834a8efa6caccb1676102cea5712ba982f7550d4fd4d3e7b727ad5c"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -220,7 +220,7 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     /// @dev The activation timestamp must be at least MIN_NOTICE seconds in the future, and any
     ///      preexisting activation must still be more than FREEZE_WINDOW away. Pass 0 to remove a
     ///      scheduled timestamp; reverts if the upgrade has already activated or is inside its
-    ///      freeze window.
+    ///      freeze window, or if a later upgrade remains scheduled.
     /// @param id         The upgrade to schedule.
     /// @param timestamp  Future Unix timestamp for L2 activation (must be >= block.timestamp + MIN_NOTICE), or 0 to
     /// clear.
@@ -233,8 +233,8 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         if (timestamp != 0 && timestamp < uint64(block.timestamp) + MIN_NOTICE) {
             revert ProtocolVersions_InsufficientNotice(timestamp);
         }
+        if (timestamp == 0 || current == 0) _assertNoScheduledSuccessor(id);
         if (timestamp != 0) {
-            if (current == 0) _assertNoScheduledSuccessor(id);
             _assertTimestampAfterPrevious(id, timestamp);
             _assertTimestampBeforeNext(id, timestamp);
         }
@@ -368,7 +368,7 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         if (uint64(block.timestamp) + FREEZE_WINDOW >= current) revert ProtocolVersions_ActivationFrozen(id, current);
     }
 
-    /// @dev Prevents scheduling a zero-valued hole once a later upgrade has a timestamp.
+    /// @dev Prevents creating or filling a zero-valued hole below a scheduled successor.
     function _assertNoScheduledSuccessor(uint256 id) private view {
         for (uint256 i = id + 1; i < _timestamps.length; i++) {
             if (_timestamps[i] != 0) revert ProtocolVersions_StaticScheduleHole(id, i);

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -470,6 +470,27 @@ contract ProtocolVersions_SetTimestamp_Test is ProtocolVersions_TestInit {
         assertEq(protocolVersions.scheduleId(), scheduleIdAfterRegister);
     }
 
+    /// @notice Tests that clearing an upgrade below a scheduled successor cannot create a static hole.
+    function test_setTimestamp_clearBeforeScheduledSuccessor_reverts() external {
+        uint64 current = uint64(block.timestamp) + protocolVersions.MIN_NOTICE() + 100;
+        uint64 successor = current + 100;
+
+        vm.startPrank(_owner);
+        protocolVersions.registerUpgrade(current, 0);
+        protocolVersions.registerUpgrade(successor, 0);
+        vm.stopPrank();
+
+        bytes32 scheduleIdBeforeClear = protocolVersions.scheduleId();
+        vm.expectRevert(
+            abi.encodeWithSelector(IProtocolVersions.ProtocolVersions_StaticScheduleHole.selector, CANYON, ECOTONE)
+        );
+        vm.prank(_owner);
+        protocolVersions.setTimestamp(CANYON, 0);
+
+        assertEq(protocolVersions.getSchedule()[CANYON], current);
+        assertEq(protocolVersions.scheduleId(), scheduleIdBeforeClear);
+    }
+
     /// @notice Tests that `setTimestamp` emits a `TimestampSet` event.
     function test_setTimestamp_emitsEvent_succeeds() external {
         vm.prank(_owner);


### PR DESCRIPTION
### What changed? Why?

- Prevent `setTimestamp(id, 0)` from clearing a scheduled upgrade when a later upgrade remains scheduled. This preserves the static schedule invariant that no zero-valued holes can exist below scheduled successors.
- Add regression coverage confirming a rejected clear leaves both the timestamp and schedule commitment unchanged.
- Refresh the `ProtocolVersions` semver lock for the implementation change.

### Notes to reviewers

- The successor check now applies when clearing an existing timestamp, matching the existing protection when scheduling an upgrade into an unset slot.

### How has it been tested?

- `forge test --match-path test/L1/ProtocolVersions.t.sol -vv`
- `forge fmt --check`
- `just lint-forge-tests-check-no-build`
- `just semver-lock`