### PR TITLE
fix(L1): derive AggregateVerifier timestamps after Denim

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -28,8 +28,8 @@
     "sourceCodeHash": "0x780ff372493ba9010bc0d13100ac896f2bf75730a9b17d4bb63aaf694dc3c634"
   },
   "src/L1/proofs/AggregateVerifier.sol:AggregateVerifier": {
-    "initCodeHash": "0x84c6bf00e337c889993c409f18b17986f9d9546ac6754f7730962459d301c21d",
-    "sourceCodeHash": "0x15952c01559b5c8e08faba110a49da9fb8c20e7bd4a62f7884c902847783e201"
+    "initCodeHash": "0xc14998e269a6ad7e5c2b5d5beee0eabb68a68c3758e666a76822905c4f16575f",
+    "sourceCodeHash": "0x04921678f197a1dbe20b04696822c02c22e528112900616aeeb78fd9649b28ef"
   },
   "src/L1/proofs/AnchorStateRegistry.sol:AnchorStateRegistry": {
     "initCodeHash": "0x6f3afd2d0ef97a82ca3111976322b99343a270e54cd4a405028f2f29c75f7fb1",

--- a/src/L1/proofs/AggregateVerifier.sol
+++ b/src/L1/proofs/AggregateVerifier.sol
@@ -75,6 +75,12 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
 
     /// @notice The minimum number of proofs required to resolve the game.
     uint256 public constant PROOF_THRESHOLD = 1;
+
+    /// @notice The ProtocolVersions upgrade index for Denim.
+    uint256 private constant DENIM_UPGRADE_INDEX = 13;
+
+    /// @notice The number of whole Denim blocks produced per second.
+    uint256 private constant DENIM_BLOCKS_PER_SECOND = 5;
     ////////////////////////////////////////////////////////////////
     //                         Immutables                         //
     ////////////////////////////////////////////////////////////////
@@ -114,10 +120,7 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
     /// @notice The timestamp of the L2 genesis block.
     uint64 public immutable L2_GENESIS_TIMESTAMP;
 
-    /// @notice The fixed number of seconds between consecutive L2 blocks.
-    /// @dev    This verifier derives L2 timestamps linearly from the configured genesis anchor. If
-    ///         the chain changes block time, deploy a new verifier anchored at the transition block
-    ///         and migrate to that game type for post-transition claims.
+    /// @notice The legacy number of seconds between consecutive L2 blocks.
     uint64 public immutable L2_BLOCK_TIME;
 
     /// @notice The block interval between each proposal.
@@ -414,19 +417,14 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
         // Set the game as initialized.
         initialized = true;
 
-        // L2 timestamps are fixed by the rollup genesis and block time. Pinning the upgrades active
-        // at the ending L2 block makes the schedule independent of both the proof's L1 head and the
-        // L1 block in which this game is created.
+        // Pinning the upgrades active at the ending L2 block makes the schedule independent of both
+        // the proof's L1 head and the L1 block in which this game is created.
         uint256 claimBlock = l2SequenceNumber();
         if (claimBlock < L2_GENESIS_BLOCK_NUMBER) {
             revert L2BlockBeforeGenesis(claimBlock, L2_GENESIS_BLOCK_NUMBER);
         }
 
-        uint256 blocksSinceGenesis = claimBlock - L2_GENESIS_BLOCK_NUMBER;
-        uint256 maxBlocks = (type(uint64).max - L2_GENESIS_TIMESTAMP) / L2_BLOCK_TIME;
-        if (blocksSinceGenesis > maxBlocks) revert L2TimestampOverflow(claimBlock);
-
-        uint64 claimTimestamp = L2_GENESIS_TIMESTAMP + uint64(blocksSinceGenesis * uint256(L2_BLOCK_TIME));
+        uint64 claimTimestamp = _l2Timestamp(claimBlock);
 
         // `ProtocolVersions` freezes mutations to an activation `FREEZE_WINDOW` before it takes
         // effect. Requiring the claim timestamp to have been reached on L1 additionally ensures the
@@ -1113,5 +1111,36 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
     /// @custom:semver 0.1.0
     function version() public pure virtual returns (string memory) {
         return "0.1.0";
+    }
+
+    /// @notice Derives an L2 block timestamp using the legacy cadence before Denim and whole-second groups after it.
+    function _l2Timestamp(uint256 claimBlock) private view returns (uint64) {
+        uint64[] memory schedule = PROTOCOL_VERSIONS.getSchedule();
+        if (schedule.length <= DENIM_UPGRADE_INDEX) return _legacyL2Timestamp(claimBlock);
+
+        uint64 denimActivationTimestamp = schedule[DENIM_UPGRADE_INDEX];
+        if (denimActivationTimestamp == 0) return _legacyL2Timestamp(claimBlock);
+
+        uint256 blocksUntilDenim;
+        if (denimActivationTimestamp > L2_GENESIS_TIMESTAMP) {
+            blocksUntilDenim = FixedPointMathLib.divUp(denimActivationTimestamp - L2_GENESIS_TIMESTAMP, L2_BLOCK_TIME);
+        }
+
+        uint256 blocksSinceGenesis = claimBlock - L2_GENESIS_BLOCK_NUMBER;
+        if (blocksSinceGenesis < blocksUntilDenim) return _legacyL2Timestamp(claimBlock);
+
+        uint256 denimBlock = L2_GENESIS_BLOCK_NUMBER + blocksUntilDenim;
+        uint256 claimTimestamp =
+            uint256(_legacyL2Timestamp(denimBlock)) + (claimBlock - denimBlock) / DENIM_BLOCKS_PER_SECOND;
+        if (claimTimestamp > type(uint64).max) revert L2TimestampOverflow(claimBlock);
+        return uint64(claimTimestamp);
+    }
+
+    /// @notice Derives an L2 block timestamp using the pre-Denim block cadence.
+    function _legacyL2Timestamp(uint256 claimBlock) private view returns (uint64) {
+        uint256 blocksSinceGenesis = claimBlock - L2_GENESIS_BLOCK_NUMBER;
+        uint256 maxBlocks = (type(uint64).max - L2_GENESIS_TIMESTAMP) / L2_BLOCK_TIME;
+        if (blocksSinceGenesis > maxBlocks) revert L2TimestampOverflow(claimBlock);
+        return L2_GENESIS_TIMESTAMP + uint64(blocksSinceGenesis * uint256(L2_BLOCK_TIME));
     }
 }

