### PR TITLE
fix(L1): require complete initial upgrade schedules

### DIFF
--- a/interfaces/L1/IProtocolVersions.sol
+++ b/interfaces/L1/IProtocolVersions.sol
@@ -29,6 +29,7 @@ interface IProtocolVersions is IProxyAdminOwnedBase, ISemver, IReinitializableBa
     error ProtocolVersions_TimestampNotBeforeNext(uint256 id, uint256 nextId, uint64 timestamp, uint64 nextTimestamp);
     error ProtocolVersions_NotInitialized();
     error ProtocolVersions_InsufficientNotice(uint64 timestamp);
+    error ProtocolVersions_InvalidInitialScheduleLength(uint256 providedLength, uint256 expectedLength);
 
     function initialize(address _incidentResponder, uint64[] calldata _initialSchedule) external;
     function registerUpgrade(uint64 timestamp, uint256 minProtocolVersion) external returns (uint256);
@@ -39,6 +40,7 @@ interface IProtocolVersions is IProxyAdminOwnedBase, ISemver, IReinitializableBa
 
     function MIN_NOTICE() external view returns (uint64);
     function FREEZE_WINDOW() external view returns (uint64);
+    function INITIAL_UPGRADE_COUNT() external view returns (uint256);
     function minimumProtocolVersion() external view returns (uint256);
     function incidentResponder() external view returns (address);
     function scheduleId() external view returns (bytes32);

--- a/interfaces/L1/IProtocolVersions.sol
+++ b/interfaces/L1/IProtocolVersions.sol
@@ -40,7 +40,7 @@ interface IProtocolVersions is IProxyAdminOwnedBase, ISemver, IReinitializableBa
 
     function MIN_NOTICE() external view returns (uint64);
     function FREEZE_WINDOW() external view returns (uint64);
-    function INITIAL_UPGRADE_COUNT() external view returns (uint256);
+    function INITIAL_UPGRADE_COUNT() external pure returns (uint256);
     function minimumProtocolVersion() external view returns (uint256);
     function incidentResponder() external view returns (address);
     function scheduleId() external view returns (bytes32);

--- a/scripts/deploy/DeployConfig.s.sol
+++ b/scripts/deploy/DeployConfig.s.sol
@@ -5,6 +5,8 @@ import { console } from "lib/forge-std/src/console.sol";
 import { Script } from "lib/forge-std/src/Script.sol";
 import { stdJson } from "lib/forge-std/src/StdJson.sol";
 
