### PR TITLE
docs(L1): document AggregateVerifier L1 origin split

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -29,7 +29,7 @@
   },
   "src/L1/proofs/AggregateVerifier.sol:AggregateVerifier": {
     "initCodeHash": "0x84c6bf00e337c889993c409f18b17986f9d9546ac6754f7730962459d301c21d",
-    "sourceCodeHash": "0xab669e0a55462740b4c1c06fe94aa709044146e3eeec4a0123fbc67dd7f35c28"
+    "sourceCodeHash": "0xe6f8a0d8d8ff5a28f13badc251ce85c5e9e0ed4e6b20e32737c25f3cdc4a6bcd"
   },
   "src/L1/proofs/AnchorStateRegistry.sol:AnchorStateRegistry": {
     "initCodeHash": "0x6f3afd2d0ef97a82ca3111976322b99343a270e54cd4a405028f2f29c75f7fb1",

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -29,7 +29,7 @@
   },
   "src/L1/proofs/AggregateVerifier.sol:AggregateVerifier": {
     "initCodeHash": "0x84c6bf00e337c889993c409f18b17986f9d9546ac6754f7730962459d301c21d",
-    "sourceCodeHash": "0x367088b445d3585be61041400367271082d341c1f6272e8044fb4073b6b5f493"
+    "sourceCodeHash": "0x15952c01559b5c8e08faba110a49da9fb8c20e7bd4a62f7884c902847783e201"
   },
   "src/L1/proofs/AnchorStateRegistry.sol:AnchorStateRegistry": {
     "initCodeHash": "0x6f3afd2d0ef97a82ca3111976322b99343a270e54cd4a405028f2f29c75f7fb1",

--- a/src/L1/proofs/AggregateVerifier.sol
+++ b/src/L1/proofs/AggregateVerifier.sol
@@ -345,9 +345,11 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
     }
 
     /// @notice Initializes the contract.
-    /// @param proof The proof.
+    /// @param proof The proof, encoded as proof type || L1 origin hash || L1 origin number || verifier payload.
     /// @dev This function may only be called once.
     /// @dev First byte of the proof is the proof type.
+    /// @dev The proof-supplied L1 origin hash is verified against the supplied block number and journaled. It need not
+    /// equal `l1Head()`, which the factory captures at game creation for proofs submitted after initialization.
     function initializeWithInitData(bytes calldata proof) external payable virtual {
         // The game must not have already been initialized.
         if (initialized) revert AlreadyInitialized();
@@ -807,6 +809,9 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
     }
 
     /// @notice Getter for the parent hash of the L1 block when the dispute game was created.
+    /// @dev Proofs submitted through `verifyProposalProof`, `challenge`, and `nullify` journal this factory-captured
+    /// hash. Initialization instead journals the independently verified L1 origin hash supplied to
+    /// `initializeWithInitData`.
     function l1Head() public pure returns (Hash) {
         return Hash.wrap(_getArgBytes32(0x34));
     }

--- a/src/L1/proofs/AggregateVerifier.sol
+++ b/src/L1/proofs/AggregateVerifier.sol
@@ -345,9 +345,8 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
     }
 
     /// @notice Initializes the contract.
-    /// @param proof The proof, encoded as proof type || L1 origin hash || L1 origin number || verifier payload.
+    /// @param proof Encoding: uint8 proofType || bytes32 l1OriginHash || uint256 l1OriginNumber || verifier payload.
     /// @dev This function may only be called once.
-    /// @dev First byte of the proof is the proof type.
     /// @dev The proof-supplied L1 origin hash is verified against the supplied block number and journaled. It need not
     /// equal `l1Head()`, which the factory captures at game creation for proofs submitted after initialization.
     function initializeWithInitData(bytes calldata proof) external payable virtual {


### PR DESCRIPTION
### What changed? Why?

- Clarify the `initializeWithInitData` proof encoding: proof type, L1 origin hash, L1 origin number, and verifier payload.
- Document that initialization validates and journals the proof-supplied L1 origin, while `verifyProposalProof`, `challenge`, and `nullify` journal the factory-captured `l1Head`.
- Update the `AggregateVerifier` semver source hash for the NatSpec change.

This makes the two L1-origin paths explicit so readers do not infer that initialization requires the game-creation `l1Head`.

### Notes to reviewers

This changes NatSpec only; runtime behavior and the init-code hash are unchanged.

### How has it been tested?

- `just semver-lock`
- `just test --match-path test/L1/proofs/AggregateVerifier.t.sol`
- `forge fmt --check`
- `git diff --check`