--- a/test/L1/proofs/AggregateVerifier.t.sol
+++ b/test/L1/proofs/AggregateVerifier.t.sol
@@ -20,6 +20,9 @@ import { BaseTest } from "./BaseTest.t.sol";
 contract AggregateVerifierTest is BaseTest {
     using LibClone for address;
 
+    uint256 private constant DENIM_UPGRADE_INDEX = 13;
+    uint256 private constant DENIM_BLOCKS_PER_SECOND = 5;
+
     AggregateVerifier private aggregateVerifierImpl;
 
     function setUp() public override {
@@ -101,6 +104,55 @@ contract AggregateVerifierTest is BaseTest {
             _generateProof("second", AggregateVerifier.ProofType.TEE)
         );
         assertEq(secondGame.scheduleId(), protocolVersions.activatedScheduleId(_l2Timestamp(currentL2BlockNumber)));
+    }
+
+    function test_initialize_denimBlockTimestamps_succeeds() public {
+        uint64 denimActivationTimestamp = L2_GENESIS_TIMESTAMP + 1;
+        uint64 denimBlockTimestamp = L2_GENESIS_TIMESTAMP + L2_BLOCK_TIME;
+        uint64[] memory schedule = new uint64[](DENIM_UPGRADE_INDEX + 2);
+        for (uint256 i; i < DENIM_UPGRADE_INDEX; i++) {
+            schedule[i] = L2_GENESIS_TIMESTAMP;
+        }
+        schedule[DENIM_UPGRADE_INDEX] = denimActivationTimestamp;
+        schedule[DENIM_UPGRADE_INDEX + 1] = denimBlockTimestamp + 1;
+        _importProtocolVersionsSchedule(schedule);
+
+        _setSingleBlockAggregateVerifier(L2_GENESIS_TIMESTAMP);
+
+        bytes32 denimScheduleId = protocolVersions.scheduleId(DENIM_UPGRADE_INDEX);
+        bytes32 postDenimScheduleId = protocolVersions.scheduleId(DENIM_UPGRADE_INDEX + 1);
+        address parent = address(anchorStateRegistry);
+
+        for (uint256 l2BlockNumber = 1; l2BlockNumber <= DENIM_BLOCKS_PER_SECOND + 1; l2BlockNumber++) {
+            vm.warp(denimBlockTimestamp + (l2BlockNumber - 1) / DENIM_BLOCKS_PER_SECOND);
+            AggregateVerifier game = _createSingleBlockGame(l2BlockNumber, parent);
+            assertEq(
+                game.scheduleId(), l2BlockNumber <= DENIM_BLOCKS_PER_SECOND ? denimScheduleId : postDenimScheduleId
+            );
+            parent = address(game);
+        }
+    }
+
+    function test_initialize_unscheduledDenimUsesLegacyTimestamp_succeeds() public {
+        uint64[] memory schedule = new uint64[](DENIM_UPGRADE_INDEX + 1);
+        for (uint256 i; i < DENIM_UPGRADE_INDEX; i++) {
+            schedule[i] = L2_GENESIS_TIMESTAMP;
+        }
+        _importProtocolVersionsSchedule(schedule);
+        _setSingleBlockAggregateVerifier(L2_GENESIS_TIMESTAMP);
+
+        uint64 legacyBlockTimestamp = L2_GENESIS_TIMESTAMP + L2_BLOCK_TIME;
+        vm.warp(legacyBlockTimestamp - 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AggregateVerifier.L2TimestampInFuture.selector, legacyBlockTimestamp, legacyBlockTimestamp - 1
+            )
+        );
+        _createSingleBlockGame(1, address(anchorStateRegistry));
+
+        vm.warp(legacyBlockTimestamp);
+        AggregateVerifier game = _createSingleBlockGame(1, address(anchorStateRegistry));
+        assertEq(game.scheduleId(), protocolVersions.scheduleId(DENIM_UPGRADE_INDEX - 1));
     }
 
     /// @notice A claim whose L2 timestamp L1 has not yet reached cannot open a game, so a game can