+import { ProtocolVersionsConfig } from "src/libraries/ProtocolVersionsConfig.sol";
+
 /// @title DeployConfig
 /// @notice Represents the configuration required to deploy the system, read from a JSON file.
 contract DeployConfig is Script {
@@ -65,7 +67,8 @@ contract DeployConfig is Script {
     uint64[] internal _protocolVersionsInitialSchedule;
 
     /// @notice The chain's existing hardfork activation timestamps, used to seed `ProtocolVersions`.
-    /// @dev Chains with no upgrade history leave this unset and start with an empty registry.
+    /// @dev Chains with no upgrade history leave this unset. Otherwise the schedule must contain one entry per known
+    /// contract-backed upgrade, including zero for unscheduled upgrades.
     function protocolVersionsInitialSchedule() public view returns (uint64[] memory) {
         return _protocolVersionsInitialSchedule;
     }
@@ -138,6 +141,7 @@ contract DeployConfig is Script {
             require(schedule[i] <= type(uint64).max, "DeployConfig: initial schedule timestamp exceeds uint64");
             _protocolVersionsInitialSchedule.push(uint64(schedule[i]));
         }
+        ProtocolVersionsConfig.assertValidInitialScheduleLength(schedule.length);
     }
 
     /// @notice Allow the `useUpgradedFork` config to be overridden in testing environments

--- a/scripts/deploy/SystemDeploy.s.sol
+++ b/scripts/deploy/SystemDeploy.s.sol
@@ -40,6 +40,7 @@ import { TEEVerifier } from "src/L1/proofs/tee/TEEVerifier.sol";
 import { ISP1Verifier } from "interfaces/L1/proofs/zk/ISP1Verifier.sol";
 import { ZKVerifier } from "src/L1/proofs/zk/ZKVerifier.sol";
 import { Constants } from "src/libraries/Constants.sol";
+import { ProtocolVersionsConfig } from "src/libraries/ProtocolVersionsConfig.sol";
 import { SemverComp } from "src/libraries/SemverComp.sol";
 import { GameType, GameTypes, Hash, Proposal } from "src/libraries/bridge/Types.sol";
 import { Claim } from "src/libraries/bridge/LibUDT.sol";
@@ -313,6 +314,10 @@ contract SystemDeploy is Script {
     }
 
     function deploy(DeployInput memory _input) public returns (DeployOutput memory output_) {
+        // Validate before any broadcast because a later revert cannot roll back transactions already sent by the
+        // script.
+        _assertValidOPChainInput(_input.opChainInput);
+
         output_.superchain = _deployOrLoadSuperchain(_input);
         if (_implementationsEmpty(_input.implementations)) {
             output_.impls = _deployImplementations(_input.implementationsInput);
@@ -483,7 +488,6 @@ contract SystemDeploy is Script {
         internal
         returns (Types.DeployOutput memory output_, Types.Implementations memory impls_)
     {
-        _assertValidOPChainInput(_input);
         impls_ = _impls;
 
         output_.opChainProxyAdmin = IProxyAdmin(
@@ -1093,6 +1097,7 @@ contract SystemDeploy is Script {
         if (_input.roles.systemConfigOwner == address(0)) revert InvalidRoleAddress("systemConfigOwner");
         if (_input.roles.batcher == address(0)) revert InvalidRoleAddress("batcher");
         if (_input.roles.unsafeBlockSigner == address(0)) revert InvalidRoleAddress("unsafeBlockSigner");
+        ProtocolVersionsConfig.assertValidInitialScheduleLength(_input.initialUpgradeSchedule.length);
         if (Hash.unwrap(_input.startingAnchorRoot.root) == bytes32(0)) {
             revert InvalidStartingAnchorRoot();
         }

--- a/scripts/libraries/Types.sol
+++ b/scripts/libraries/Types.sol
@@ -32,10 +32,10 @@ library Types {
     }
 
     /// @notice The full set of inputs to deploy a new OP Stack chain.
-    /// @custom:field initialUpgradeSchedule The chain's hardfork activation timestamps, one entry per
-    ///              upgrade in the node's fork order, zero for unscheduled ones. Seeds
-    ///              `ProtocolVersions` at initialization, which is the only way to enter
-    ///              activations that are already in the past.
+    /// @custom:field initialUpgradeSchedule The chain's hardfork activation timestamps, exactly one entry per known
+    /// contract-backed upgrade in the node's fork order, including zero for unscheduled upgrades. An empty array is
+    /// reserved for chains with no upgrade history. Seeds `ProtocolVersions` at initialization, which is the only way
+    /// to enter activations that are already in the past.
     struct DeployInput {
         Roles roles;
         uint32 basefeeScalar;

--- a/snapshots/abi/ProtocolVersions.json
+++ b/snapshots/abi/ProtocolVersions.json
@@ -19,6 +19,19 @@
   },
   {
     "inputs": [],
+    "name": "INITIAL_UPGRADE_COUNT",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "MIN_NOTICE",
     "outputs": [
       {
@@ -423,6 +436,22 @@
       }
     ],
     "name": "ProtocolVersions_InsufficientNotice",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "providedLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedLength",
+        "type": "uint256"
+      }
+    ],
+    "name": "ProtocolVersions_InvalidInitialScheduleLength",
     "type": "error"
   },
   {

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -16,8 +16,8 @@
     "sourceCodeHash": "0x811596e7486cab9ceeeb61405b9ae510d93fcbbdfa11949201a367506c53194a"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
-    "initCodeHash": "0x909a923012cab53fdfc4ea8f9f54173d64d2e3c250e8d69cb10ea226e21a4adf",
-    "sourceCodeHash": "0x2b338e2c3cb163445841a1bfca2370e731b4cba4be35018cb07b2d22a3465f67"
+    "initCodeHash": "0x910071d92b181b50fa1ece6beeed99716a02b7ab5fbfbb4a7aa8b8f4f1a569da",
+    "sourceCodeHash": "0xefbaeac9679a7a6627dd93d782bbd5f7d48a044b724a05d5413c8e1fe5fe14be"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.15;
 import { ProxyAdminOwnedBase } from "src/universal/ProxyAdminOwnedBase.sol";
 import { ReinitializableBase } from "src/universal/ReinitializableBase.sol";
 import { Initializable } from "lib/openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
+import { ProtocolVersionsConfig } from "src/libraries/ProtocolVersionsConfig.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
@@ -122,6 +123,11 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
         _disableInitializers();
     }
 
+    /// @notice Number of contract-backed upgrades a non-empty initial schedule must contain.
+    function INITIAL_UPGRADE_COUNT() public pure returns (uint256) {
+        return ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT;
+    }
+
     /// @notice Initializes the registry by seeding the hash chain, importing any preexisting upgrade
     ///         schedule, and appointing the initial incidentResponder. Callable only by the
     ///         ProxyAdmin or its owner.
@@ -134,7 +140,8 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     /// @param _incidentResponder Initial incidentResponder allowed to delay activations, or address(0) to leave unset.
     /// @param _initialSchedule   Activation timestamps for already-known upgrades, ordered by ascending
     ///                           upgrade id, using 0 for an upgrade that is registered but unscheduled.
-    ///                           Pass an empty array for a chain with no upgrade history.
+    ///                           Pass an empty array for a chain with no upgrade history; otherwise the
+    ///                           array must contain exactly INITIAL_UPGRADE_COUNT entries.
     function initialize(
         address _incidentResponder,
         uint64[] calldata _initialSchedule
@@ -144,6 +151,7 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     {
         // Initialization transactions must come from the ProxyAdmin or its owner.
         _assertOnlyProxyAdminOrProxyAdminOwner();
+        ProtocolVersionsConfig.assertValidInitialScheduleLength(_initialSchedule.length);
 
         // Seed the hash chain at index 0. Keeping the seed as the first array element lets
         // `scheduleId` and `_refreshScheduleId` avoid an empty-registry special case, and makes a

--- a/src/libraries/ProtocolVersionsConfig.sol
+++ b/src/libraries/ProtocolVersionsConfig.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Interfaces
+import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
+
+/// @title ProtocolVersionsConfig
+/// @notice Shared configuration and validation for ProtocolVersions initial schedules.
+library ProtocolVersionsConfig {
+    /// @notice Number of contract-backed upgrades in the node's positional schedule, from Regolith through Denim.
+    /// @dev This must match `BaseUpgrade::CONTRACT_VARIANTS` in base/base and be updated only by appending upgrades.
+    uint256 internal constant INITIAL_UPGRADE_COUNT = 14;
+
+    /// @notice Rejects non-empty initial schedules that do not cover the complete known upgrade ladder.
+    function assertValidInitialScheduleLength(uint256 _length) internal pure {
+        if (_length != 0 && _length != INITIAL_UPGRADE_COUNT) {
+            revert IProtocolVersions.ProtocolVersions_InvalidInitialScheduleLength(_length, INITIAL_UPGRADE_COUNT);
+        }
+    }
+}

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -8,6 +8,7 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 // Contracts
 import { ProxyAdminOwnedBase } from "src/universal/ProxyAdminOwnedBase.sol";
 import { Proxy } from "src/universal/Proxy.sol";
+import { ProtocolVersionsConfig } from "src/libraries/ProtocolVersionsConfig.sol";
 
 // Interfaces
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
@@ -58,6 +59,14 @@ abstract contract ProtocolVersions_TestInit is CommonTest {
         proxy.upgradeTo(impl);
         return IProtocolVersions(address(proxy));
     }
+
+    /// @dev Pads a test prefix with explicit unscheduled entries through the complete known upgrade ladder.
+    function _completeSchedule(uint64[] memory _prefix) internal pure returns (uint64[] memory schedule_) {
+        schedule_ = new uint64[](ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT);
+        for (uint256 i = 0; i < _prefix.length; i++) {
+            schedule_[i] = _prefix[i];
+        }
+    }
 }
 
 /// @title ProtocolVersions_Initialize_Test
@@ -71,6 +80,11 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
         assertEq(protocolVersions.proxyAdminOwner(), proxyAdminOwner);
         assertEq(protocolVersions.incidentResponder(), deploy.cfg().superchainConfigIncidentResponder());
         assertEq(protocolVersions.scheduleId(), bytes32(0));
+    }
+
+    /// @notice Pins the contract's positional schedule length to the current node upgrade ladder.
+    function test_initialUpgradeCount_matchesNodeSchedule_succeeds() external view {
+        assertEq(protocolVersions.INITIAL_UPGRADE_COUNT(), 14);
     }
 
     /// @notice Tests that initialization appoints the provided incidentResponder and emits the event.
@@ -96,10 +110,11 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
     /// @notice Tests that the initializer imports a preexisting schedule, building the same hash
     ///         chain the equivalent sequence of registrations would have.
     function test_initialize_importsSchedule_succeeds() external {
-        uint64[] memory schedule = new uint64[](3);
-        schedule[0] = 10;
-        schedule[1] = 0;
-        schedule[2] = 30;
+        uint64[] memory prefix = new uint64[](3);
+        prefix[0] = 10;
+        prefix[1] = 0;
+        prefix[2] = 30;
+        uint64[] memory schedule = _completeSchedule(prefix);
 
         IProtocolVersions imported = _deployUninitializedProxy();
         vm.prank(EIP1967Helper.getAdmin(address(imported)));
@@ -111,18 +126,20 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
         assertEq(stored[1], schedule[1]);
         assertEq(stored[2], schedule[2]);
 
-        bytes32 link0 = keccak256(abi.encode(bytes32(0), uint256(0), uint64(10)));
-        bytes32 link1 = keccak256(abi.encode(link0, uint256(1), uint64(0)));
-        bytes32 link2 = keccak256(abi.encode(link1, uint256(2), uint64(30)));
-        assertEq(imported.scheduleId(0), link0);
-        assertEq(imported.scheduleId(), link2);
+        bytes32 expected;
+        for (uint256 i = 0; i < schedule.length; i++) {
+            expected = keccak256(abi.encode(expected, i, schedule[i]));
+            assertEq(imported.scheduleId(i), expected);
+        }
+        assertEq(imported.scheduleId(), expected);
     }
 
     /// @notice Tests that an imported schedule is held to the same ordering rule as registration.
     function test_initialize_importUnorderedSchedule_reverts() external {
-        uint64[] memory schedule = new uint64[](2);
-        schedule[0] = 30;
-        schedule[1] = 10;
+        uint64[] memory prefix = new uint64[](2);
+        prefix[0] = 30;
+        prefix[1] = 10;
+        uint64[] memory schedule = _completeSchedule(prefix);
 
         IProtocolVersions imported = _deployUninitializedProxy();
         vm.expectRevert(
@@ -132,6 +149,42 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
                 CANYON,
                 uint64(30),
                 uint64(10)
+            )
+        );
+        vm.prank(EIP1967Helper.getAdmin(address(imported)));
+        imported.initialize(address(0), schedule);
+    }
+
+    /// @notice Tests that a non-empty proper prefix cannot initialize a schedule that diverges from the node.
+    function test_initialize_truncatedInitialSchedule_reverts() external {
+        uint64[] memory prefix = new uint64[](4);
+        prefix[0] = 1_686_789_347;
+        prefix[1] = 1_704_992_401;
+        prefix[2] = 1_708_560_000;
+        prefix[3] = 1_710_374_401;
+
+        IProtocolVersions imported = _deployUninitializedProxy();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IProtocolVersions.ProtocolVersions_InvalidInitialScheduleLength.selector,
+                prefix.length,
+                ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT
+            )
+        );
+        vm.prank(EIP1967Helper.getAdmin(address(imported)));
+        imported.initialize(address(0), prefix);
+    }
+
+    /// @notice Tests that entries unknown to the node cannot make the contract commit to a longer schedule.
+    function test_initialize_overlongInitialSchedule_reverts() external {
+        uint64[] memory schedule = new uint64[](ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT + 1);
+
+        IProtocolVersions imported = _deployUninitializedProxy();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IProtocolVersions.ProtocolVersions_InvalidInitialScheduleLength.selector,
+                schedule.length,
+                ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT
             )
         );
         vm.prank(EIP1967Helper.getAdmin(address(imported)));
@@ -1042,13 +1095,13 @@ contract ProtocolVersions_ActivatedScheduleId_Test is ProtocolVersions_TestInit 
     }
 
     /// @notice Cross-implementation golden for the full real Base mainnet contract-backed schedule.
