### PR TITLE
fix(semver-lock): normalize source line endings

### DIFF
--- a/scripts/autogen/generate-semver-lock/main.go
+++ b/scripts/autogen/generate-semver-lock/main.go
@@ -88,15 +88,22 @@ func processFile(file string) (*SemverLockResult, []error) {
 		return nil, []error{fmt.Errorf("failed to read source file: %w", err)}
 	}
 
-	trimmedSourceCode := bytes.TrimSuffix(sourceCode, []byte("\n"))
+	normalizedSourceCode := normalizeSourceCode(sourceCode)
 
 	return &SemverLockResult{
 		ContractKey: contractKey,
 		SemverLockOutput: SemverLockOutput{
 			InitCodeHash:   crypto.Keccak256Hash(initCodeBytes).Hex(),
-			SourceCodeHash: crypto.Keccak256Hash(trimmedSourceCode).Hex(),
+			SourceCodeHash: crypto.Keccak256Hash(normalizedSourceCode).Hex(),
 		},
 	}, nil
+}
+
+// normalizeSourceCode makes source hashes independent of the checkout's line-ending
+// configuration while preserving the existing behavior of ignoring one trailing newline.
+func normalizeSourceCode(sourceCode []byte) []byte {
+	sourceCode = bytes.ReplaceAll(sourceCode, []byte("\r\n"), []byte("\n"))
+	return bytes.TrimSuffix(sourceCode, []byte("\n"))
 }
 
 func hasSemverVersion(artifact *solc.ForgeArtifact, contractName string) bool {

--- a/scripts/autogen/generate-semver-lock/main_test.go
+++ b/scripts/autogen/generate-semver-lock/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeSourceCode(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "Unix line endings",
+			source: "contract Test {\n    function version() public pure returns (string memory) {}\n}\n",
+			want:   "contract Test {\n    function version() public pure returns (string memory) {}\n}",
+		},
+		{
+			name:   "Windows line endings",
+			source: "contract Test {\r\n    function version() public pure returns (string memory) {}\r\n}\r\n",
+			want:   "contract Test {\n    function version() public pure returns (string memory) {}\n}",
+		},
+		{
+			name:   "No trailing newline",
+			source: "contract Test {}",
+			want:   "contract Test {}",
+		},
+		{
+			name:   "Only one trailing newline is ignored",
+			source: "contract Test {}\r\n\r\n",
+			want:   "contract Test {}\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, string(normalizeSourceCode([]byte(tt.source))))
+		})
+	}
+}
+
+func TestProcessFile_LineEndingsProduceSameSourceHash(t *testing.T) {
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.Mkdir("src", 0755))
+
+	artifact := `{
+  "ast": {
+    "nodes": [{
+      "nodeType": "ContractDefinition",
+      "name": "Test",
+      "nodes": [{
+        "nodeType": "FunctionDefinition",
+        "name": "version",
+        "documentation": {"text": "@custom:semver 1.0.0"}
+      }]
+    }]
+  },
+  "bytecode": {"object": "0x00"},
+  "metadata": {
+    "settings": {
+      "compilationTarget": {"src/Test.sol": "Test"}
+    }
+  }
+}`
+	require.NoError(t, os.WriteFile("Test.json", []byte(artifact), 0644))
+
+	require.NoError(t, os.WriteFile("src/Test.sol", []byte("contract Test {\n}\n"), 0644))
+	lf, errs := processFile("Test.json")
+	require.Empty(t, errs)
+	require.NotNil(t, lf)
+
+	require.NoError(t, os.WriteFile("src/Test.sol", []byte("contract Test {\r\n}\r\n"), 0644))
+	crlf, errs := processFile("Test.json")
+	require.Empty(t, errs)
+	require.NotNil(t, crlf)
+
+	require.Equal(t, lf.SemverLockOutput.SourceCodeHash, crlf.SemverLockOutput.SourceCodeHash)
+}


### PR DESCRIPTION
## Summary

- normalize CRLF source files to LF before computing semver-lock source hashes
- preserve the existing behavior of ignoring exactly one trailing newline
- cover both the normalization boundary and the full artifact-to-source-hash path

## Why

`generate-semver-lock` hashes Solidity source bytes from the working tree. With no repository EOL policy, a Windows checkout using `core.autocrlf=true` has `i/lf w/crlf` Solidity files. The same commit therefore produces different `sourceCodeHash` values locally and in Linux CI, causing a false semver-lock diff.

Normalizing only CRLF pairs makes the hash independent of checkout configuration without changing hashes produced from the repository's LF sources.

## Validation

- `go test ./scripts/autogen/generate-semver-lock`
- `go test ./scripts/autogen/... ./scripts/checks/common`
- `git diff --check`