### PR TITLE
fix(L1): leave time for schedule propagation

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -16,8 +16,8 @@
     "sourceCodeHash": "0x811596e7486cab9ceeeb61405b9ae510d93fcbbdfa11949201a367506c53194a"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
-    "initCodeHash": "0x58f6c7cca0659a3ea85823b67eb1b331fcfd5173007896be8a4ee8af99a4fc5a",
-    "sourceCodeHash": "0x0f55edce2f83f4153ebe42a50ff0509bb567182acf3dc6913ab470cc0e823a37"
+    "initCodeHash": "0x54c2a142728d60511fd15a7d6bb962b0f33d833ee727de16189fd18b6246b492",
+    "sourceCodeHash": "0xe28be8c9615f626d69ec44f73b626499dd934f859fed9fb85462f714d3fbf0b8"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -17,7 +17,7 @@
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
     "initCodeHash": "0x54c2a142728d60511fd15a7d6bb962b0f33d833ee727de16189fd18b6246b492",
-    "sourceCodeHash": "0xe28be8c9615f626d69ec44f73b626499dd934f859fed9fb85462f714d3fbf0b8"
+    "sourceCodeHash": "0x53c8ad6dc42e61b43b3ef2a91e154a02e719c595c8d1481b4b738faa7ebdf13d"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x9b1f3555b499709485d51d5d9665002c0eb1e5eb893be1fb978a30749e894858",

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -49,7 +49,7 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     /// @dev One hour covers the post-Fjord 30-minute maximum sequencer drift plus the default finalized reader's
     /// nominal 27m48s observation latency, leaving a 2m12s margin. This finite bound cannot cover unbounded finality or
     /// delivery delays; consumers must reject stale changes that alter fork rules for existing L2 blocks.
-    uint64 public constant FREEZE_WINDOW = MIN_NOTICE;
+    uint64 public constant FREEZE_WINDOW = 1 hours;
 
     /// @notice Activation timestamp for each registered upgrade, indexed by upgrade id (0 = not scheduled).
     ///         An upgrade id is registered iff it is a valid index into this array.

--- a/src/L1/ProtocolVersions.sol
+++ b/src/L1/ProtocolVersions.sol
@@ -46,12 +46,10 @@ contract ProtocolVersions is ProxyAdminOwnedBase, Initializable, Reinitializable
     uint64 public constant MIN_NOTICE = 1 hours;
 
     /// @notice Window before a scheduled activation during which that timestamp can no longer change.
-    /// @dev Sized to the post-Fjord maximum sequencer drift: an L2 block may carry a timestamp up to
-    ///      1800 seconds ahead of its L1 origin, so from L1 time `activation - FREEZE_WINDOW` onwards
-    ///      the sequencer can already have produced the block that activates the upgrade. Freezing at
-    ///      that point makes L1's answer to "was this upgrade active at a given L2 timestamp" final
-    ///      before any L2 block can depend on it, rather than leaving it mutable until activation.
-    uint64 public constant FREEZE_WINDOW = 30 minutes;
+    /// @dev One hour covers the post-Fjord 30-minute maximum sequencer drift plus the default finalized reader's
+    /// nominal 27m48s observation latency, leaving a 2m12s margin. This finite bound cannot cover unbounded finality or
+    /// delivery delays; consumers must reject stale changes that alter fork rules for existing L2 blocks.
+    uint64 public constant FREEZE_WINDOW = MIN_NOTICE;
 
     /// @notice Activation timestamp for each registered upgrade, indexed by upgrade id (0 = not scheduled).
     ///         An upgrade id is registered iff it is a valid index into this array.

--- a/test/L1/ProtocolVersions.t.sol
+++ b/test/L1/ProtocolVersions.t.sol
@@ -25,6 +25,7 @@ abstract contract ProtocolVersions_TestInit is CommonTest {
     /// @dev Ascending ids assigned by registration order in these tests.
     uint256 internal constant CANYON = 0;
     uint256 internal constant ECOTONE = 1;
+    uint64 internal constant MAX_SEQUENCER_DRIFT = 30 minutes;
 
     address internal _owner;
     address internal _nonOwner = makeAddr("non-owner");
@@ -123,7 +124,7 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
 
     /// @notice Tests that initialization rejects a future activation already inside its freeze window.
     function test_initialize_importFutureActivationInsufficientNotice_reverts() external {
-        uint64 activation = uint64(block.timestamp) + protocolVersions.FREEZE_WINDOW();
+        uint64 activation = uint64(block.timestamp) + protocolVersions.FREEZE_WINDOW() - 1;
         uint64[] memory schedule = new uint64[](1);
         schedule[0] = activation;
 
@@ -299,7 +300,7 @@ contract ProtocolVersions_RegisterUpgrade_Test is ProtocolVersions_TestInit {
     ///         commitment for an L2 timestamp the sequencer may already have produced, and an
     ///         append that clears the floor lands above every such timestamp.
     function test_registerUpgrade_cannotMoveReachableSchedule_reverts() external {
-        uint64 reachable = uint64(block.timestamp) + protocolVersions.FREEZE_WINDOW();
+        uint64 reachable = uint64(block.timestamp) + MAX_SEQUENCER_DRIFT;
         uint64 allowed = uint64(block.timestamp) + protocolVersions.MIN_NOTICE();
         bytes32 settled = protocolVersions.activatedScheduleId(reachable);
 
@@ -736,6 +737,19 @@ contract ProtocolVersions_SetTimestamp_Test is ProtocolVersions_TestInit {
         uint64 ts = _scheduleCanyon(100);
 
         vm.warp(ts - protocolVersions.FREEZE_WINDOW());
+        vm.expectRevert(
+            abi.encodeWithSelector(IProtocolVersions.ProtocolVersions_ActivationFrozen.selector, CANYON, ts)
+        );
+        vm.prank(_owner);
+        protocolVersions.setTimestamp(CANYON, 0);
+    }
+
+    /// @notice Tests that schedule changes freeze before the sequencer-drift horizon, leaving time for finalized
+    /// readers to observe them before an L2 block can activate.
+    function test_setTimestamp_duringFinalizedReadBuffer_reverts() external {
+        uint64 ts = _scheduleCanyon(100);
+
+        vm.warp(ts - MAX_SEQUENCER_DRIFT - 1);
         vm.expectRevert(
             abi.encodeWithSelector(IProtocolVersions.ProtocolVersions_ActivationFrozen.selector, CANYON, ts)
         );


### PR DESCRIPTION
### What changed? Why?

- Extend `ProtocolVersions.FREEZE_WINDOW` from 30 minutes to one hour, independently of `MIN_NOTICE`, so finalized readers have time to observe schedule changes before the sequencer-drift horizon makes the prior schedule reachable.
- Add regression coverage for the finalized-read buffer and retain the existing exact-boundary coverage.
- Refresh the ProtocolVersions semver lock because the contract bytecode changes.

### Notes to reviewers

- The one-hour window covers the post-Fjord 30-minute maximum sequencer drift plus the default finalized reader's nominal 27m48s observation latency, leaving a 2m12s margin. This is a bounded contract-side mitigation; consumers must still reject stale schedule changes when finality or delivery delays exceed that assumption.

### How has it been tested?

- `just test --match-path test/L1/ProtocolVersions.t.sol` (80 passed)
- `just lint-check`
- `just test` (1,221 passed, 1 skipped)