### PR TITLE
perf: optimize loop increment gas cost in GasPriceOracle

### DIFF
--- a/src/L2/GasPriceOracle.sol
+++ b/src/L2/GasPriceOracle.sol
@@ -264,12 +264,13 @@ contract GasPriceOracle is ISemver {
     function _getCalldataGas(bytes memory _data) internal pure returns (uint256) {
         uint256 total = 0;
         uint256 length = _data.length;
-        for (uint256 i = 0; i < length; i++) {
+        for (uint256 i = 0; i < length;) {
             if (_data[i] == 0) {
                 total += 4;
             } else {
                 total += 16;
             }
+            unchecked { ++i; }
         }
         return total + (68 * 16);
     }


### PR DESCRIPTION
### Summary
Optimizes gas consumption in `GasPriceOracle._getCalldataGas` by wrapping the loop counter increment in an `unchecked` block. 

Since `i < length` is enforced by the loop condition, `i++` cannot overflow `uint256`. Bypassing default overflow checks saves gas per byte iteration.