### PR TITLE
docs(L1): correct ProtocolVersions proof binding NatSpec

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -17,7 +17,7 @@
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
     "initCodeHash": "0x746f2c953680f6675e13be55678f546e9779b3903b385399cdc8890e7c46ec64",
-    "sourceCodeHash": "0xffe5ecd626c4895d336f696e679063711a2846f1f59c677aff9eb8dc35ac3dfb"
+    "sourceCodeHash": "0xa3785ba3177294519f26c18c0b757cfc52623b122d27f74518579c73937ee7b7"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -30,10 +30,14 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      Changing any upgrade's timestamp recomputes its link and all subsequent links, making
 ///      scheduleId fully reproducible from (upgrade count, current timestamps). Keeping the seed as
 ///      the array's first element lets both `scheduleId` and the refresh loop avoid an
-///      empty-registry special case. Proof journals bind to `scheduleId`, pinning every proof in a
-///      dispute game to the schedule in effect at the game's L1 origin block; cross-chain domain
-///      separation is provided by the journal itself, which commits the L2 chain id and registry
-///      address alongside `scheduleId`.
+///      empty-registry special case.
+///
+///      `AggregateVerifier` pins `activatedScheduleId` at game initialization using the ending L2 claim
+///      timestamp. Every proof journal commits to that pinned value.
+///
+///      `scheduleId` commits only to registry contents. `AggregateVerifier` journals pair it with
+///      `CONFIG_HASH`; they do not separately encode `L2_CHAIN_ID` or the `PROTOCOL_VERSIONS` address.
+///      Any deployment-level domain separation must therefore be part of `CONFIG_HASH`.
 ///
 ///      The contract is deployed behind an OP proxy: the implementation constructor disables
 ///      initializers, and `initialize` (run through the proxy) seeds the hash chain.


### PR DESCRIPTION
### What changed? Why?

- Correct `ProtocolVersions` NatSpec: `AggregateVerifier` pins the active upgrade schedule using the ending L2 claim timestamp, rather than the dispute game's L1 origin.
- Clarify that proof journals pair `scheduleId` with `CONFIG_HASH`; they do not separately commit to `L2_CHAIN_ID` or the `PROTOCOL_VERSIONS` address. This documents the actual domain-separation boundary.
- Refresh the `ProtocolVersions` semver-lock source hash to reflect the NatSpec change.

### Notes to reviewers

- This changes documentation only: implementation behavior, the journal schema, and the implementation init code hash are unchanged.
- Deployment-specific domain separation must be included in `CONFIG_HASH`.

### How has it been tested?

- `just semver-lock`
- `forge fmt --check`
