### PR TITLE
fix(L1): retarget the AggregateVerifier cadence switch to Denim

### DIFF
--- a/snapshots/semver-lock.json
+++ b/snapshots/semver-lock.json
@@ -28,8 +28,8 @@
     "sourceCodeHash": "0x780ff372493ba9010bc0d13100ac896f2bf75730a9b17d4bb63aaf694dc3c634"
   },
   "src/L1/proofs/AggregateVerifier.sol:AggregateVerifier": {
-    "initCodeHash": "0x0642919b493a739e0280ded0dab2123c0c0d569fb613203ad71f79eca25af8e4",
-    "sourceCodeHash": "0xa03d89648901890b4e2ab06a72578045f75d6dfa649dbac0ae9364fd20f0657d"
+    "initCodeHash": "0xac5b40f2fadfbf26c206e5abb44870a93053063ba03ceb523a09799785c82e06",
+    "sourceCodeHash": "0x1234f4ea80d6da4f0c0e98cf11839b423d211da2027faf4c10ccf131aa62d8d7"
   },
   "src/L1/proofs/AnchorStateRegistry.sol:AnchorStateRegistry": {
     "initCodeHash": "0x6f3afd2d0ef97a82ca3111976322b99343a270e54cd4a405028f2f29c75f7fb1",

--- a/src/L1/proofs/AggregateVerifier.sol
+++ b/src/L1/proofs/AggregateVerifier.sol
@@ -87,11 +87,14 @@ contract AggregateVerifier is Clone, ReentrancyGuard, ISemver {
     uint256 public constant PROOF_THRESHOLD = 1;
 
     /// @notice The ProtocolVersions upgrade index at which L2 blocks switch to the fast cadence.
-    /// @dev    This is the one place the contract is tied to a specific hardfork: index 12 is Cobalt,
+    /// @dev    This is the one place the contract is tied to a specific hardfork: index 13 is Denim,
     ///         which drops the L2 block time from 2s to 200ms. Everything downstream is expressed as
     ///         slow-vs-fast blocks, so a later cadence change is a new index and new interval pair
     ///         rather than new machinery.
-    uint256 private constant FAST_BLOCK_UPGRADE_INDEX = 12;
+    /// @dev    Index 13 is one past the end of the current Base mainnet schedule, so `getSchedule()`
+    ///         returns a shorter array until Denim is registered. `_firstFastBlock()` treats that as
+    ///         unscheduled, which is the same state an index-in-range zero timestamp produces.
+    uint256 private constant FAST_BLOCK_UPGRADE_INDEX = 13;
 
     /// @notice The number of whole fast-cadence L2 blocks produced per second.
     uint256 private constant FAST_BLOCKS_PER_SECOND = 5;

--- a/test/L1/proofs/AggregateVerifier.t.sol
+++ b/test/L1/proofs/AggregateVerifier.t.sol
@@ -20,7 +20,7 @@ import { BaseTest } from "./BaseTest.t.sol";
 contract AggregateVerifierTest is BaseTest {
     using LibClone for address;
 
-    uint256 private constant FAST_BLOCK_UPGRADE_INDEX = 12;
+    uint256 private constant FAST_BLOCK_UPGRADE_INDEX = 13;
     uint256 private constant FAST_BLOCKS_PER_SECOND = 5;
 
     AggregateVerifier private aggregateVerifierImpl;


### PR DESCRIPTION
Reverts the fork target introduced in #431 (merged). The 200ms block-time hardfork moved back to Denim.

## What changed?

- `FAST_BLOCK_UPGRADE_INDEX` in `AggregateVerifier`: `12` (Cobalt) → `13` (Denim).
- Test-local `FAST_BLOCK_UPGRADE_INDEX` in `AggregateVerifier.t.sol` follows it. Every test references the constant symbolically, so no fixture arithmetic changed.
- `snapshots/semver-lock.json` regenerated — only the `AggregateVerifier` entry moves.
- Semver stays at `0.2.0`. Nothing has consumed 0.2.0 yet — it was introduced by #431 and no deployment reads it — so there is no version anyone could be pinned to and nothing to bump away from.

No machinery changed. `_firstFastBlock()`, `_l2Timestamp()`, and `_intervalsAt()` are unchanged; only the index they read is different.

## Why?

The switch to Cobalt in #431 was made on the reasoning that the Base mainnet schedule is 13 entries long (indices 0–12) and could therefore never reach index 13. That is true today but it isn't a constraint — `_timestamps` is a dynamic array and `registerUpgrade` extends it, which is exactly how Denim gets its entry.

Both indices fail open in the same way and for the same duration:

- **Index 12 (Cobalt)** exists today with a zero timestamp. `_firstFastBlock()` hits `if (fastActivationTimestamp == 0) return type(uint256).max`.
- **Index 13 (Denim)** is one past the end. `_firstFastBlock()` hits `if (schedule.length <= FAST_BLOCK_UPGRADE_INDEX) return type(uint256).max`.

Either way the verifier reports "unscheduled" and every game gets the slow-block intervals until the entry is written. So this change is behaviour-neutral on every chain as of today, and the operational requirement is identical to what it was before: the speedup activation has to be registered on `ProtocolVersions` before the fork, or the verifier stays on the slow cadence silently.

## How to test?

```
just build-go-ffi
forge test --match-contract AggregateVerifier
```

32 passed, 0 failed on this branch.

The two cases that pin the index behaviour directly:

```
forge test --match-test test_intervalsForStartingBlock_speedupUnscheduled_succeeds -vv
forge test --match-test test_initialize_unscheduledSpeedupUsesSlowTimestamp_succeeds -vv
```

`_importSpeedupSchedule` builds a `FAST_BLOCK_UPGRADE_INDEX + 2`-long schedule and writes the activation at the constant, so the scheduled-speedup cases (`test_intervalsForStartingBlock_selectsOnFirstFastBlock_succeeds`, `test_initialize_scheduleChangesAtL2ActivationBoundary_succeeds`, `test_initialize_straddlingGame_usesSlowInterval_succeeds`) now exercise a 15-entry registry with Denim at 13 rather than a 14-entry one with Cobalt at 12.

Lock check — should be a no-op after the commit:

```
FOUNDRY_PROFILE=ci forge build --force --skip "/**/test/**" --skip "/**/scripts/**"
go run scripts/autogen/generate-semver-lock/main.go
git diff --exit-code snapshots/semver-lock.json
```

## Note

`test/L1/ProtocolVersions.t.sol` still names Cobalt at index 12 (`schedule[12] = 0; // Cobalt is unscheduled on Base mainnet.`). That is a factual statement about contract registration order, not a targeting choice, and is unrelated to this change — left alone.
