### PR TITLE
docs(L1): clarify AggregateVerifier freeze semantics

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -29,7 +29,7 @@
   },
   "src/L1/proofs/AggregateVerifier.sol:AggregateVerifier": {
     "initCodeHash": "0x84c6bf00e337c889993c409f18b17986f9d9546ac6754f7730962459d301c21d",
-    "sourceCodeHash": "0xab669e0a55462740b4c1c06fe94aa709044146e3eeec4a0123fbc67dd7f35c28"
+    "sourceCodeHash": "0x57938108a4aae689564e15c96e46b8ab0908725fd7cb0431112e601acdab9988"
   },
   "src/L1/proofs/AnchorStateRegistry.sol:AnchorStateRegistry": {
     "initCodeHash": "0x6f3afd2d0ef97a82ca3111976322b99343a270e54cd4a405028f2f29c75f7fb1",

--- a/src/L1/proofs/AggregateVerifier.sol
+++ b/src/L1/proofs/AggregateVerifier.sol
@@ -427,9 +427,9 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
 
         uint64 claimTimestamp = L2_GENESIS_TIMESTAMP + uint64(blocksSinceGenesis * uint256(L2_BLOCK_TIME));
 
-        // `ProtocolVersions` only freezes an activation once L1 time reaches it, so a claim whose L2
-        // timestamp is still in L1's future would pin a schedule the owner can afterwards clear or
-        // delay. Requiring the claim to have already passed on L1 keeps the pin canonical for life.
+        // `ProtocolVersions` freezes mutations to an activation `FREEZE_WINDOW` before it takes
+        // effect. Requiring the claim timestamp to have been reached on L1 additionally ensures the
+        // game's L2 time is not still in L1's future when its active schedule is pinned.
         if (claimTimestamp > block.timestamp) revert L2TimestampInFuture(claimTimestamp, block.timestamp);
 
         scheduleId = PROTOCOL_VERSIONS.activatedScheduleId(claimTimestamp);


### PR DESCRIPTION
### What changed? Why?

Updated the `AggregateVerifier` schedule-pinning comment to accurately describe `ProtocolVersions` `FREEZE_WINDOW` semantics. The comment now also explains that the L1 timestamp check prevents a game's L2 time from being in L1's future when its active schedule is pinned.

### Notes to reviewers

Documentation-only change; contract behavior is unchanged.

### How has it been tested?

- `forge fmt --check src/L1/proofs/AggregateVerifier.sol`
- `git diff --check`