-    ///         The live tail commits to all 13 entries, including PectraBlobSchedule and Cobalt as
+    ///         The live tail commits to all 14 entries, including PectraBlobSchedule, Cobalt, and Denim as
     ///         unscheduled zero-timestamp entries.
     function test_scheduleId_matchesBaseMainnetFullScheduleGoldenValue_succeeds() external {
         IProtocolVersions mainnet = _importBaseMainnetStaticSchedule();
 
-        assertEq(mainnet.scheduleId(), 0x5ee41f186b0a439783060587cfbb942f6f1d94ecc76376c9782580c943ff2b6d);
-        assertEq(mainnet.scheduleId(12), mainnet.scheduleId());
+        assertEq(mainnet.scheduleId(), 0xd06078191f7b4b687750aa46ae2ad31ed105d09868a38f7ab557039c0899ffc5);
+        assertEq(mainnet.scheduleId(13), mainnet.scheduleId());
     }
 
     uint64 private constant BASE_MAINNET_GENESIS_TIMESTAMP = 1_686_789_347;
@@ -1067,7 +1120,7 @@ contract ProtocolVersions_ActivatedScheduleId_Test is ProtocolVersions_TestInit 
     ///      the only path that can enter it. The resulting chain must match what the equivalent
     ///      sequence of `registerUpgrade` calls would have produced, which these goldens pin.
     function _importBaseMainnetStaticSchedule() private returns (IProtocolVersions) {
-        uint64[] memory schedule = new uint64[](13);
+        uint64[] memory schedule = new uint64[](ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT);
         schedule[0] = BASE_MAINNET_GENESIS_TIMESTAMP;
         schedule[1] = BASE_MAINNET_CANYON_TIMESTAMP;
         schedule[2] = BASE_MAINNET_DELTA_TIMESTAMP;
@@ -1081,6 +1134,7 @@ contract ProtocolVersions_ActivatedScheduleId_Test is ProtocolVersions_TestInit 
         schedule[10] = BASE_MAINNET_AZUL_TIMESTAMP;
         schedule[11] = BASE_MAINNET_BERYL_TIMESTAMP;
         schedule[12] = 0; // Cobalt is unscheduled on Base mainnet.
+        schedule[13] = 0; // Denim is unscheduled on Base mainnet.
 
         return _importSchedule(schedule);
     }