@@ -198,6 +250,27 @@ contract AggregateVerifierTest is BaseTest {
             address(anchorStateRegistry),
             _generateProof("timestamp-overflow", AggregateVerifier.ProofType.TEE)
         );
+    }
+
+    function test_initialize_denimTimestampOverflow_reverts() public {
+        uint64 genesisTimestamp = type(uint64).max - L2_BLOCK_TIME;
+        uint64[] memory schedule = new uint64[](DENIM_UPGRADE_INDEX + 1);
+        for (uint256 i; i < DENIM_UPGRADE_INDEX; i++) {
+            schedule[i] = genesisTimestamp;
+        }
+        schedule[DENIM_UPGRADE_INDEX] = genesisTimestamp + 1;
+        _importProtocolVersionsSchedule(schedule);
+        _setSingleBlockAggregateVerifier(genesisTimestamp);
+
+        vm.warp(uint256(type(uint64).max) + 3);
+        address parent = address(anchorStateRegistry);
+        for (uint256 l2BlockNumber = 1; l2BlockNumber <= DENIM_BLOCKS_PER_SECOND; l2BlockNumber++) {
+            parent = address(_createSingleBlockGame(l2BlockNumber, parent));
+        }
+
+        uint256 overflowingBlock = DENIM_BLOCKS_PER_SECOND + 1;
+        vm.expectRevert(abi.encodeWithSelector(AggregateVerifier.L2TimestampOverflow.selector, overflowingBlock));
+        _createSingleBlockGame(overflowingBlock, parent);
     }
 
     function testInitializeFailsIfInvalidCallDataSize() public {
@@ -431,6 +504,36 @@ contract AggregateVerifierTest is BaseTest {
     function _advanceL2BlockAndClaim() private returns (Claim rootClaim) {
         currentL2BlockNumber += BLOCK_INTERVAL;
         return Claim.wrap(keccak256(abi.encode(currentL2BlockNumber)));
+    }
+
+    function _createSingleBlockGame(uint256 l2BlockNumber, address parent) private returns (AggregateVerifier) {
+        Claim rootClaim = Claim.wrap(keccak256(abi.encode(l2BlockNumber)));
+        bytes memory extraData = abi.encodePacked(l2BlockNumber, parent, rootClaim.raw());
+        bytes memory proof = _generateProof(abi.encode(l2BlockNumber), AggregateVerifier.ProofType.TEE);
+
+        vm.deal(TEE_PROVER, INIT_BOND);
+        vm.prank(TEE_PROVER);
+        return AggregateVerifier(
+            address(
+                factory.createWithInitData{ value: INIT_BOND }(
+                    GameTypes.AGGREGATE_VERIFIER, rootClaim, extraData, proof
+                )
+            )
+        );
+    }
+
+    function _setSingleBlockAggregateVerifier(uint64 genesisTimestamp) private {
+        AggregateVerifier implementation = _deployAggregateVerifier(
+            1,
+            1,
+            AggregateVerifier.ScheduleConfig({
+                protocolVersions: IProtocolVersions(address(protocolVersions)),
+                genesisBlockNumber: L2_GENESIS_BLOCK_NUMBER,
+                genesisTimestamp: genesisTimestamp,
+                blockTime: L2_BLOCK_TIME
+            })
+        );
+        factory.setImplementation(GameTypes.AGGREGATE_VERIFIER, IDisputeGame(address(implementation)));
     }
 
     function _createAndAssertInitializedGame(


### PR DESCRIPTION
- Derive post-Denim claim timestamps from the registered activation, preserving legacy timing before the fork.
- Group five Denim blocks per whole-second timestamp so games no longer treat valid post-fork claims as future blocks.