### PR TITLE
perf: optimize loop increment in TEEProverRegistry

### DIFF
--- a/src/L1/proofs/tee/TEEProverRegistry.sol
+++ b/src/L1/proofs/tee/TEEProverRegistry.sol
@@ -243,11 +243,12 @@ contract TEEProverRegistry is OwnableManagedUpgradeable, ISemver {
         transferOwnership(initialOwner);
         transferManagement(initialManager);
         gameType = gameType_;
-        for (uint256 i = 0; i < initialProposers.length; i++) {
+        for (uint256 i = 0; i < initialProposers.length;) {
             if (initialProposers[i] != address(0)) {
                 isValidProposer[initialProposers[i]] = true;
                 emit ProposerSet(initialProposers[i], true);
             }
+            unchecked { ++i; }
         }
     }
 


### PR DESCRIPTION
### Summary
Optimizes gas consumption in `TEEProverRegistry.initialize` by wrapping the loop counter increment in an `unchecked` block at the end of the loop body.

Since `i < initialProposers.length` is strictly enforced by the loop condition, `i++` cannot overflow `uint256`.