@@ -1090,7 +1144,7 @@ contract ProtocolVersions_ActivatedScheduleId_Test is ProtocolVersions_TestInit 
     function _importSchedule(uint64[] memory schedule) private returns (IProtocolVersions) {
         IProtocolVersions imported = _deployUninitializedProxy();
         vm.prank(EIP1967Helper.getAdmin(address(imported)));
-        imported.initialize(address(0), schedule);
+        imported.initialize(address(0), _completeSchedule(schedule));
         return imported;
     }
 }

--- a/test/L1/proofs/BaseTest.t.sol
+++ b/test/L1/proofs/BaseTest.t.sol
@@ -21,6 +21,7 @@ import { AggregateVerifier } from "src/L1/proofs/AggregateVerifier.sol";
 import { IVerifier } from "interfaces/L1/proofs/IVerifier.sol";
 import { ProtocolVersions } from "src/L1/ProtocolVersions.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
+import { ProtocolVersionsConfig } from "src/libraries/ProtocolVersionsConfig.sol";
 
 import { MockVerifier } from "test/mocks/MockVerifier.sol";
 
@@ -121,7 +122,11 @@ contract BaseTest is Test {
     ///      Must be called before any game is created, since games pin the registry they see.
     function _importProtocolVersionsSchedule(uint64[] memory schedule) internal {
         protocolVersions = ProtocolVersions(_deployProxy(address(new ProtocolVersions())));
-        protocolVersions.initialize(address(0), schedule);
+        uint64[] memory completeSchedule = new uint64[](ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT);
+        for (uint256 i = 0; i < schedule.length; i++) {
+            completeSchedule[i] = schedule[i];
+        }
+        protocolVersions.initialize(address(0), completeSchedule);
         _deployAndSetAggregateVerifier();
     }
 

--- a/test/deploy/DeployConfig.t.sol
+++ b/test/deploy/DeployConfig.t.sol
@@ -3,7 +3,9 @@ pragma solidity 0.8.15;
 
 import { Test } from "lib/forge-std/src/Test.sol";
 
+import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
 import { DeployConfig } from "scripts/deploy/DeployConfig.s.sol";
+import { ProtocolVersionsConfig } from "src/libraries/ProtocolVersionsConfig.sol";
 
 contract DeployConfigHarness is DeployConfig {
     function readSchedule(string memory _json) public {
@@ -22,10 +24,10 @@ contract DeployConfig_Test is Test {
     ///         `ProtocolVersions.initialize`, so a key that silently fails to parse would leave that
     ///         chain permanently stuck with an empty registry.
     function test_readSchedule_parsesTimestampsInOrder_succeeds() public {
-        cfg.readSchedule('{"protocolVersionsInitialSchedule":[1686789347,1704992401,0,1710374401]}');
+        cfg.readSchedule('{"protocolVersionsInitialSchedule":[1686789347,1704992401,0,1710374401,0,0,0,0,0,0,0,0,0,0]}');
 
         uint64[] memory schedule = cfg.protocolVersionsInitialSchedule();
-        assertEq(schedule.length, 4);
+        assertEq(schedule.length, ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT);
         assertEq(schedule[0], 1_686_789_347);
         assertEq(schedule[1], 1_704_992_401);
         assertEq(schedule[2], 0);
@@ -40,12 +42,24 @@ contract DeployConfig_Test is Test {
 
     /// @dev Config state is reused across reads, so a second read must replace rather than append.
     function test_readSchedule_twice_replacesSchedule_succeeds() public {
-        cfg.readSchedule('{"protocolVersionsInitialSchedule":[1686789347,1704992401]}');
-        cfg.readSchedule('{"protocolVersionsInitialSchedule":[1710374401]}');
+        cfg.readSchedule('{"protocolVersionsInitialSchedule":[1686789347,1704992401,0,0,0,0,0,0,0,0,0,0,0,0]}');
+        cfg.readSchedule('{"protocolVersionsInitialSchedule":[1710374401,0,0,0,0,0,0,0,0,0,0,0,0,0]}');
 
         uint64[] memory schedule = cfg.protocolVersionsInitialSchedule();
-        assertEq(schedule.length, 1);
+        assertEq(schedule.length, ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT);
         assertEq(schedule[0], 1_710_374_401);
+        assertEq(schedule[1], 0);
+    }
+
+    function test_readSchedule_truncatedSchedule_reverts() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IProtocolVersions.ProtocolVersions_InvalidInitialScheduleLength.selector,
+                uint256(4),
+                ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT
+            )
+        );
+        cfg.readSchedule('{"protocolVersionsInitialSchedule":[1686789347,1704992401,1708560000,1710374401]}');
     }
 
     function test_readSchedule_timestampAboveUint64_reverts() public {

--- a/test/deploy/SystemDeploy.t.sol
+++ b/test/deploy/SystemDeploy.t.sol
@@ -185,6 +185,22 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
         );
     }
 
+    /// @notice Pins initial schedule validation before superchain deployment can broadcast.
+    function test_deploy_truncatedInitialSchedule_reverts() public {
+        SystemDeploy.DeployInput memory input = _defaultDeployInput();
+        input.opChainInput.initialUpgradeSchedule = new uint64[](ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT - 1);
+        input.superchainInput.superchainProxyAdminOwner = address(0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IProtocolVersions.ProtocolVersions_InvalidInitialScheduleLength.selector,
+                ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT - 1,
+                ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT
+            )
+        );
+        systemDeploy.deploy(input);
+    }
+
     function test_deploy_multiproofDisabled_allowsUnsetL2BlockTime_succeeds() public {
         SystemDeploy.DeployInput memory input = _defaultDeployInput();
         input.implementationsInput.multiproofConfigHash = bytes32(0);

--- a/test/deploy/SystemDeploy.t.sol
+++ b/test/deploy/SystemDeploy.t.sol
@@ -17,6 +17,7 @@ import { AggregateVerifier } from "src/L1/proofs/AggregateVerifier.sol";
 import { TEEProverRegistry } from "src/L1/proofs/tee/TEEProverRegistry.sol";
 import { TEEVerifier } from "src/L1/proofs/tee/TEEVerifier.sol";
 import { ZKVerifier } from "src/L1/proofs/zk/ZKVerifier.sol";
+import { ProtocolVersionsConfig } from "src/libraries/ProtocolVersionsConfig.sol";
 import { GameType, Hash, Proposal } from "src/libraries/bridge/Types.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { DevTEEProverRegistry } from "test/mocks/MockDevTEEProverRegistry.sol";
@@ -160,7 +161,7 @@ contract SystemDeploy_Test is Test, SystemDeployAssertions {
     function test_deploy_seedsProtocolVersionsWithInitialSchedule_succeeds() public {
         vm.warp(1_800_000_000);
 
-        uint64[] memory schedule = new uint64[](4);
+        uint64[] memory schedule = new uint64[](ProtocolVersionsConfig.INITIAL_UPGRADE_COUNT);
         schedule[0] = 1_686_789_347;
         schedule[1] = 1_704_992_401;
         schedule[2] = 0; // Unscheduled on this chain.


### PR DESCRIPTION
## Summary
- reject non-empty initial schedule imports unless they contain exactly all 14 contract-backed upgrades through Denim
- enforce the same completeness check while parsing deployment configs and expose the expected upgrade count
- preflight direct `SystemDeploy` inputs before any broadcast can leave a partial deployment
- update schedule fixtures and the cross-implementation full-schedule golden with explicit zero entries for unscheduled upgrades

## Test plan
- [x] `just test` (1,212 passed, 1 skipped)
- [x] `just lint-check`
- [x] `just snapshots`